### PR TITLE
docs(openspec+ux): vincular specs con mockups UX

### DIFF
--- a/docs/TESTING-STRATEGY.md
+++ b/docs/TESTING-STRATEGY.md
@@ -1,0 +1,1806 @@
+# PadelPro — Estrategia de Testing
+
+> **Versión:** 1.0 · **Fecha:** 2026-05-22  
+> **Generado por:** `test-strategist`  
+> **Fuente de verdad para:** `tester-tdd`, `test-runner`, `api-tester`, `verification-specialist`, `reality-checker`, `database-optimizer`  
+>
+> Este documento es **ley**. Toda decisión de testing, todo umbral, todo comando canónico se lee aquí.  
+> Los agentes no tienen defaults propios mientras este fichero exista.
+
+---
+
+## 1. Executive Summary
+
+### Objetivo de la estrategia
+
+PadelPro es un sistema de reservas de pádel con integración nativa en Telegram, pasarela de pago Redsys (HMAC SHA-256) y requisitos estrictos de RGPD. La estrategia de testing tiene como objetivo garantizar que:
+
+- El dominio de negocio (reservas, pagos, OTP, auditoría) funcione correctamente y sea testeable de forma totalmente aislada de la infraestructura.
+- Las integraciones externas (Redsys, Telegram Bot API, SMTP) estén validadas mediante doubles controlados (WireMock) y no introduzcan fragilidad en la suite.
+- La restricción de solapamiento de reservas (`EXCLUDE USING gist` + `SELECT FOR UPDATE`) esté cubierta con tests de concurrencia reales sobre PostgreSQL 15 — nunca con H2.
+- Ninguna credencial, token, OTP en claro ni dato personal sensible aparezca en logs ni en respuestas de error.
+- El pipeline de CI falle automáticamente si cualquier umbral de cobertura o calidad no se alcanza.
+
+### Stack de testing consolidado
+
+| Capa | Framework | Versión | Notas |
+|---|---|---|---|
+| Backend — unit | JUnit 5 + AssertJ + Mockito | Bundled con Spring Boot 3.2 | Strict stubs activados por defecto |
+| Backend — integration | Spring Boot Test + MockMvc + Testcontainers + WireMock | Testcontainers 1.19.x | PostgreSQL 15 real; WireMock para Redsys y Telegram |
+| Backend — architecture | ArchUnit | 1.3.x | Fronteras hexagonales por módulo |
+| Backend — mutation | Pitest (PIT) | 1.15.x | Módulos: `pagos`, `otp`, `reservas` |
+| Backend — coverage | JaCoCo | Bundled con Spring Boot | HTML + XML; quality gate en Maven |
+| Frontend — unit/components | Vitest + React Testing Library | Vitest 1.x + RTL 15.x | Nativo ESM, alineado con Vite |
+| Frontend — API mock | MSW (Mock Service Worker) | 2.x | Handlers en `frontend/tests/mocks/` |
+| Frontend — E2E | Playwright | 1.44.x | Chromium obligatorio; Firefox opcional |
+| Frontend — coverage | c8 (via Vitest) | Incluido en Vitest | Umbral en `vitest.config.ts` |
+| CI | GitHub Actions | — | Jobs: build, unit-tests, integration-tests, coverage, quality-gate, lint |
+
+### Umbrales de cobertura globales
+
+| Métrica | Mínimo | Objetivo |
+|---|---|---|
+| Líneas (backend) | 80 % | 85 % |
+| Branches (backend) | 75 % | 80 % |
+| Líneas (frontend) | 75 % | 80 % |
+| Flujos críticos | **100 %** | 100 % |
+| Reglas de negocio (RN-xx) | **100 %** | 100 % |
+| Mutation score (módulos críticos) | 70 % | 75 % |
+| Duplicación de código | < 3 % | < 2 % |
+
+### Quality gate — build fails if
+
+- Cualquier test unitario o de integración falla.
+- La cobertura de líneas baja del 80 % (backend) o del 75 % (frontend).
+- La cobertura de branches baja del 75 % (backend).
+- Cualquier flujo crítico o regla de negocio declarada en esta estrategia tiene cobertura < 100 %.
+- El linter reporta errores (warnings no bloquean).
+- OWASP Dependency-Check detecta vulnerabilidad CRITICAL o HIGH sin supresión justificada.
+- `npm audit` (frontend) detecta vulnerabilidad HIGH o CRITICAL.
+- Mutation score < 70 % en `pagos`, `otp` o `reservas`.
+
+### Quién consume este documento y para qué
+
+| Agente | Uso |
+|---|---|
+| `tester-tdd` | Fuente única de verdad para frameworks, estructura, umbrales y ciclo TDD. No usa defaults propios. |
+| `test-runner` | Comandos canónicos, umbrales, estructura de carpetas para tests de código ya implementado. |
+| `api-tester` | Casos de seguridad OWASP, flujos críticos y forma de errores. |
+| `verification-specialist` | Comandos de build/test/lint, umbrales de cobertura para su quality gate. |
+| `reality-checker` | Comandos de validación, umbrales y flujos críticos para su veredicto PASS/NEEDS WORK. |
+| `database-optimizer` | Estrategia híbrida H2/Testcontainers y restricciones de la capa de datos. |
+
+---
+
+## 2. Pirámide de Testing
+
+### Distribución objetivo
+
+```
+              ▲
+             / \
+            /E2E\          5 %  — Playwright — flujos críticos completos
+           /─────\
+          / Integr \      15 %  — MockMvc + Testcontainers + WireMock
+         /──────────\
+        /    Unit    \    80 %  — JUnit 5 / Vitest — dominio, servicios, mappers
+       ──────────────────
+```
+
+### Justificación de la distribución
+
+La distribución estándar 80/15/5 se aplica con dos ajustes motivados por el dominio:
+
+**1. Peso elevado en integración (15 % vs. el 10 % habitual):**  
+PadelPro integra dos sistemas externos con contratos no triviales: Redsys (HMAC SHA-256 + 3DES-CBC) y Telegram Bot API (validación por header secreto). Ambas integraciones tienen lógica de firma que no se puede simular fielmente con mocks en memoria — necesitan WireMock levantado como servidor HTTP real para probar serialización, encoding Base64 y cálculo de firmas. Además, la restricción `EXCLUDE USING gist` es PostgreSQL-específica e imposible de probar en H2.
+
+**2. E2E acotado a flujos de negocio críticos (5 %):**  
+Los flujos E2E cubren únicamente los tres casos de uso principales (CU-01, CU-02, CU-03). No se usa E2E para flujos administrativos o de configuración — la cobertura de integración es suficiente para esos casos.
+
+### Clasificación de tests por módulo
+
+| Módulo | Unit | Integration | E2E |
+|---|---|---|---|
+| `reservas` | Entidades, domain service `ReservaDisponibilidadService`, mappers | Controller (MockMvc), repositorio (Testcontainers), solapamiento gist | CU-01, CU-02 |
+| `pagos` | `Pago` entidad, `PagoCalculoService`, HMAC calculation | Webhook adapter (WireMock), repositorio (Testcontainers) | CU-03 |
+| `usuarios` | `Usuario` entidad, `PasswordPolicyService`, `AuthApplicationService` | `AuthController` (MockMvc), lockout, refresh token | Login + logout |
+| `mensajeria` | Parser de comandos Telegram, routing | `BotTelegramAdapter` (WireMock), secret header | — |
+| `otp` | `Otp.estaExpirado()`, `estaUsado()`, generación SHA-256 | `OtpApplicationService` con repositorio real | OTP flow |
+| `auditoria` | `AuditoriaEntry` (inmutable) | Escritura en BD real; retención | — |
+| `shared` | `JwtProvider`, `PasswordPolicyService` | `SecurityConfig` RBAC | — |
+| Frontend | Componentes, hooks, utils | MSW handlers | E2E Playwright |
+
+---
+
+## 3. Stack de Testing por Capa
+
+### 3.1 Backend — Java 21 + Spring Boot 3.2
+
+#### Tests unitarios
+
+- **JUnit 5** (jupiter): incluido en `spring-boot-starter-test`. Sin necesidad de dependencia explícita.
+- **AssertJ 3.x**: fluent assertions — preferido sobre `assertEquals`. Bundled con Spring Boot 3.2.
+- **Mockito 5.x** con `MockitoSettings(strictness = STRICT_STUBS)` activado por defecto en Spring Boot Test. Prohíbe stubs sin usar — señal de test mal escrito.
+- Los tests unitarios **no arrancan contexto Spring** — `@ExtendWith(MockitoExtension.class)` únicamente. Sin `@SpringBootTest` en tests de dominio.
+
+```xml
+<!-- pom.xml — spring-boot-starter-test ya incluye todo lo necesario -->
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-test</artifactId>
+    <scope>test</scope>
+</dependency>
+```
+
+#### Tests de integración
+
+```xml
+<!-- Testcontainers — PostgreSQL 15 -->
+<dependency>
+    <groupId>org.testcontainers</groupId>
+    <artifactId>postgresql</artifactId>
+    <version>1.19.8</version>
+    <scope>test</scope>
+</dependency>
+<dependency>
+    <groupId>org.testcontainers</groupId>
+    <artifactId>junit-jupiter</artifactId>
+    <version>1.19.8</version>
+    <scope>test</scope>
+</dependency>
+<!-- WireMock — Redsys y Telegram -->
+<dependency>
+    <groupId>org.wiremock</groupId>
+    <artifactId>wiremock-standalone</artifactId>
+    <version>3.5.4</version>
+    <scope>test</scope>
+</dependency>
+<!-- Spring Security Test — @WithMockUser, @WithUserDetails -->
+<dependency>
+    <groupId>org.springframework.security</groupId>
+    <artifactId>spring-security-test</artifactId>
+    <scope>test</scope>
+</dependency>
+```
+
+#### Tests de arquitectura (ArchUnit)
+
+```xml
+<dependency>
+    <groupId>com.tngtech.archunit</groupId>
+    <artifactId>archunit-junit5</artifactId>
+    <version>1.3.0</version>
+    <scope>test</scope>
+</dependency>
+```
+
+**Reglas ArchUnit obligatorias por módulo:**
+
+```java
+// <module>/src/test/java/com/padelpro/<module>/arch/<Module>ArchTest.java
+@AnalyzeClasses(packages = "com.padelpro.<module>")
+class <Module>ArchTest {
+
+    // 1. La capa domain NO depende de infrastructure
+    @ArchTest
+    static final ArchRule domain_no_depends_on_infrastructure =
+        noClasses().that().resideInAPackage("..domain..")
+            .should().dependOnClassesThat()
+            .resideInAPackage("..infrastructure..");
+
+    // 2. La capa domain NO depende de application
+    @ArchTest
+    static final ArchRule domain_no_depends_on_application =
+        noClasses().that().resideInAPackage("..domain..")
+            .should().dependOnClassesThat()
+            .resideInAPackage("..application..");
+
+    // 3. Los controllers NO acceden directamente a repositories o JPA adapters
+    @ArchTest
+    static final ArchRule controllers_no_direct_repo_access =
+        noClasses().that().resideInAPackage("..infrastructure.adapter.inbound..")
+            .should().dependOnClassesThat()
+            .resideInAPackage("..infrastructure.adapter.outbound..");
+
+    // 4. Los ApplicationService son @Transactional solo en application, no en domain
+    @ArchTest
+    static final ArchRule transactional_only_in_application =
+        noClasses().that().resideInAPackage("..domain..")
+            .should().beAnnotatedWith(Transactional.class);
+
+    // 5. Los ports (interfaces) viven solo en domain
+    @ArchTest
+    static final ArchRule ports_in_domain_only =
+        classes().that().haveNameMatching(".*Port|.*UseCase")
+            .should().resideInAPackage("..domain.port..");
+}
+```
+
+#### Mutation testing (Pitest)
+
+```xml
+<!-- pom.xml — plugin en el módulo raíz o en cada módulo crítico -->
+<plugin>
+    <groupId>org.pitest</groupId>
+    <artifactId>pitest-maven</artifactId>
+    <version>1.15.3</version>
+    <dependencies>
+        <dependency>
+            <groupId>org.pitest</groupId>
+            <artifactId>pitest-junit5-plugin</artifactId>
+            <version>1.2.1</version>
+        </dependency>
+    </dependencies>
+    <configuration>
+        <!-- Solo en módulos críticos -->
+        <targetClasses>
+            <param>com.padelpro.pagos.domain.*</param>
+            <param>com.padelpro.pagos.application.*</param>
+            <param>com.padelpro.otp.domain.*</param>
+            <param>com.padelpro.otp.application.*</param>
+            <param>com.padelpro.reservas.domain.*</param>
+            <param>com.padelpro.reservas.application.*</param>
+        </targetClasses>
+        <targetTests>
+            <param>com.padelpro.pagos.*</param>
+            <param>com.padelpro.otp.*</param>
+            <param>com.padelpro.reservas.*</param>
+        </targetTests>
+        <mutationThreshold>70</mutationThreshold>
+        <coverageThreshold>80</coverageThreshold>
+        <outputFormats>
+            <outputFormat>HTML</outputFormat>
+            <outputFormat>XML</outputFormat>
+        </outputFormats>
+        <timestampedReports>false</timestampedReports>
+    </configuration>
+</plugin>
+```
+
+#### Cobertura (JaCoCo)
+
+```xml
+<!-- pom.xml — maven-surefire + failsafe + jacoco -->
+<plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-surefire-plugin</artifactId>
+    <configuration>
+        <!-- Surefire ejecuta *Test.java -->
+        <includes>
+            <include>**/*Test.java</include>
+        </includes>
+        <excludes>
+            <exclude>**/*IT.java</exclude>
+        </excludes>
+    </configuration>
+</plugin>
+
+<plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-failsafe-plugin</artifactId>
+    <executions>
+        <execution>
+            <goals>
+                <goal>integration-test</goal>
+                <goal>verify</goal>
+            </goals>
+        </execution>
+    </executions>
+    <configuration>
+        <!-- Failsafe ejecuta *IT.java -->
+        <includes>
+            <include>**/*IT.java</include>
+        </includes>
+    </configuration>
+</plugin>
+
+<plugin>
+    <groupId>org.jacoco</groupId>
+    <artifactId>jacoco-maven-plugin</artifactId>
+    <executions>
+        <execution>
+            <id>prepare-agent</id>
+            <goals><goal>prepare-agent</goal></goals>
+        </execution>
+        <execution>
+            <id>prepare-agent-integration</id>
+            <goals><goal>prepare-agent-integration</goal></goals>
+        </execution>
+        <execution>
+            <id>report</id>
+            <phase>verify</phase>
+            <goals>
+                <goal>report</goal>
+                <goal>report-integration</goal>
+                <goal>merge</goal>
+            </goals>
+            <configuration>
+                <outputDirectory>${project.reporting.outputDirectory}/jacoco</outputDirectory>
+                <formats>
+                    <format>HTML</format>
+                    <format>XML</format>
+                </formats>
+            </configuration>
+        </execution>
+        <execution>
+            <id>check</id>
+            <phase>verify</phase>
+            <goals><goal>check</goal></goals>
+            <configuration>
+                <rules>
+                    <rule>
+                        <element>BUNDLE</element>
+                        <limits>
+                            <limit>
+                                <counter>LINE</counter>
+                                <value>COVEREDRATIO</value>
+                                <minimum>0.80</minimum>
+                            </limit>
+                            <limit>
+                                <counter>BRANCH</counter>
+                                <value>COVEREDRATIO</value>
+                                <minimum>0.75</minimum>
+                            </limit>
+                        </limits>
+                    </rule>
+                </rules>
+                <excludes>
+                    <!-- Ver §4 para justificación de exclusiones -->
+                    <exclude>**/config/**</exclude>
+                    <exclude>**/*Application.class</exclude>
+                    <exclude>**/dto/**</exclude>
+                    <exclude>**/exception/*Exception.class</exclude>
+                    <exclude>**/entity/*Entity.class</exclude>
+                </excludes>
+            </configuration>
+        </execution>
+    </executions>
+</plugin>
+```
+
+---
+
+### 3.2 Frontend — React 18 + Vite + TypeScript
+
+#### Tests unitarios y de componentes
+
+**Vitest** en lugar de Jest — justificación: Vitest es el runner nativo del ecosistema Vite. Elimina la capa de transformación Jest/Babel (incompatibilidad ESM nativa), comparte la configuración de `vite.config.ts`, y es entre 2x y 5x más rápido en modo watch. Con TypeScript 5.x + ESM, Jest requiere configuración no trivial que Vitest evita por diseño.
+
+```typescript
+// vitest.config.ts
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./tests/setup.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html', 'lcov'],
+      reportsDirectory: './coverage',
+      thresholds: {
+        lines: 75,
+        branches: 70,
+        functions: 75,
+        statements: 75,
+      },
+      exclude: [
+        'tests/**',
+        '**/*.d.ts',
+        '**/*.config.*',
+        'src/main.tsx',
+        'src/vite-env.d.ts',
+      ],
+    },
+  },
+});
+```
+
+```typescript
+// tests/setup.ts
+import '@testing-library/jest-dom';
+import { server } from './mocks/server';
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+```
+
+#### Mocking de API — MSW
+
+```typescript
+// tests/mocks/server.ts
+import { setupServer } from 'msw/node';
+import { authHandlers } from './handlers/auth.handlers';
+import { reservasHandlers } from './handlers/reservas.handlers';
+import { pagosHandlers } from './handlers/pagos.handlers';
+
+export const server = setupServer(
+  ...authHandlers,
+  ...reservasHandlers,
+  ...pagosHandlers,
+);
+```
+
+Estructura de handlers:
+```
+frontend/tests/mocks/
+├── server.ts
+├── handlers/
+│   ├── auth.handlers.ts      — POST /api/auth/login, /refresh, /logout
+│   ├── reservas.handlers.ts  — GET/POST /api/reservas, POST /{id}/unirse
+│   ├── pagos.handlers.ts     — POST /api/pagos/iniciar, GET /api/pagos
+│   └── usuarios.handlers.ts  — GET/PATCH /api/usuarios/me
+└── fixtures/
+    ├── reserva.fixture.ts
+    ├── usuario.fixture.ts
+    └── pago.fixture.ts
+```
+
+#### E2E — Playwright
+
+```typescript
+// playwright.config.ts
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  timeout: 30_000,
+  retries: process.env.CI ? 2 : 0,
+  reporter: [['html', { outputFolder: 'playwright-report' }], ['list']],
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  // Arrancar backend + frontend antes de E2E
+  webServer: [
+    {
+      command: 'cd ../backend && mvn spring-boot:run -Dspring-boot.run.profiles=test',
+      port: 8080,
+      timeout: 60_000,
+      reuseExistingServer: !process.env.CI,
+    },
+    {
+      command: 'npm run dev',
+      port: 5173,
+      reuseExistingServer: !process.env.CI,
+    },
+  ],
+});
+```
+
+---
+
+### 3.3 Base de datos — Estrategia híbrida H2 / Testcontainers
+
+#### DECISION CRITICA — Incompatibilidad H2 con `btree_gist`
+
+> **H2 NO puede ejecutar la extensión `btree_gist` ni el constraint `EXCLUDE USING gist` de PostgreSQL.**  
+> Esta restricción afecta directamente a la tabla `reservations` y a la lógica anti-solapamiento.
+
+**Regla absoluta:**
+
+| Tipo de test | Base de datos | Cuándo usarla |
+|---|---|---|
+| Tests unitarios de dominio | Sin BD (mocks) | `Reserva`, `Pago`, `Otp` — entidades puras |
+| Tests unitarios de repositorios simples | H2 modo `MODE=PostgreSQL` | CRUD de `users`, `audit_log`, `notification_log`, `otp_codes` — sin constraints gist |
+| Tests de integración con solapamiento | **Testcontainers PostgreSQL 15** | Todo lo que toque `reservations` — OBLIGATORIO |
+| Tests de integración con Flyway | **Testcontainers PostgreSQL 15** | Verificar que las migraciones se aplican correctamente |
+| Tests de integración de controllers | **Testcontainers PostgreSQL 15** | MockMvc + BD real = máxima fidelidad |
+
+#### `application-test.yml` — H2 (tests unitarios de repositorios simples)
+
+```yaml
+# src/test/resources/application-test.yml
+spring:
+  datasource:
+    url: jdbc:h2:mem:padelpro_test;DB_CLOSE_DELAY=-1;MODE=PostgreSQL;DATABASE_TO_LOWER=true
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: ''
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+  flyway:
+    enabled: false   # H2 no soporta las extensiones PostgreSQL de Flyway
+
+logging:
+  level:
+    com.padelpro: WARN
+    org.hibernate.SQL: OFF
+```
+
+#### `application-it.yml` — Testcontainers PostgreSQL 15 (integration tests)
+
+```yaml
+# src/test/resources/application-it.yml
+spring:
+  datasource:
+    # La URL la inyecta @DynamicPropertySource del BaseIntegrationTest
+    url: ${spring.datasource.url}
+    username: ${spring.datasource.username}
+    password: ${spring.datasource.password}
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: false
+  flyway:
+    enabled: true
+    clean-on-validation-error: true   # Solo en tests; nunca en producción
+
+app:
+  jwt:
+    secret: test-secret-key-padelpro-256-bits-minimum-length
+    access-token-expiration-ms: 900000    # 15 min
+    refresh-token-expiration-ms: 604800000 # 7 días
+  telegram:
+    webhook-secret: test-telegram-webhook-secret
+    bot-token: test-telegram-bot-token
+  redsys:
+    secret-key: test-redsys-secret-key
+    merchant-code: '999008881'
+    terminal: '001'
+```
+
+#### Clase base de integración
+
+```java
+// src/test/java/com/padelpro/shared/BaseIntegrationTest.java
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@Testcontainers
+@ActiveProfiles("it")
+public abstract class BaseIntegrationTest {
+
+    @Container
+    static final PostgreSQLContainer<?> postgres =
+        new PostgreSQLContainer<>("postgres:15-alpine")
+            .withDatabaseName("padelpro_test")
+            .withUsername("padelpro_test")
+            .withPassword("padelpro_test")
+            .withReuse(true);  // Reutiliza el contenedor entre clases IT del mismo build
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    /**
+     * Limpieza entre tests cuando @Transactional no es suficiente
+     * (e.g., tests de solapamiento que verifican el constraint gist).
+     */
+    @Sql("/sql/cleanup.sql")
+    protected void cleanDatabase() { /* @Sql hace el trabajo */ }
+}
+```
+
+#### WireMock — integraciones externas
+
+```java
+// src/test/java/com/padelpro/shared/BaseExternalServiceIT.java
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Testcontainers
+@ActiveProfiles("it")
+public abstract class BaseExternalServiceIT extends BaseIntegrationTest {
+
+    @RegisterExtension
+    static WireMockExtension telegramServer = WireMockExtension.newInstance()
+        .options(WireMockConfiguration.wireMockConfig().dynamicPort())
+        .build();
+
+    @RegisterExtension
+    static WireMockExtension redsysServer = WireMockExtension.newInstance()
+        .options(WireMockConfiguration.wireMockConfig().dynamicPort())
+        .build();
+
+    @DynamicPropertySource
+    static void configureMockServers(DynamicPropertyRegistry registry) {
+        registry.add("app.telegram.api-url", () -> telegramServer.baseUrl());
+        registry.add("app.redsys.tpv-url", () -> redsysServer.baseUrl());
+    }
+}
+```
+
+#### Limpieza entre tests de integración
+
+```sql
+-- src/test/resources/sql/cleanup.sql
+-- Orden de borrado respeta las FKs
+DELETE FROM notification_log;
+DELETE FROM audit_log;
+DELETE FROM otp_codes;
+DELETE FROM participants;
+DELETE FROM payments;
+DELETE FROM reservations;
+DELETE FROM refresh_tokens;
+DELETE FROM system_config WHERE id = 1;
+DELETE FROM users;
+
+-- Reiniciar secuencias
+ALTER SEQUENCE users_id_seq RESTART WITH 1;
+ALTER SEQUENCE audit_log_id_seq RESTART WITH 1;
+ALTER SEQUENCE otp_codes_id_seq RESTART WITH 1;
+ALTER SEQUENCE participants_id_seq RESTART WITH 1;
+ALTER SEQUENCE refresh_tokens_id_seq RESTART WITH 1;
+ALTER SEQUENCE notification_log_id_seq RESTART WITH 1;
+```
+
+---
+
+### 3.4 CI/CD — GitHub Actions
+
+#### Estructura de jobs
+
+```yaml
+# .github/workflows/ci.yml
+name: CI
+
+on:
+  pull_request:
+    branches: [develop]
+  push:
+    branches: [develop, main]
+
+jobs:
+  build:
+    name: Build
+    timeout-minutes: 3
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+      - name: Build (sin tests)
+        run: mvn -B clean compile -DskipTests
+
+  unit-tests:
+    name: Unit Tests
+    needs: build
+    timeout-minutes: 2
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+      - name: Run unit tests
+        run: mvn -B test -Dtest="*Test" -DfailIfNoTests=false
+
+  integration-tests:
+    name: Integration Tests
+    needs: build
+    timeout-minutes: 8
+    runs-on: ubuntu-latest
+    services:
+      # Docker socket disponible para Testcontainers
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+      - name: Run integration tests
+        run: mvn -B verify -Dtest="NONE" -DfailIfNoTests=false
+        env:
+          TESTCONTAINERS_RYUK_DISABLED: "true"
+
+  frontend-tests:
+    name: Frontend Tests
+    needs: build
+    timeout-minutes: 3
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install dependencies
+        run: npm ci --prefix frontend
+      - name: Run frontend tests
+        run: npm run test:coverage --prefix frontend
+      - name: Lint frontend
+        run: npm run lint --prefix frontend
+
+  quality-gate:
+    name: Quality Gate
+    needs: [unit-tests, integration-tests, frontend-tests]
+    timeout-minutes: 1
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+      - name: Check coverage thresholds
+        run: mvn -B jacoco:check
+      - name: OWASP Dependency Check
+        run: mvn -B dependency-check:check -DfailBuildOnCVSS=7
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: '**/target/site/jacoco/'
+
+  lint:
+    name: Lint Backend
+    needs: build
+    timeout-minutes: 2
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+      - name: Checkstyle
+        run: mvn -B checkstyle:check
+```
+
+**Tiempos máximos por job:**
+
+| Job | Máximo |
+|---|---|
+| build | 3 min |
+| unit-tests | 2 min |
+| integration-tests | 8 min |
+| frontend-tests | 3 min |
+| quality-gate | 1 min |
+| lint | 2 min |
+
+---
+
+## 4. Umbrales de Cobertura
+
+| Métrica | Mínimo | Objetivo | Cómo se mide | Quién verifica |
+|---|---|---|---|---|
+| Line coverage (backend) | 80 % | 85 % | JaCoCo `jacoco:check` | CI quality-gate job |
+| Branch coverage (backend) | 75 % | 80 % | JaCoCo `jacoco:check` | CI quality-gate job |
+| Line coverage (frontend) | 75 % | 80 % | Vitest c8 `--coverage` | CI frontend-tests job |
+| Branch coverage (frontend) | 70 % | 75 % | Vitest c8 `--coverage` | CI frontend-tests job |
+| Flujos críticos | **100 %** | 100 % | Revisión manual + JaCoCo XML | `verification-specialist` |
+| Reglas de negocio (RN-xx) | **100 %** | 100 % | Tests dedicados por RN | `verification-specialist` |
+| Mutation score (`pagos`, `otp`, `reservas`) | 70 % | 75 % | Pitest `mutationThreshold` | CI (fase manual) |
+| Duplicación de código | < 3 % | < 2 % | Checkstyle / ESLint | CI lint job |
+
+### Flujos críticos de PadelPro (cobertura 100 % no negociable)
+
+Los siguientes flujos deben tener al menos un test de integración que los recorra de extremo a extremo:
+
+1. **Autenticación completa**: login → JWT access token → uso del token → refresh → logout → refresh inválido (401).
+2. **OTP Telegram**: generación (SHA-256 almacenado, TTL 10 min) → envío → validación correcta → OTP marcado `used=true` → 4.º intento fallido → OTP invalidado.
+3. **Creación de reserva (web)**: disponibilidad → INSERT reserva + pago + participante (atómico) → publicación en Telegram (WireMock).
+4. **Anti-solapamiento de reservas**: dos peticiones concurrentes al mismo slot → exactamente una falla con 409. Test de concurrencia con Testcontainers PostgreSQL 15 (constraint `gist`).
+5. **Cancelación de reserva**: dentro del plazo → `CANCELLED` + pago `CANCELLED`; fuera del plazo → reserva `CANCELLED`, pago `PENDING`.
+6. **Unirse a reserva**: hueco disponible → participante añadido; hueco completo → 409; usuario ya participante → 409.
+7. **Pago Redsys — inicio**: cálculo de importe en backend → firma HMAC SHA-256 → URL del TPV generada; PAN/CVV nunca en logs.
+8. **Pago Redsys — webhook**: HMAC válido → pago `PAID`; HMAC inválido → ignorado (200 sin cambio de estado); webhook duplicado → idempotente (segunda llamada no cambia nada).
+9. **RBAC — endpoints admin**: `USER` accede a `/api/admin/**` → 403; `ADMIN` accede → 200.
+10. **RBAC — ownership**: `USER` B accede a reserva de `USER` A → 403 (no 200, no 404).
+11. **Bot Telegram**: webhook sin `X-Telegram-Bot-Api-Secret-Token` → 403; webhook con secret correcto → 200.
+12. **RGPD — anonimización**: `DELETE /api/admin/usuarios/{id}` → `first_name=ANONIMIZADO`, `phone=NULL`, `email=deleted_{id}@...`, entrada `audit_log.action=USER_ANONYMIZED`, `refresh_tokens` revocados.
+13. **Bloqueo de cuenta**: 10 intentos fallidos en 10 min → cuenta `LOCKED`; desbloqueo automático tras 15 min.
+14. **Account lockout OTP**: 3 intentos fallidos → OTP `used=true` (invalidado automáticamente).
+
+### Exclusiones de cobertura (justificadas)
+
+| Patrón excluido | Justificación |
+|---|---|
+| `**/config/**` | Clases de configuración Spring sin lógica de negocio testeable |
+| `**/*Application.class` | Clase main de Spring Boot — arranque de contexto sin lógica |
+| `**/dto/**` | Records/DTOs con cero lógica — solo fields y constructores |
+| `**/*Exception.class` | Jerarquía de excepciones sin lógica propia |
+| `**/entity/*Entity.class` | Entidades JPA — la lógica está en el domain model, no en la entidad de infraestructura |
+| `**/SwaggerConfig.class`, `**/OpenApiConfig.class` | Configuración de documentación sin lógica |
+
+---
+
+## 5. Naming y Estructura de Tests
+
+### 5.1 Backend (Java)
+
+#### Naming de clases
+
+| Tipo | Sufijo | Ejemplo |
+|---|---|---|
+| Test unitario | `Test` | `ReservaTest.java`, `OtpApplicationServiceTest.java` |
+| Test de integración | `IT` | `ReservaControllerIT.java`, `PagoWebhookAdapterIT.java` |
+| Test de arquitectura | `ArchTest` | `ReservasArchTest.java`, `SharedArchTest.java` |
+| Test de concurrencia | `ConcurrencyIT` | `ReservaSolapamientoConcurrencyIT.java` |
+
+#### Naming de métodos
+
+Formato: `should_<comportamiento_esperado>_when_<condicion>`
+
+```java
+// Unitarios
+void should_lanzar_excepcion_when_reserva_solapada()
+void should_calcular_importe_correcto_when_duracion_90_minutos()
+void should_marcar_otp_usado_when_validacion_correcta()
+
+// Integración
+void should_return_409_when_slot_ya_reservado()
+void should_return_403_when_user_role_accede_admin_endpoint()
+void should_return_401_when_token_no_presente()
+void should_invalidar_otp_when_tercer_intento_fallido()
+```
+
+#### Maven Surefire vs. Failsafe
+
+- **Surefire** (`mvn test`): ejecuta `*Test.java` — tests unitarios.
+- **Failsafe** (`mvn verify`): ejecuta `*IT.java` — tests de integración. Requiere Docker para Testcontainers.
+
+### 5.2 Frontend (TypeScript/React)
+
+#### Naming de archivos
+
+| Tipo | Convención | Ejemplo |
+|---|---|---|
+| Test de componente | `<Component>.test.tsx` collocated | `ReservaForm.test.tsx` |
+| Test de hook | `<hook>.test.ts` collocated | `useAuth.test.ts` |
+| Test de util | `<util>.test.ts` collocated | `formatFecha.test.ts` |
+| E2E | `tests/e2e/<flow>.spec.ts` | `reserva-flow.spec.ts` |
+
+### 5.3 Patrón AAA — obligatorio en todos los tests
+
+```java
+@Test
+void should_return_409_when_slot_ya_reservado() throws Exception {
+    // Arrange
+    UsuarioEntity usuario = usuarioRepository.save(UsuarioBuilder.unUsuarioActivo().build());
+    reservaRepository.save(ReservaBuilder.unaReserva()
+        .conFecha(LocalDate.now().plusDays(1))
+        .conHoraInicio(LocalTime.of(18, 0))
+        .conDuracion(60)
+        .conOwner(usuario)
+        .build());
+    String token = generarTokenJwt(usuario);
+
+    // Act
+    ResultActions result = mockMvc.perform(post("/api/reservas")
+        .header("Authorization", "Bearer " + token)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(
+            CrearReservaRequest.builder()
+                .fecha(LocalDate.now().plusDays(1))
+                .horaInicio(LocalTime.of(18, 0))
+                .duracionMinutos(60)
+                .build()
+        )));
+
+    // Assert
+    result.andExpect(status().isConflict())
+          .andExpect(jsonPath("$.code").value("SLOT_NO_DISPONIBLE"));
+}
+```
+
+---
+
+## 6. Builders y Datos de Test
+
+### 6.1 Backend — Builders por entidad
+
+Ubicación: `src/test/java/com/padelpro/<module>/builders/`
+
+Convención: valor válido por defecto + métodos `con<Campo>(...)`.
+
+```java
+// builders/UsuarioBuilder.java
+public class UsuarioBuilder {
+    private String login = "testuser";
+    private String passwordHash = "$2a$12$test-bcrypt-hash";
+    private String firstName = "Test";
+    private String lastName = "Usuario";
+    private String phone = "+34600000001";
+    private String email = "test@padelpro.local";
+    private UserStatus status = UserStatus.ACTIVE;
+    private UserRole role = UserRole.USER;
+
+    public static UsuarioBuilder unUsuarioActivo() { return new UsuarioBuilder(); }
+    public static UsuarioBuilder unAdmin() {
+        return new UsuarioBuilder().conRole(UserRole.ADMIN);
+    }
+
+    public UsuarioBuilder conLogin(String login) { this.login = login; return this; }
+    public UsuarioBuilder conEmail(String email) { this.email = email; return this; }
+    public UsuarioBuilder conRole(UserRole role) { this.role = role; return this; }
+    public UsuarioBuilder conStatus(UserStatus status) { this.status = status; return this; }
+    public UsuarioBuilder conTelegramChatId(String chatId) {
+        this.telegramChatId = chatId; return this;
+    }
+
+    public UsuarioEntity build() {
+        UsuarioEntity e = new UsuarioEntity();
+        e.setLogin(login);
+        e.setPasswordHash(passwordHash);
+        // ... setters
+        return e;
+    }
+}
+```
+
+**Builders obligatorios:**
+
+| Builder | Módulo | Campos clave |
+|---|---|---|
+| `UsuarioBuilder` | `usuarios` | login, email, phone, role, status, telegramChatId |
+| `ReservaBuilder` | `reservas` | fecha, horaInicio, duracionMinutos, estado, canal, owner |
+| `ParticipanteBuilder` | `reservas` | reservaId, userId, externalName, slotPosition, isOwner |
+| `PagoBuilder` | `pagos` | reservaId, amount, method, status, redsysOrderId |
+| `OtpBuilder` | `otp` | userId, code, type, expiresAt, used |
+| `PistaBuilder` | `shared` | — (si se añade entidad pista en versiones futuras) |
+
+### 6.2 Frontend — Factories
+
+```typescript
+// tests/factories/reserva.factory.ts
+import { Reserva, ReservaStatus } from '../../src/types/reserva';
+
+export const buildReserva = (overrides: Partial<Reserva> = {}): Reserva => ({
+  id: '550e8400-e29b-41d4-a716-446655440000',
+  fecha: '2026-06-01',
+  horaInicio: '18:00',
+  horaFin: '19:30',
+  duracionMinutos: 90,
+  status: ReservaStatus.CONFIRMED,
+  canal: 'WEB',
+  participantes: [],
+  ...overrides,
+});
+```
+
+### 6.3 Fixtures — respuestas de sistemas externos
+
+```
+src/test/resources/fixtures/
+├── redsys/
+│   ├── webhook-pago-aprobado.json          — Ds_Response=0000
+│   ├── webhook-pago-rechazado.json         — Ds_Response=0190
+│   ├── webhook-firma-invalida.json         — Ds_Signature manipulado
+│   └── webhook-duplicado.json             — mismo Ds_Merchant_Order
+└── telegram/
+    ├── update-reserva-comando.json         — mensaje "reserva de pista ..."
+    ├── update-cancelacion-comando.json     — mensaje "cancelacion reserva ..."
+    ├── update-vincular-otp.json            — mensaje "/vincular XXXXXX"
+    ├── update-sin-secret.json              — request sin header X-Telegram-Bot-Api-Secret-Token
+    └── update-chat-id-desconocido.json    — chat_id no vinculado a ningún usuario
+```
+
+**Prohibido:** Datos de test hardcodeados dispersos en tests individuales. Todo dato de test pasa por builders o factories.
+
+---
+
+## 7. Reglas de Mocking
+
+### Regla 1 — Solo dependencias externas al SUT
+
+```
+✅ Mockear: ReservaRepositoryPort (cuando el SUT es ReservaApplicationService)
+✅ Mockear: MensajeriaPort (puerto de salida)
+✅ Mockear: TelegramClientAdapter en tests unitarios de MensajeriaApplicationService
+❌ NUNCA: mockear ReservaApplicationService cuando es el SUT
+❌ NUNCA: mockear el Repositorio JPA en tests de integración (usar Testcontainers)
+```
+
+### Regla 2 — Strict stubs obligatorios
+
+```java
+// En tests unitarios Spring Boot 3.2 — ya activado por defecto
+// Si se usa @ExtendWith(MockitoExtension.class) directamente:
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
+class ReservaApplicationServiceTest { ... }
+```
+
+Cualquier stub definido pero no invocado falla el test — señal de test mal diseñado o redundante.
+
+### Regla 3 — WireMock para Redsys y Telegram en integration tests
+
+```java
+// En BaseExternalServiceIT — WireMock como servidor HTTP real
+telegramServer.stubFor(WireMock.post("/bot{token}/sendMessage")
+    .willReturn(WireMock.ok()
+        .withHeader("Content-Type", "application/json")
+        .withBodyFile("telegram/send-message-ok.json")));
+```
+
+### Regla 4 — MSW en frontend
+
+```typescript
+// tests/mocks/handlers/reservas.handlers.ts
+import { http, HttpResponse } from 'msw';
+
+export const reservasHandlers = [
+  http.get('/api/reservas/disponibles', () =>
+    HttpResponse.json([buildReserva({ status: ReservaStatus.CONFIRMED })]),
+  ),
+  http.post('/api/reservas', () =>
+    HttpResponse.json(buildReserva(), { status: 201 }),
+  ),
+];
+```
+
+### Regla 5 — Verificación de interacciones solo cuando forma parte del contrato
+
+```java
+// ✅ Verificar que el servicio de auditoría registró la acción — es parte del contrato
+verify(auditoriaPort).registrar(
+    eq("RESERVATION_CREATED"),
+    eq("RESERVATION"),
+    eq(reservaId.toString()),
+    any()
+);
+
+// ❌ NO verificar detalles de implementación interna (cuántas veces se llama save, etc.)
+```
+
+---
+
+## 8. Tests por Área Crítica
+
+### 8.1 Autenticación
+
+```java
+// UsuarioControllerIT.java — tests de seguridad mínimos obligatorios
+
+@Test
+void should_return_200_and_jwt_when_credenciales_validas() { ... }
+
+@Test
+void should_return_401_when_password_incorrecta() { ... }
+
+@Test
+void should_not_leak_user_existence_in_401_response() {
+    // El mensaje de error 401 es idéntico para usuario inexistente y password incorrecta
+}
+
+@Test
+void should_return_423_when_cuenta_bloqueada_por_10_intentos() { ... }
+
+@Test
+void should_return_401_when_refresh_token_revocado() { ... }
+
+@Test
+void should_return_401_when_refresh_token_expirado() { ... }
+
+@Test
+void should_invalidar_refresh_token_on_logout() { ... }
+
+@Test
+void should_return_401_on_refresh_after_logout() { ... }
+
+@Test
+void should_return_401_when_no_auth_header() throws Exception {
+    mockMvc.perform(get("/api/usuarios/me"))
+           .andExpect(status().isUnauthorized());
+}
+
+@Test
+void should_return_403_when_usuario_pendiente_intenta_login() { ... }
+```
+
+#### OTP Telegram
+
+```java
+// OtpApplicationServiceIT.java
+
+@Test
+void should_almacenar_otp_como_sha256_no_en_claro() {
+    // Arrange: generar OTP
+    // Act: buscar en BD
+    // Assert: el campo code en BD no es igual al código generado en claro
+    //         (es el hash SHA-256)
+}
+
+@Test
+void should_expirar_otp_despues_de_10_minutos() { ... }
+
+@Test
+void should_invalidar_otp_en_cuarto_intento_fallido() { ... }
+
+@Test
+void should_marcar_used_true_despues_de_validacion_correcta() { ... }
+
+@Test
+void should_rechazar_otp_ya_usado() { ... }
+
+@Test
+void should_rechazar_otp_de_otro_usuario() { ... }
+```
+
+### 8.2 RBAC — Todos los endpoints
+
+Cada endpoint del OpenAPI debe tener al menos estos dos tests de seguridad:
+
+```java
+// Template RBAC — aplicar a cada endpoint protegido
+
+@Test
+void should_return_401_when_no_autenticado() throws Exception {
+    mockMvc.perform(get("/api/<endpoint>"))
+           .andExpect(status().isUnauthorized());
+}
+
+@Test
+void should_return_403_when_rol_insuficiente() throws Exception {
+    mockMvc.perform(get("/api/admin/<endpoint>")
+            .with(user("testuser").roles("USER")))
+           .andExpect(status().isForbidden());
+}
+```
+
+**Tabla de cobertura RBAC mínima:**
+
+| Endpoint | PUBLIC | USER | ADMIN |
+|---|---|---|---|
+| `POST /auth/login` | ✅ 200 | — | — |
+| `POST /auth/register` | ✅ 201 | — | — |
+| `POST /auth/refresh` | ✅ 200 | — | — |
+| `POST /auth/logout` | ✅ 401 anon | ✅ 200 | ✅ 200 |
+| `GET /usuarios/me` | ✅ 401 anon | ✅ 200 | ✅ 200 |
+| `GET /admin/usuarios` | ✅ 401 anon | ✅ 403 | ✅ 200 |
+| `POST /admin/usuarios` | ✅ 401 anon | ✅ 403 | ✅ 201 |
+| `DELETE /admin/usuarios/{id}` | ✅ 401 anon | ✅ 403 | ✅ 200 |
+| `GET /reservas/disponibles` | ✅ 401 anon | ✅ 200 | ✅ 200 |
+| `POST /reservas` | ✅ 401 anon | ✅ 201 | ✅ 201 |
+| `DELETE /reservas/{id}` | ✅ 401 anon | ✅ solo owner | ✅ 200 |
+| `GET /admin/reservas` | ✅ 401 anon | ✅ 403 | ✅ 200 |
+| `POST /pagos/iniciar` | ✅ 401 anon | ✅ solo owner | ✅ 200 |
+| `POST /admin/pagos/{id}/efectivo` | ✅ 401 anon | ✅ 403 | ✅ 200 |
+| `POST /otp/verificar` | ✅ 401 anon | ✅ 200 | ✅ 200 |
+
+### 8.3 Redsys — Pagos
+
+```java
+// PagoWebhookAdapterIT.java
+
+@Test
+void should_procesar_pago_when_hmac_valido_y_respuesta_aprobada() {
+    // Arrange: crear reserva y pago PENDING
+    // Act: POST /api/pagos/webhook con payload firmado correctamente
+    // Assert: payment.status == PAID, audit_log contiene PAYMENT_CONFIRMED
+}
+
+@Test
+void should_ignorar_webhook_when_hmac_invalido() {
+    // Assert: payment.status sigue en PENDING, no se crea audit_log de PAYMENT_CONFIRMED
+    // El endpoint responde 200 (nunca revelar el fallo a Redsys)
+}
+
+@Test
+void should_ser_idempotente_when_webhook_duplicado() {
+    // Primer webhook → PAID
+    // Segundo webhook idéntico → sigue PAID, no hay duplicado
+}
+
+@Test
+void should_pan_cvv_nunca_aparecer_en_audit_log() {
+    // Después de procesar webhook, buscar en audit_log.details
+    // No debe contener patrones de PAN (16 dígitos) ni CVV
+}
+
+@Test
+void should_calcular_importe_en_backend_no_aceptar_de_frontend() {
+    // El importe en payments.amount es price_per_hour × duration / 60
+    // No debe ser manipulable desde el request del frontend
+}
+```
+
+### 8.4 Reservas — Anti-solapamiento
+
+```java
+// ReservaSolapamientoConcurrencyIT.java (requiere Testcontainers — NO H2)
+
+@Test
+@Transactional(propagation = Propagation.NOT_SUPPORTED)  // Sin transacción padre
+void should_exactamente_una_reserva_succeed_when_peticiones_concurrentes_mismo_slot()
+    throws InterruptedException, ExecutionException {
+
+    // Arrange
+    int threadCount = 10;
+    ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+    CountDownLatch latch = new CountDownLatch(threadCount);
+    AtomicInteger successCount = new AtomicInteger(0);
+    AtomicInteger conflictCount = new AtomicInteger(0);
+    UsuarioEntity[] usuarios = crearNUsuarios(threadCount);
+
+    // Act
+    List<Future<?>> futures = new ArrayList<>();
+    for (int i = 0; i < threadCount; i++) {
+        final int idx = i;
+        futures.add(executor.submit(() -> {
+            latch.countDown();
+            latch.await();
+            try {
+                mockMvc.perform(post("/api/reservas")
+                    .header("Authorization", "Bearer " + tokens[idx])
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(buildReservaRequestJson(fecha, LocalTime.of(18, 0), 60)));
+                // Si llega aquí sin excepción = 201 o 409
+                // Contar según status
+            } catch (Exception e) { throw new RuntimeException(e); }
+        }));
+    }
+
+    // Assert
+    // Exactamente 1 éxito, threadCount-1 conflictos
+    assertThat(successCount.get()).isEqualTo(1);
+    assertThat(conflictCount.get()).isEqualTo(threadCount - 1);
+}
+
+@Test
+void should_constraint_gist_rechazar_solapamiento_via_sql_directo()
+    throws Exception {
+    // Test de la segunda barrera — directo a la BD sin pasar por la aplicación
+    // INSERT que viola el constraint gist debe lanzar excepción de PostgreSQL
+}
+```
+
+### 8.5 Bot Telegram
+
+```java
+// BotTelegramAdapterIT.java
+
+@Test
+void should_return_403_when_secret_token_invalido() throws Exception {
+    mockMvc.perform(post("/api/bot/telegram")
+            .header("X-Telegram-Bot-Api-Secret-Token", "wrong-secret")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(loadFixture("telegram/update-reserva-comando.json")))
+           .andExpect(status().isForbidden());
+}
+
+@Test
+void should_return_200_when_secret_token_valido() throws Exception {
+    // Verificar que el webhook es procesado
+}
+
+@Test
+void should_responder_error_when_chat_id_no_vinculado() throws Exception {
+    // El bot responde al chat indicando que debe vincular la cuenta
+}
+
+@Test
+void should_vinculacion_exitosa_when_otp_tipo_telegram_link_valido() { ... }
+```
+
+### 8.6 Base de datos — Constraints
+
+```java
+// RepositorioConstraintsIT.java (Testcontainers)
+
+@Test
+void should_lanzar_excepcion_when_email_duplicado() { ... }
+
+@Test
+void should_lanzar_excepcion_when_redsys_order_id_duplicado() { ... }
+
+@Test
+void should_lanzar_excepcion_when_telegram_chat_id_duplicado() { ... }
+
+@Test
+void should_set_null_participant_user_id_when_user_deleted_logically() {
+    // El user se inactiva (soft-delete), el participant.user_id queda NULL (SET NULL)
+}
+
+@Test
+void should_restringir_borrado_reserva_cuando_tiene_pago() {
+    // ON DELETE RESTRICT en payments.reservation_id
+    // No se puede borrar una reserva que tiene pago
+}
+
+@Test
+void should_flyway_aplicar_todas_las_migraciones_en_orden() {
+    // Verifica que V1 a V12 se aplican sin error en un contenedor limpio
+}
+```
+
+---
+
+## 9. Tests de Cumplimiento RGPD
+
+```java
+// RgpdComplianceIT.java
+
+@Test
+void should_respuesta_error_no_exponer_datos_personales() throws Exception {
+    // Intentar login con usuario inexistente
+    // La respuesta 401 NO debe contener email, nombre, teléfono
+    mockMvc.perform(post("/api/auth/login")
+            .content("{\"login\":\"inexistente\",\"password\":\"wrong\"}"))
+           .andExpect(status().isUnauthorized())
+           .andExpect(jsonPath("$.message").doesNotContain("@"))
+           .andExpect(jsonPath("$.message").doesNotContain("+34"));
+}
+
+@Test
+void should_logs_no_contener_passwords_ni_tokens() {
+    // Capturar log output durante un login
+    // Verificar que no aparece la password ni el JWT
+    // Usar ListAppender de Logback en tests
+}
+
+@Test
+void should_logs_no_contener_otp_en_claro() {
+    // Durante generación de OTP, verificar que el código no aparece en logs
+}
+
+@Test
+void should_anonimizar_usuario_correctamente_when_derecho_al_olvido() throws Exception {
+    // Arrange: usuario activo con telegram_chat_id vinculado
+    // Act: DELETE /api/admin/usuarios/{id}
+    // Assert:
+    //   - users.first_name = 'ANONIMIZADO'
+    //   - users.last_name = 'ANONIMIZADO'
+    //   - users.phone = NULL
+    //   - users.email = 'deleted_{id}@padelpro.invalid'
+    //   - users.telegram_chat_id = NULL
+    //   - participants.external_name = 'ANONIMIZADO' donde user_id = {id}
+    //   - audit_log contiene action='USER_ANONYMIZED'
+    //   - refresh_tokens.revoked = true para todos los tokens del usuario
+    //   - otp_codes.used = true para todos los OTPs activos del usuario
+}
+
+@Test
+void should_retener_reservas_y_pagos_aunque_usuario_anonimizado() {
+    // reservations y payments NO se borran con la anonimización
+}
+
+@Test
+void should_pan_cvv_nunca_en_audit_log_details() {
+    // Después de procesar cualquier webhook Redsys, buscar patrones de tarjeta
+    // en audit_log.details — nunca debe aparecer
+}
+```
+
+---
+
+## 10. Política de Flaky Tests
+
+### Definición y detección
+
+Un test es **flaky** si pasa en menos del 95 % de las ejecuciones sin cambios en el código bajo test.
+
+**Causas frecuentes en PadelPro:**
+- `Thread.sleep()` para esperar procesamiento asíncrono → usar `Awaitility`.
+- Tests de concurrencia sin barreras (`CountDownLatch`) → corregir sincronización.
+- Estado compartido entre tests sin cleanup → añadir `@Sql("/sql/cleanup.sql")` o `@Transactional`.
+- WireMock con stubs solapados entre tests → resetear en `@AfterEach`.
+
+### Política de cuarentena
+
+```java
+// Test identificado como flaky: añadir tag y documentar
+@Test
+@Tag("flaky")
+@Disabled("Flaky desde 2026-06-01. Issue: #123. Deadline: 2026-06-08.")
+void should_ejemplo_test_flaky() { ... }
+```
+
+| Etapa | Acción |
+|---|---|
+| Detección | CI marca test como flaky si falla sin cambios de código |
+| Cuarentena | `@Tag("flaky")` — excluido de la suite de merge |
+| Deadline | 7 días calendario desde detección |
+| Si no se corrige | Issue GitHub `type:bug priority:must area:<modulo>` |
+
+### Awaitility — sustituto de Thread.sleep
+
+```java
+// ❌ PROHIBIDO
+Thread.sleep(2000);
+
+// ✅ OBLIGATORIO
+Awaitility.await()
+    .atMost(5, TimeUnit.SECONDS)
+    .pollInterval(100, TimeUnit.MILLISECONDS)
+    .until(() -> notificationLogRepository.findByUserId(userId).stream()
+        .anyMatch(n -> n.getStatus() == NotificationStatus.SENT));
+```
+
+---
+
+## 11. Tiempos Máximos de Ejecución
+
+| Suite | Tiempo máximo | Acción si se supera |
+|---|---|---|
+| Tests unitarios backend | 2 minutos | Investigar tests lentos; `Thread.sleep` prohibido |
+| Tests integración backend | 8 minutos | Revisar cleanup SQL; habilitar `withReuse(true)` en Testcontainers |
+| Tests unitarios frontend | 90 segundos | Reducir renders innecesarios; revisar MSW handlers |
+| Suite E2E completa | 5 minutos | Revisar `webServer` config; reducir tests E2E a solo flujos críticos |
+| Test individual | 5 segundos | Requiere comentario justificando la duración en el método de test |
+
+---
+
+## 12. Quality Gate — Criterios de Fallo Automático
+
+La build de CI falla **sin excepción** si se cumple cualquiera de estas condiciones:
+
+| Condición | Herramienta | Job |
+|---|---|---|
+| Cualquier test unitario falla | Maven Surefire / Vitest | `unit-tests` / `frontend-tests` |
+| Cualquier test de integración falla | Maven Failsafe | `integration-tests` |
+| Cobertura de líneas < 80 % (backend) | JaCoCo `jacoco:check` | `quality-gate` |
+| Cobertura de branches < 75 % (backend) | JaCoCo `jacoco:check` | `quality-gate` |
+| Cobertura de líneas < 75 % (frontend) | Vitest c8 | `frontend-tests` |
+| Linter reporta error (no warning) | Checkstyle / ESLint | `lint` |
+| CVE CRITICAL o HIGH sin supresión | OWASP Dependency-Check | `quality-gate` |
+| npm audit HIGH o CRITICAL | npm audit | `frontend-tests` |
+| Mutation score < 70 % en módulos críticos | Pitest | Manual (fase CI avanzada) |
+| Test E2E crítico falla | Playwright | `e2e-tests` (job separado) |
+
+**Nunca** bajar los umbrales para hacer pasar la build. Si la cobertura está por debajo del umbral, añadir los tests que faltan.
+
+---
+
+## 13. Comandos Canónicos
+
+> Estos son los comandos exactos que TODOS los agentes (`verification-specialist`, `reality-checker`, `api-tester`, `tester-tdd`) deben usar. No hay variaciones.
+
+| Propósito | Comando | Output |
+|---|---|---|
+| **Build sin tests** | `mvn -B clean compile -DskipTests` | `BUILD SUCCESS` o errores de compilación |
+| **Unit tests backend** | `mvn -B test -Dtest="*Test" -DfailIfNoTests=false` | Surefire report en `target/surefire-reports/` |
+| **Integration tests backend** | `mvn -B verify -Dtest="NONE" -DfailIfNoTests=false` | Failsafe report en `target/failsafe-reports/` |
+| **Todos los tests backend** | `mvn -B verify` | Unit + integration + JaCoCo check |
+| **Generar reporte de cobertura** | `mvn -B jacoco:report` | HTML en `target/site/jacoco/index.html` |
+| **Verificar umbrales de cobertura** | `mvn -B jacoco:check` | Falla si < 80 % líneas / < 75 % branches |
+| **Tests de arquitectura** | `mvn -B test -Dtest="*ArchTest"` | ArchUnit violations o PASS |
+| **Mutation testing** | `mvn -B org.pitest:pitest-maven:mutationCoverage` | HTML en `target/pit-reports/` |
+| **Lint backend (Checkstyle)** | `mvn -B checkstyle:check` | Violations o `BUILD SUCCESS` |
+| **OWASP Dependency Check** | `mvn -B dependency-check:check -DfailBuildOnCVSS=7` | Reporte HTML + fallo si HIGH/CRITICAL |
+| **Unit tests frontend** | `npm run test --prefix frontend` | Vitest output |
+| **Unit tests frontend con cobertura** | `npm run test:coverage --prefix frontend` | Coverage report en `frontend/coverage/` |
+| **Lint frontend** | `npm run lint --prefix frontend` | ESLint output |
+| **E2E (requiere servidor levantado)** | `npm run test:e2e --prefix frontend` | Playwright report en `playwright-report/` |
+| **Todos los tests locales** | `mvn -B verify && npm run test:coverage --prefix frontend` | Suite completa |
+| **Solo tests de un módulo** | `mvn -B test -pl reservas -Dtest="*Test"` | Tests del módulo `reservas` |
+| **Arrancar servidor para api-tester** | `mvn -f backend/pom.xml spring-boot:run -Dspring-boot.run.profiles=test &` | Servidor en `http://localhost:8080` |
+
+**Variables de entorno requeridas para tests de integración:**
+
+```bash
+# No requeridas — Testcontainers inyecta sus propias credenciales vía @DynamicPropertySource
+# El perfil 'it' usa los valores inyectados dinámicamente
+```
+
+---
+
+## 14. Estructura de Carpetas
+
+### Backend (Maven multi-módulo)
+
+```
+backend/
+├── pom.xml                                    ← parent pom
+│
+├── reservas/
+│   ├── src/
+│   │   ├── main/java/com/padelpro/reservas/
+│   │   └── test/
+│   │       ├── java/com/padelpro/reservas/
+│   │       │   ├── unit/
+│   │       │   │   ├── domain/
+│   │       │   │   │   ├── ReservaTest.java
+│   │       │   │   │   └── ParticipanteTest.java
+│   │       │   │   └── application/
+│   │       │   │       └── ReservaApplicationServiceTest.java
+│   │       │   ├── integration/
+│   │       │   │   ├── ReservaControllerIT.java
+│   │       │   │   ├── ReservaRepositorioIT.java
+│   │       │   │   └── ReservaSolapamientoConcurrencyIT.java
+│   │       │   ├── arch/
+│   │       │   │   └── ReservasArchTest.java
+│   │       │   └── builders/
+│   │       │       ├── ReservaBuilder.java
+│   │       │       └── ParticipanteBuilder.java
+│   │       └── resources/
+│   │           ├── application-test.yml       ← H2 para unit repos simples
+│   │           ├── application-it.yml         ← Testcontainers PostgreSQL 15
+│   │           ├── sql/
+│   │           │   └── cleanup.sql
+│   │           └── fixtures/
+│   │               ├── redsys/
+│   │               └── telegram/
+│
+├── pagos/
+│   └── src/test/
+│       ├── java/com/padelpro/pagos/
+│       │   ├── unit/
+│       │   │   ├── domain/
+│       │   │   │   └── PagoTest.java
+│       │   │   └── application/
+│       │   │       └── PagoApplicationServiceTest.java
+│       │   ├── integration/
+│       │   │   ├── PagoControllerIT.java
+│       │   │   ├── PagoWebhookAdapterIT.java   ← WireMock Redsys
+│       │   │   └── PagoRepositorioIT.java
+│       │   ├── arch/
+│       │   │   └── PagosArchTest.java
+│       │   └── builders/
+│       │       └── PagoBuilder.java
+│       └── resources/
+│           ├── application-test.yml
+│           ├── application-it.yml
+│           └── fixtures/redsys/
+│
+├── usuarios/
+│   └── src/test/
+│       ├── java/com/padelpro/usuarios/
+│       │   ├── unit/
+│       │   │   ├── domain/
+│       │   │   │   └── UsuarioTest.java
+│       │   │   └── application/
+│       │   │       ├── AuthApplicationServiceTest.java
+│       │   │       └── UsuarioApplicationServiceTest.java
+│       │   ├── integration/
+│       │   │   ├── AuthControllerIT.java       ← login, refresh, logout, lockout
+│       │   │   ├── UsuarioControllerIT.java
+│       │   │   └── AdminUsuarioControllerIT.java
+│       │   ├── arch/
+│       │   │   └── UsuariosArchTest.java
+│       │   └── builders/
+│       │       └── UsuarioBuilder.java
+│       └── resources/
+│           ├── application-test.yml
+│           └── application-it.yml
+│
+├── mensajeria/
+│   └── src/test/
+│       ├── java/com/padelpro/mensajeria/
+│       │   ├── unit/
+│       │   │   └── application/
+│       │   │       └── MensajeriaApplicationServiceTest.java
+│       │   └── integration/
+│       │       └── BotTelegramAdapterIT.java   ← WireMock Telegram
+│       └── resources/
+│           └── fixtures/telegram/
+│
+├── otp/
+│   └── src/test/
+│       ├── java/com/padelpro/otp/
+│       │   ├── unit/
+│       │   │   ├── domain/
+│       │   │   │   └── OtpTest.java
+│       │   │   └── application/
+│       │   │       └── OtpApplicationServiceTest.java
+│       │   ├── integration/
+│       │   │   └── OtpApplicationServiceIT.java
+│       │   └── builders/
+│       │       └── OtpBuilder.java
+│       └── resources/
+│
+├── auditoria/
+│   └── src/test/
+│       └── java/com/padelpro/auditoria/
+│           ├── unit/
+│           │   └── domain/
+│           │       └── AuditoriaEntryTest.java
+│           └── integration/
+│               └── AuditoriaApplicationServiceIT.java
+│
+└── shared/
+    └── src/test/
+        ├── java/com/padelpro/shared/
+        │   ├── BaseIntegrationTest.java        ← clase base con Testcontainers
+        │   ├── BaseExternalServiceIT.java      ← clase base con WireMock
+        │   ├── security/
+        │   │   └── JwtProviderTest.java
+        │   ├── integration/
+        │   │   ├── SecurityConfigIT.java       ← RBAC global
+        │   │   └── RgpdComplianceIT.java       ← RGPD
+        │   └── builders/
+        │       └── (builders compartidos si aplica)
+        └── resources/
+            └── sql/
+                └── cleanup.sql
+```
+
+### Frontend
+
+```
+frontend/
+├── src/
+│   ├── components/
+│   │   └── ReservaForm/
+│   │       ├── ReservaForm.tsx
+│   │       └── ReservaForm.test.tsx           ← collocated
+│   ├── hooks/
+│   │   ├── useAuth.ts
+│   │   └── useAuth.test.ts                    ← collocated
+│   └── utils/
+│       ├── formatFecha.ts
+│       └── formatFecha.test.ts                ← collocated
+│
+└── tests/
+    ├── e2e/
+    │   ├── reserva-flow.spec.ts               ← CU-01 + CU-02
+    │   ├── pago-flow.spec.ts                  ← CU-03
+    │   └── auth-flow.spec.ts                  ← Login, logout, RBAC
+    ├── mocks/
+    │   ├── server.ts
+    │   └── handlers/
+    │       ├── auth.handlers.ts
+    │       ├── reservas.handlers.ts
+    │       ├── pagos.handlers.ts
+    │       └── usuarios.handlers.ts
+    ├── factories/
+    │   ├── reserva.factory.ts
+    │   ├── usuario.factory.ts
+    │   └── pago.factory.ts
+    ├── fixtures/
+    │   ├── reserva-list.json
+    │   └── usuario-profile.json
+    └── setup.ts
+```
+
+---
+
+## 15. Guía de Onboarding para Desarrolladores
+
+### "Cómo ejecutar todos los tests con un solo comando"
+
+```bash
+# Desde la raíz del repositorio
+# Requiere: Java 21, Maven 3.9+, Node.js 20+, Docker (para Testcontainers)
+
+# Backend completo + frontend
+mvn -B verify && npm run test:coverage --prefix frontend
+
+# Solo backend
+mvn -B verify
+
+# Solo frontend
+npm run test:coverage --prefix frontend
+
+# Solo E2E (requiere backend + frontend levantados)
+npm run test:e2e --prefix frontend
+```
+
+### "Cómo añadir un test unitario paso a paso"
+
+1. Identifica la clase bajo test (SUT): e.g., `OtpApplicationService`.
+2. Crea el archivo: `otp/src/test/java/com/padelpro/otp/unit/application/OtpApplicationServiceTest.java`.
+3. Añade la anotación de extensión:
+   ```java
+   @ExtendWith(MockitoExtension.class)
+   @MockitoSettings(strictness = Strictness.STRICT_STUBS)
+   class OtpApplicationServiceTest { ... }
+   ```
+4. Usa un builder para el objeto de test: `OtpBuilder.unOtpActivo().build()`.
+5. Sigue el patrón AAA con comentarios visibles.
+6. Ejecuta solo ese test: `mvn -B test -Dtest="OtpApplicationServiceTest" -pl otp`.
+
+### "Cómo añadir un test de integración con Testcontainers"
+
+1. Extiende `BaseIntegrationTest` (ya tiene el contenedor PostgreSQL 15 configurado).
+2. El nombre de la clase termina en `IT`: e.g., `ReservaControllerIT`.
+3. Usa el perfil `it` (aplicado automáticamente en `BaseIntegrationTest`).
+4. Añade `@Sql("/sql/cleanup.sql")` en `@BeforeEach` para aislar el estado.
+5. Ejecuta la suite de integración: `mvn -B verify -Dtest="NONE" -pl reservas`.
+6. Si el test toca la restricción gist de solapamiento, usa `Propagation.NOT_SUPPORTED` para que el constraint de PostgreSQL dispare correctamente.
+
+### "Cómo depurar un test fallido en CI"
+
+1. Descarga el artefacto `coverage-report` de la ejecución de CI para ver el reporte HTML de JaCoCo.
+2. Para tests de integración fallidos, comprueba los logs de Testcontainers:
+   ```bash
+   # Logs del contenedor PostgreSQL durante los tests
+   mvn -B verify -Dtest="NONE" -Dtestcontainers.log-level=DEBUG
+   ```
+3. Para tests de WireMock fallidos, habilitar logging de requests:
+   ```java
+   wiremockServer.setGlobalFixedDelay(0);
+   System.setProperty("wiremock.verbose", "true");
+   ```
+4. Para tests de concurrencia intermitentes, ejecutar 10 veces:
+   ```bash
+   mvn -B test -Dtest="ReservaSolapamientoConcurrencyIT" -Dsurefire.rerunFailingTestsCount=10
+   ```
+5. Si el test pasa en local y falla en CI, verificar que Docker está disponible (Testcontainers requiere Docker socket).
+
+---
+
+## 16. Roadmap de Adopción
+
+El repositorio parte de cero — sin código de producción, sin tests. Las fases son secuenciales.
+
+### Fase 0 — Scaffolding (Sprint 1, Ticket TICKET-001)
+- [ ] Generar `docs/TESTING-STRATEGY.md` (este documento) con `test-strategist`.
+- [ ] Aprobar la estrategia con el propietario del producto.
+- [ ] Añadir dependencias de test en todos los `pom.xml` de módulos.
+- [ ] Crear `BaseIntegrationTest.java` con Testcontainers.
+- [ ] Crear `BaseExternalServiceIT.java` con WireMock.
+- [ ] Crear `sql/cleanup.sql`.
+- [ ] Configurar JaCoCo con umbrales en el `pom.xml` padre.
+- [ ] Configurar GitHub Actions CI con los jobs del §3.4.
+- [ ] Crear `vitest.config.ts` con c8 y umbrales.
+- [ ] Configurar MSW server en `tests/setup.ts`.
+
+### Fase 1 — Primer ciclo TDD (Sprint 1)
+- [ ] **US-003 — Auto-registro**: primera historia de menor complejidad.
+- [ ] Ciclo Red-Green-Refactor para `POST /api/auth/register`.
+- [ ] Tests unitarios: `UsuarioBuilder`, `AuthApplicationServiceTest`, `PasswordPolicyServiceTest`.
+- [ ] Tests de integración: `AuthControllerIT.should_return_201_when_registro_valido`.
+- [ ] Test RBAC: `should_return_401_when_no_autenticado`.
+
+### Fase 2 — Auth y RBAC (Sprint 1-2)
+- [ ] **US-001** — Login web + JWT.
+- [ ] **US-002** — Refresh token + logout.
+- [ ] **US-004** — Vinculación Telegram + OTP tipo TELEGRAM_LINK.
+- [ ] **US-005** — Toggle estado usuario (ADMIN).
+- [ ] **US-008** — Confirmar OTP para operaciones críticas.
+- [ ] Cobertura completa de la tabla RBAC del §8.2.
+- [ ] Tests de bloqueo de cuenta (10 intentos → LOCKED).
+
+### Fase 3 — Reservas (Sprint 2-3)
+- [ ] **US-006** — Crear reserva (web).
+- [ ] **US-007** — Disponibilidad de pista.
+- [ ] **US-009** — Cancelar reserva (dentro y fuera del plazo).
+- [ ] **US-010** — Unirse a reserva (hueco libre y hueco completo).
+- [ ] **US-011** — Reserva vía Telegram + OTP.
+- [ ] Test de concurrencia `ReservaSolapamientoConcurrencyIT`.
+- [ ] Test del constraint gist a nivel SQL.
+
+### Fase 4 — Pagos Redsys (Sprint 3)
+- [ ] **US-014** — Inicio de pago Redsys (HMAC SHA-256).
+- [ ] **US-015** — Webhook Redsys (aprobado, rechazado, inválido, duplicado).
+- [ ] **US-016** — Pago en efectivo (ADMIN).
+- [ ] Tests PCI-lite: verificar que PAN/CVV nunca aparecen.
+
+### Fase 5 — E2E críticos (Sprint 3-4)
+- [ ] `reserva-flow.spec.ts`: CU-01 (crear) + CU-02 (unirse).
+- [ ] `pago-flow.spec.ts`: CU-03 (pago online).
+- [ ] `auth-flow.spec.ts`: login → reserva → logout → refresh inválido.
+
+### Fase 6 — Mutation testing (Post Sprint 4)
+- [ ] Configurar Pitest en módulos `pagos`, `otp`, `reservas`.
+- [ ] Alcanzar mutation score ≥ 70 %.
+- [ ] Añadir tests adicionales si mutation score < 70 %.
+
+---
+
+## 17. Decisiones Abiertas
+
+Las siguientes decisiones requieren confirmación del propietario del producto antes de que `tester-tdd` pueda iniciar la Fase 1:
+
+| # | Decisión | Impacto en testing | Acción requerida |
+|---|---|---|---|
+| **D-TEST-01** | **OTP almacenado como SHA-256 vs. en claro** (referencia D-SEC-02 de `security-design.md`): el campo `otp_codes.code` es `VARCHAR(6)`. Si se decide almacenar como SHA-256, el test `should_almacenar_otp_como_sha256_no_en_claro` requiere verificar que el valor en BD es un hash de 64 caracteres, no 6 dígitos. | Cambia la lógica del builder `OtpBuilder` y los assertions del test de almacenamiento. | Confirmar decisión D-SEC-02 en `security-design.md`. |
+| **D-TEST-02** | **Confirmación OTP en reservas web** (referencia P2 de `data-model.md`): ¿La reserva creada desde web requiere OTP para pasar de `PENDING_CONFIRMATION` a `CONFIRMED`? Si no, el test de creación de reserva web debe verificar status `CONFIRMED` directamente. | El flujo de test de CU-01 web cambia según si hay o no paso de OTP intermedio. | Validar RN-07 para canal WEB con el dueño del producto. |
+| **D-TEST-03** | **Lifetime del access token** (referencia D-SEC-07 de `security-design.md`): 15 min (este documento) vs. 8h (README). Los tests de expiración de token deben usar el valor correcto en el `application-it.yml`. | Los tests que verifican expiración dependen del valor configurado. | Confirmar con D-SEC-07 el valor definitivo. |
+| **D-TEST-04** | **Rotación de refresh tokens** (D-SEC-01): si se implementa en v1.0, añadir test `should_invalidar_refresh_antiguo_when_usado` y `should_detectar_reutilizacion_de_token_robado`. Si no se implementa, no son necesarios. | Añade 2 tests de integración al flujo de auth si se implementa. | Confirmar con D-SEC-01. |
+| **D-TEST-05** | **Portabilidad de datos RGPD** (`GET /api/usuarios/me/exportar`, D-SEC-03): si se implementa, añadir test que verifica que la exportación incluye todos los datos propios y no incluye datos de otros usuarios. | Añade 1-2 tests de integración al controlador de usuarios. | Confirmar con D-SEC-03. |
+| **D-TEST-06** | **Horario de apertura del club** (P4 de `data-model.md`): si se añaden columnas `opening_time`/`closing_time` a `system_config`, añadir tests que verifiquen que no se puede crear una reserva fuera del horario. | Añade casos de test en `ReservaControllerIT` y en `ReservaDisponibilidadService`. | Confirmar si es requisito v1.0 o v2. |
+| **D-TEST-07** | **Módulo frontend — alcance de E2E**: ¿los flujos E2E de Playwright corren contra el backend completo (con Testcontainers PostgreSQL 15) o contra el backend con H2 y WireMock? Recomendación: backend de test con perfil `it` + Testcontainers para máxima fidelidad. | Afecta a la configuración `webServer` de `playwright.config.ts` y al entorno de CI E2E. | Confirmar antes de escribir los E2E de la Fase 5. |

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,0 +1,1007 @@
+# PadelPro — Modelo de Datos
+
+> **Versión:** 1.0 · **Motor:** PostgreSQL 15 · **Generado:** 2026-05-22
+>
+> Fuente de verdad para `backend-architect` (mapeo JPA), `database-optimizer` (índices/N+1), `api-tester`/`frontend-engineer` (DTOs) y `security-auditor` (trazabilidad y RGPD).
+
+---
+
+## 1. Resumen ejecutivo
+
+| # | Entidad | Tabla SQL | Responsabilidad | PK | Épica |
+|---|---|---|---|---|---|
+| 1 | Usuario | `users` | Usuarios registrados, autenticación, roles y vinculación Telegram | `BIGSERIAL` | EP-01 |
+| 2 | Token de refresco | `refresh_tokens` | Tokens JWT de larga duración para renovar sesiones | `BIGSERIAL` | EP-01 |
+| 3 | Reserva | `reservations` | Ciclo de vida completo de una reserva de pista | `UUID` | EP-02 |
+| 4 | Participante | `participants` | Jugadores asignados a una reserva (registrados o externos) | `BIGSERIAL` | EP-02 |
+| 5 | Pago | `payments` | Transacción económica asociada a cada reserva | `UUID` | EP-03 |
+| 6 | Código OTP | `otp_codes` | Códigos de un solo uso para operaciones críticas (TTL 10 min) | `BIGSERIAL` | EP-01/EP-02/EP-04 |
+| 7 | Log de auditoría | `audit_log` | Registro inmutable de todas las acciones del sistema | `BIGSERIAL` | EP-05 |
+| 8 | Log de notificaciones | `notification_log` | Registro de mensajes enviados (email / Telegram) | `BIGSERIAL` | EP-06 |
+| 9 | Configuración del sistema | `system_config` | Parámetros globales del club (singleton, id=1) | `BIGSERIAL` | EP-05 |
+
+**Decisiones de modelado clave:**
+
+| Decisión | Elección | Justificación |
+|---|---|---|
+| PK de entidades externas | `UUID` (`gen_random_uuid()`) | `reservations` y `payments` aparecen en URLs y webhooks externos (Redsys). UUID evita la enumeración secuencial y la correlación de volumen. |
+| PK de entidades internas | `BIGSERIAL` | `users`, `participants`, `otp_codes`, `audit_log`, `notification_log`, `refresh_tokens`, `system_config` nunca se exponen directamente en rutas públicas. BIGSERIAL es más eficiente en índices B-tree. |
+| Enumeraciones | Tipos `ENUM` de PostgreSQL | Garantizan integridad a nivel de BD sin CHECK; el catálogo `pg_type` sirve de documentación viva. |
+| Campos monetarios | `NUMERIC(12,2)` | Precisión decimal exacta; nunca `FLOAT` ni `DOUBLE` para importes. |
+| Timestamps | `TIMESTAMPTZ` | Todos los instantes se almacenan con zona horaria (UTC). Nunca `TIMESTAMP` sin zona. |
+| Borrado de usuarios | Soft-delete (`status=INACTIVE`) | Preserva historial de reservas y auditoría. Nunca borrado físico de usuarios. |
+| Borrado de reservas | Transición de estado (`status=CANCELLED`) | Las reservas nunca se borran; la trazabilidad es obligatoria. |
+| Campos sensibles cifrados | AES-256 a nivel aplicación | `redsys_secret_key`, `telegram_bot_token`, `smtp_password` en `system_config`. |
+
+---
+
+## 2. Diagrama ER
+
+```mermaid
+erDiagram
+    users {
+        bigserial id PK
+        varchar(50) login UK
+        varchar(255) password_hash
+        varchar(100) first_name
+        varchar(100) last_name
+        varchar(20) phone UK
+        varchar(150) email UK
+        user_status status
+        user_role role
+        varchar(50) telegram_chat_id UK
+        timestamptz telegram_linked_at
+        timestamptz registered_at
+        timestamptz updated_at
+    }
+
+    refresh_tokens {
+        bigserial id PK
+        bigint user_id FK
+        varchar(512) token_hash UK
+        timestamptz expires_at
+        boolean revoked
+        varchar(45) ip_address
+        timestamptz created_at
+    }
+
+    reservations {
+        uuid id PK
+        bigint owner_id FK
+        date reservation_date
+        time start_time
+        time end_time
+        integer duration_minutes
+        reservation_status status
+        reservation_channel channel
+        text notes
+        varchar(50) telegram_message_id
+        timestamptz created_at
+        timestamptz updated_at
+    }
+
+    participants {
+        bigserial id PK
+        uuid reservation_id FK
+        bigint user_id FK
+        varchar(100) external_name
+        varchar(20) external_phone
+        integer slot_position
+        boolean is_owner
+        reservation_channel joined_via
+        timestamptz joined_at
+    }
+
+    payments {
+        uuid id PK
+        uuid reservation_id FK
+        numeric(12-2) amount
+        payment_method method
+        payment_status status
+        varchar(100) redsys_order_id UK
+        varchar(500) payment_url
+        payment_gateway gateway
+        varchar(100) transaction_id
+        bigint registered_by_id FK
+        timestamptz paid_at
+        timestamptz created_at
+        timestamptz updated_at
+    }
+
+    otp_codes {
+        bigserial id PK
+        bigint user_id FK
+        varchar(6) code
+        otp_type type
+        timestamptz expires_at
+        boolean used
+        timestamptz created_at
+    }
+
+    audit_log {
+        bigserial id PK
+        bigint user_id FK
+        varchar(100) action
+        varchar(50) entity_type
+        varchar(36) entity_id
+        text details
+        varchar(45) ip_address
+        audit_channel channel
+        timestamptz created_at
+    }
+
+    notification_log {
+        bigserial id PK
+        bigint user_id FK
+        notification_type type
+        varchar(255) recipient
+        varchar(255) subject
+        text message
+        notification_status status
+        varchar(500) error_message
+        varchar(50) related_entity_type
+        varchar(36) related_entity_id
+        timestamptz sent_at
+        timestamptz created_at
+    }
+
+    system_config {
+        bigserial id PK
+        numeric(12-2) price_per_hour
+        integer cancellation_deadline_hours
+        integer max_participants
+        payment_gateway payment_gateway
+        varchar(50) redsys_merchant_code
+        varchar(5) redsys_terminal
+        varchar(255) redsys_secret_key
+        varchar(255) telegram_bot_token
+        varchar(50) telegram_group_id
+        varchar(100) smtp_host
+        integer smtp_port
+        varchar(100) smtp_user
+        varchar(255) smtp_password
+        bigint updated_by_id FK
+        timestamptz updated_at
+    }
+
+    users ||--o{ refresh_tokens : "tiene tokens activos"
+    users ||--o{ reservations : "es titular de"
+    users ||--o{ participants : "participa como"
+    users ||--o{ otp_codes : "recibe códigos"
+    users ||--o{ audit_log : "genera entradas"
+    users ||--o{ notification_log : "recibe notificaciones"
+    users ||--o| system_config : "actualizó por última vez"
+    reservations ||--|{ participants : "tiene entre 1 y 4"
+    reservations ||--|| payments : "tiene exactamente un pago"
+    payments }o--|| users : "registrado por admin"
+```
+
+---
+
+## 3. Especificación entidad por entidad
+
+### 3.1 `users`
+
+**Propósito:** Usuarios registrados en la plataforma. Centraliza la identidad, credenciales, rol, estado de la cuenta y vinculación con Telegram.
+
+**Tabla SQL:** `users`
+
+**Columnas:**
+
+| Nombre | Tipo SQL | Nullable | Default | Constraint | Descripción |
+|---|---|---|---|---|---|
+| `id` | `BIGSERIAL` | NO | autoincremento | PK | Clave primaria interna |
+| `login` | `VARCHAR(50)` | NO | — | UK, `chk_users_login_format` | Nombre de usuario para login. Solo alfanumérico + guión bajo. |
+| `password_hash` | `VARCHAR(255)` | NO | — | — | Hash BCrypt de la contraseña |
+| `first_name` | `VARCHAR(100)` | NO | — | — | Nombre de pila |
+| `last_name` | `VARCHAR(100)` | NO | — | — | Apellidos |
+| `phone` | `VARCHAR(20)` | NO | — | UK, `chk_users_phone_format` | Teléfono E.164. Identificador para mensajes directos Telegram. |
+| `email` | `VARCHAR(150)` | NO | — | UK | Correo electrónico |
+| `status` | `user_status` | NO | `'PENDING'` | — | Estado de la cuenta |
+| `role` | `user_role` | NO | `'USER'` | — | Rol en la plataforma |
+| `telegram_chat_id` | `VARCHAR(50)` | SÍ | NULL | UK | ID de chat de Telegram. Se rellena cuando el usuario inicia conversación con el bot. |
+| `telegram_linked_at` | `TIMESTAMPTZ` | SÍ | NULL | — | Instante en que se vinculó Telegram |
+| `registered_at` | `TIMESTAMPTZ` | NO | `now()` | — | Fecha de alta |
+| `updated_at` | `TIMESTAMPTZ` | NO | `now()` | — | Última modificación |
+
+**Enums usados:**
+
+```sql
+CREATE TYPE user_status AS ENUM ('PENDING', 'ACTIVE', 'INACTIVE');
+CREATE TYPE user_role   AS ENUM ('ADMIN', 'USER');
+```
+
+**PK:** `id BIGSERIAL`
+
+**FKs:** ninguna (es entidad raíz)
+
+**Índices:**
+
+| Nombre | Columnas | Tipo | Justificación |
+|---|---|---|---|
+| `users_pkey` | `id` | BTREE UNIQUE | PK automática |
+| `idx_users_login` | `login` | BTREE UNIQUE | Q8 — autenticación O(log n) |
+| `idx_users_phone` | `phone` | BTREE UNIQUE | Lookup por teléfono (OTP, Telegram DM) |
+| `idx_users_email` | `email` | BTREE UNIQUE | Reset de contraseña, unicidad |
+| `idx_users_telegram_chat_id` | `telegram_chat_id` | BTREE UNIQUE | Identificación de usuario entrante desde bot |
+| `idx_users_status_role` | `(status, role)` | BTREE | Listado admin filtrado por estado y rol |
+
+**Constraints de negocio:**
+
+```sql
+ALTER TABLE users ADD CONSTRAINT chk_users_login_format
+  CHECK (login ~ '^[a-zA-Z0-9_]{3,50}$');
+
+ALTER TABLE users ADD CONSTRAINT chk_users_phone_format
+  CHECK (phone ~ '^\+[1-9]\d{7,14}$');
+```
+
+**Campos de auditoría:** `registered_at`, `updated_at`. No hay `created_by` porque el usuario se crea a sí mismo (auto-registro) o por un admin (capturado en `audit_log`).
+
+**Soft-delete:** El borrado es lógico: `status = 'INACTIVE'`. Nunca `DELETE FROM users`.
+
+---
+
+### 3.2 `refresh_tokens`
+
+**Propósito:** Almacena los tokens JWT de refresco activos. Permite invalidar sesiones individuales en logout sin romper otras sesiones del mismo usuario.
+
+**Tabla SQL:** `refresh_tokens`
+
+**Columnas:**
+
+| Nombre | Tipo SQL | Nullable | Default | Constraint | Descripción |
+|---|---|---|---|---|---|
+| `id` | `BIGSERIAL` | NO | autoincremento | PK | Clave primaria |
+| `user_id` | `BIGINT` | NO | — | FK → `users(id)` ON DELETE CASCADE | Usuario propietario del token |
+| `token_hash` | `VARCHAR(512)` | NO | — | UK | SHA-256 del refresh token. Nunca se almacena el token en claro. |
+| `expires_at` | `TIMESTAMPTZ` | NO | — | — | Expiración del token (típicamente 30 días) |
+| `revoked` | `BOOLEAN` | NO | `false` | — | `true` tras logout o rotación |
+| `ip_address` | `VARCHAR(45)` | SÍ | NULL | — | IP de origen del login (IPv4/IPv6) |
+| `created_at` | `TIMESTAMPTZ` | NO | `now()` | — | Instante de emisión |
+
+**PK:** `id BIGSERIAL`
+
+**FKs:**
+
+| Columna | Referencia | ON DELETE | ON UPDATE |
+|---|---|---|---|
+| `user_id` | `users(id)` | CASCADE | NO ACTION |
+
+**Índices:**
+
+| Nombre | Columnas | Tipo | Justificación |
+|---|---|---|---|
+| `refresh_tokens_pkey` | `id` | BTREE UNIQUE | PK automática |
+| `idx_rt_token_hash` | `token_hash` | BTREE UNIQUE | Validación O(log n) del refresh token |
+| `idx_rt_user_active` | `(user_id, expires_at)` | BTREE parcial `WHERE revoked = false` | Listar tokens activos por usuario |
+| `idx_rt_cleanup` | `expires_at` | BTREE parcial `WHERE revoked = false` | Job nocturno de limpieza de tokens expirados |
+
+**Campos de auditoría:** No aplica. La tabla es de infraestructura de seguridad y se limpia automáticamente.
+
+---
+
+### 3.3 `reservations`
+
+**Propósito:** Reserva de la pista. Gestiona el ciclo de vida completo desde `PENDING_CONFIRMATION` hasta `COMPLETED` o `CANCELLED`, incluyendo el canal de creación y el mensaje publicado en Telegram.
+
+**Tabla SQL:** `reservations`
+
+**Columnas:**
+
+| Nombre | Tipo SQL | Nullable | Default | Constraint | Descripción |
+|---|---|---|---|---|---|
+| `id` | `UUID` | NO | `gen_random_uuid()` | PK | Identificador externo. UUID evita enumeración secuencial. |
+| `owner_id` | `BIGINT` | NO | — | FK → `users(id)` | Titular de la reserva y responsable del pago (RN-04) |
+| `reservation_date` | `DATE` | NO | — | — | Fecha de la reserva |
+| `start_time` | `TIME` | NO | — | `chk_res_start_minutes` | Hora de inicio (en punto o en media hora) |
+| `end_time` | `TIME` | NO | — | `chk_res_end_time` | Hora de fin = start_time + duration_minutes |
+| `duration_minutes` | `INTEGER` | NO | — | `chk_res_duration` | Duración en minutos: 60, 90, 120, 150 o 180 |
+| `status` | `reservation_status` | NO | `'PENDING_CONFIRMATION'` | — | Estado del ciclo de vida |
+| `channel` | `reservation_channel` | NO | — | — | Canal por el que se creó la reserva |
+| `notes` | `TEXT` | SÍ | NULL | — | Observaciones libres del titular |
+| `telegram_message_id` | `VARCHAR(50)` | SÍ | NULL | — | ID del mensaje publicado en el grupo de Telegram para poder editarlo al añadir participantes (US-020) |
+| `cancellation_reason` | `VARCHAR(255)` | SÍ | NULL | — | Motivo de cancelación si `status = 'CANCELLED'` |
+| `created_at` | `TIMESTAMPTZ` | NO | `now()` | — | Instante de creación |
+| `updated_at` | `TIMESTAMPTZ` | NO | `now()` | — | Última modificación |
+
+**Enums usados:**
+
+```sql
+CREATE TYPE reservation_status  AS ENUM ('PENDING_CONFIRMATION', 'CONFIRMED', 'CANCELLED', 'COMPLETED');
+CREATE TYPE reservation_channel AS ENUM ('WEB', 'TELEGRAM');
+```
+
+**PK:** `id UUID`
+
+**FKs:**
+
+| Columna | Referencia | ON DELETE | ON UPDATE |
+|---|---|---|---|
+| `owner_id` | `users(id)` | RESTRICT | NO ACTION |
+
+**Índices:**
+
+| Nombre | Columnas | Tipo | Justificación |
+|---|---|---|---|
+| `reservations_pkey` | `id` | BTREE UNIQUE | PK automática |
+| `idx_res_owner_id` | `owner_id` | BTREE | FK obligatorio; Q4 historial |
+| `idx_res_date_status` | `(reservation_date, status)` | BTREE parcial `WHERE status <> 'CANCELLED'` | Q1 disponibilidad, Q2 calendario |
+| `idx_res_date_start` | `(reservation_date, start_time)` | BTREE | Q2 ordenación semanal |
+| `idx_res_owner_date` | `(owner_id, reservation_date DESC)` | BTREE | Q4 historial de usuario |
+| `idx_res_owner_status` | `(owner_id, status)` | BTREE parcial `WHERE status IN ('PENDING_CONFIRMATION','CONFIRMED')` | Q5 reservas activas del usuario |
+| `excl_res_no_overlap` | `tsrange(date+start, date+end)` | GiST EXCLUSION parcial `WHERE status <> 'CANCELLED'` | **Barrera de seguridad anti-solapamiento a nivel BD** |
+
+**Constraints de negocio:**
+
+```sql
+-- Extensión necesaria para el exclusion constraint
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+
+ALTER TABLE reservations ADD CONSTRAINT chk_res_duration
+  CHECK (duration_minutes IN (60, 90, 120, 150, 180));
+
+ALTER TABLE reservations ADD CONSTRAINT chk_res_end_time
+  CHECK (end_time = (start_time + (duration_minutes || ' minutes')::INTERVAL));
+
+ALTER TABLE reservations ADD CONSTRAINT chk_res_start_minutes
+  CHECK (EXTRACT(MINUTE FROM start_time) IN (0, 30));
+
+ALTER TABLE reservations ADD CONSTRAINT excl_res_no_overlap
+  EXCLUDE USING gist (
+    reservation_date WITH =,
+    tsrange(
+      reservation_date + start_time,
+      reservation_date + end_time,
+      '[)'
+    ) WITH &&
+  )
+  WHERE (status <> 'CANCELLED');
+```
+
+**Campos de auditoría:** `created_at`, `updated_at`. El `owner_id` actúa como `created_by` implícito. Las transiciones de estado quedan registradas en `audit_log`.
+
+---
+
+### 3.4 `participants`
+
+**Propósito:** Jugadores asignados a una reserva. Admite tanto usuarios registrados (`user_id NOT NULL`) como jugadores externos sin cuenta (`user_id IS NULL`). Máximo 4 por reserva (RN-03).
+
+**Tabla SQL:** `participants`
+
+**Columnas:**
+
+| Nombre | Tipo SQL | Nullable | Default | Constraint | Descripción |
+|---|---|---|---|---|---|
+| `id` | `BIGSERIAL` | NO | autoincremento | PK | Clave primaria interna |
+| `reservation_id` | `UUID` | NO | — | FK → `reservations(id)` | Reserva a la que pertenece |
+| `user_id` | `BIGINT` | SÍ | NULL | FK → `users(id)` | Usuario registrado. NULL si es jugador externo. |
+| `external_name` | `VARCHAR(100)` | SÍ | NULL | — | Nombre del jugador externo |
+| `external_phone` | `VARCHAR(20)` | SÍ | NULL | `chk_part_phone_format` | Teléfono del jugador externo |
+| `slot_position` | `INTEGER` | NO | — | `chk_part_slot`, UK(reservation_id) | Posición en la reserva: 1 = titular, 2-4 = resto |
+| `is_owner` | `BOOLEAN` | NO | `false` | — | `true` solo para el titular de la reserva |
+| `joined_via` | `reservation_channel` | NO | — | — | Canal por el que se incorporó |
+| `joined_at` | `TIMESTAMPTZ` | NO | `now()` | — | Instante de incorporación |
+
+**PK:** `id BIGSERIAL`
+
+**FKs:**
+
+| Columna | Referencia | ON DELETE | ON UPDATE |
+|---|---|---|---|
+| `reservation_id` | `reservations(id)` | CASCADE | NO ACTION |
+| `user_id` | `users(id)` | SET NULL | NO ACTION |
+
+**Índices:**
+
+| Nombre | Columnas | Tipo | Justificación |
+|---|---|---|---|
+| `participants_pkey` | `id` | BTREE UNIQUE | PK automática |
+| `idx_part_reservation_id` | `reservation_id` | BTREE | FK obligatorio; Q2/Q3 JOIN con reservas |
+| `idx_part_user_id` | `user_id` | BTREE parcial `WHERE user_id IS NOT NULL` | FK obligatorio; participaciones de un usuario |
+| `idx_part_slot_unique` | `(reservation_id, slot_position)` | BTREE UNIQUE | Integridad: posición única por reserva |
+| `idx_part_user_reservation` | `(user_id, reservation_id)` | BTREE parcial `WHERE user_id IS NOT NULL` | Verificar si usuario ya está en reserva (CU-02 anti-duplicado) |
+
+**Constraints de negocio:**
+
+```sql
+ALTER TABLE participants ADD CONSTRAINT chk_part_slot
+  CHECK (slot_position BETWEEN 1 AND 4);
+
+-- Jugador externo XOR registrado: exactamente uno de los dos
+ALTER TABLE participants ADD CONSTRAINT chk_part_user_or_external
+  CHECK (
+    (user_id IS NOT NULL AND external_name IS NULL) OR
+    (user_id IS NULL     AND external_name IS NOT NULL)
+  );
+
+ALTER TABLE participants ADD CONSTRAINT chk_part_phone_format
+  CHECK (external_phone IS NULL OR external_phone ~ '^\+[1-9]\d{7,14}$');
+
+-- Solo un titular por reserva
+CREATE UNIQUE INDEX idx_part_one_owner
+  ON participants (reservation_id)
+  WHERE is_owner = true;
+```
+
+**Campos de auditoría:** `joined_at`. No hay `updated_at` porque los participantes no se modifican; se eliminan (en lógica de aplicación con estado). Las acciones se registran en `audit_log`.
+
+---
+
+### 3.5 `payments`
+
+**Propósito:** Transacción económica vinculada a cada reserva. Gestiona el ciclo de pago (online vía Redsys o en efectivo registrado por el admin). Una reserva tiene exactamente un registro de pago; el titular es el único responsable (RN-04, RN-12).
+
+**Tabla SQL:** `payments`
+
+**Columnas:**
+
+| Nombre | Tipo SQL | Nullable | Default | Constraint | Descripción |
+|---|---|---|---|---|---|
+| `id` | `UUID` | NO | `gen_random_uuid()` | PK | Identificador externo. UUID evita correlación con volumen de negocio. |
+| `reservation_id` | `UUID` | NO | — | FK → `reservations(id)`, UK | Una reserva tiene exactamente un pago |
+| `amount` | `NUMERIC(12,2)` | NO | — | `chk_pay_amount` | Importe congelado en el momento de crear la reserva (precio/hora × duración/60) |
+| `method` | `payment_method` | SÍ | NULL | — | Método elegido. NULL hasta que se inicia el pago. |
+| `status` | `payment_status` | NO | `'PENDING'` | — | Estado del ciclo de pago |
+| `redsys_order_id` | `VARCHAR(100)` | SÍ | NULL | UK | Referencia Redsys (Ds_Merchant_Order). Única por transacción. |
+| `payment_url` | `VARCHAR(500)` | SÍ | NULL | — | URL del TPV virtual Redsys generada para el pago online |
+| `gateway` | `payment_gateway` | SÍ | NULL | — | Pasarela usada |
+| `transaction_id` | `VARCHAR(100)` | SÍ | NULL | — | Referencia de la pasarela de pago (Ds_AuthorisationCode) |
+| `registered_by_id` | `BIGINT` | SÍ | NULL | FK → `users(id)` | Admin que registró el pago en efectivo |
+| `paid_at` | `TIMESTAMPTZ` | SÍ | NULL | — | Instante de confirmación del pago |
+| `created_at` | `TIMESTAMPTZ` | NO | `now()` | — | Instante de creación del registro |
+| `updated_at` | `TIMESTAMPTZ` | NO | `now()` | — | Última modificación |
+
+**Enums usados:**
+
+```sql
+CREATE TYPE payment_method  AS ENUM ('REDSYS', 'CASH');
+CREATE TYPE payment_status  AS ENUM ('PENDING', 'IN_PROGRESS', 'PAID', 'FAILED', 'CANCELLED', 'REFUNDED');
+CREATE TYPE payment_gateway AS ENUM ('REDSYS', 'STRIPE', 'PAYPAL');
+```
+
+**PK:** `id UUID`
+
+**FKs:**
+
+| Columna | Referencia | ON DELETE | ON UPDATE |
+|---|---|---|---|
+| `reservation_id` | `reservations(id)` | RESTRICT | NO ACTION |
+| `registered_by_id` | `users(id)` | SET NULL | NO ACTION |
+
+**Índices:**
+
+| Nombre | Columnas | Tipo | Justificación |
+|---|---|---|---|
+| `payments_pkey` | `id` | BTREE UNIQUE | PK automática |
+| `idx_pay_reservation_id` | `reservation_id` | BTREE UNIQUE | FK obligatorio + relación 1:1 |
+| `idx_pay_registered_by_id` | `registered_by_id` | BTREE parcial `WHERE registered_by_id IS NOT NULL` | FK obligatorio (efectivo) |
+| `idx_pay_status_paid_at` | `(status, paid_at)` | BTREE parcial `WHERE status = 'PAID'` | Q7 dashboard de ingresos por mes |
+| `idx_pay_redsys_order_id` | `redsys_order_id` | BTREE UNIQUE parcial `WHERE redsys_order_id IS NOT NULL` | Webhook Redsys: lookup por Ds_Merchant_Order |
+| `idx_pay_pending` | `(created_at)` | BTREE parcial `WHERE status = 'PENDING'` | Q5 pagos pendientes del admin |
+
+**Constraints de negocio:**
+
+```sql
+ALTER TABLE payments ADD CONSTRAINT chk_pay_amount
+  CHECK (amount > 0);
+
+-- Si el método es CASH, registered_by_id no puede ser NULL
+ALTER TABLE payments ADD CONSTRAINT chk_pay_cash_admin
+  CHECK (
+    method IS NULL OR method <> 'CASH' OR registered_by_id IS NOT NULL
+  );
+```
+
+**Campos de auditoría:** `created_at`, `updated_at`, `registered_by_id`. Todas las transiciones de estado quedan en `audit_log` con acción `PAYMENT_STATUS_CHANGED`.
+
+**Nota sobre el importe:** El campo `amount` congela el precio en el instante de creación de la reserva (`price_per_hour × duration_minutes / 60`). Cambios posteriores en `system_config.price_per_hour` no afectan a reservas ya existentes (US-024 riesgo técnico).
+
+---
+
+### 3.6 `otp_codes`
+
+**Propósito:** Códigos OTP de un solo uso generados para operaciones críticas: confirmar reserva, confirmar cancelación y resetear contraseña. TTL estricto de 10 minutos.
+
+**Tabla SQL:** `otp_codes`
+
+**Columnas:**
+
+| Nombre | Tipo SQL | Nullable | Default | Constraint | Descripción |
+|---|---|---|---|---|---|
+| `id` | `BIGSERIAL` | NO | autoincremento | PK | Clave primaria interna |
+| `user_id` | `BIGINT` | NO | — | FK → `users(id)` | Usuario al que pertenece el código |
+| `code` | `VARCHAR(6)` | NO | — | `chk_otp_format` | Código numérico de 6 dígitos |
+| `type` | `otp_type` | NO | — | — | Tipo de operación que confirma |
+| `expires_at` | `TIMESTAMPTZ` | NO | — | `chk_otp_expiry` | NOW() + 10 minutos |
+| `used` | `BOOLEAN` | NO | `false` | — | `true` tras validación. Impide reutilización. |
+| `created_at` | `TIMESTAMPTZ` | NO | `now()` | — | Instante de generación |
+
+**Enums usados:**
+
+```sql
+CREATE TYPE otp_type AS ENUM ('RESERVATION_CONFIRM', 'CANCELLATION_CONFIRM', 'PASSWORD_RESET');
+```
+
+**PK:** `id BIGSERIAL`
+
+**FKs:**
+
+| Columna | Referencia | ON DELETE | ON UPDATE |
+|---|---|---|---|
+| `user_id` | `users(id)` | CASCADE | NO ACTION |
+
+**Índices:**
+
+| Nombre | Columnas | Tipo | Justificación |
+|---|---|---|---|
+| `otp_codes_pkey` | `id` | BTREE UNIQUE | PK automática |
+| `idx_otp_user_id` | `user_id` | BTREE | FK obligatorio |
+| `idx_otp_active` | `(user_id, type, expires_at)` | BTREE parcial `WHERE used = false` | Q6 validación OTP activo < 0.5 ms |
+| `idx_otp_cleanup` | `expires_at` | BTREE parcial `WHERE used = false` | Job nocturno de limpieza |
+
+**Constraints de negocio:**
+
+```sql
+ALTER TABLE otp_codes ADD CONSTRAINT chk_otp_format
+  CHECK (code ~ '^\d{6}$');
+
+ALTER TABLE otp_codes ADD CONSTRAINT chk_otp_expiry
+  CHECK (expires_at > created_at);
+```
+
+**Campos de auditoría:** No se usan campos de auditoría en esta tabla. Los OTP usados se limpian periódicamente. El `audit_log` registra las validaciones.
+
+---
+
+### 3.7 `audit_log`
+
+**Propósito:** Registro inmutable de todas las acciones del sistema. Cada acción de usuario (crear reserva, pagar, cancelar, modificar configuración…) genera una entrada. **Nunca se borran filas**; la retención se gestiona por política (ver §8).
+
+**Tabla SQL:** `audit_log`
+
+**Columnas:**
+
+| Nombre | Tipo SQL | Nullable | Default | Constraint | Descripción |
+|---|---|---|---|---|---|
+| `id` | `BIGSERIAL` | NO | autoincremento | PK | Clave primaria interna |
+| `user_id` | `BIGINT` | SÍ | NULL | FK → `users(id)` | Usuario que ejecutó la acción. NULL para acciones del sistema/bot. |
+| `action` | `VARCHAR(100)` | NO | — | — | Código de acción: `RESERVATION_CREATED`, `PAYMENT_CONFIRMED`, `OTP_VALIDATED`, `USER_DEACTIVATED`… |
+| `entity_type` | `VARCHAR(50)` | NO | — | — | Entidad afectada: `RESERVATION`, `PAYMENT`, `USER`, `OTP`, `CONFIG` |
+| `entity_id` | `VARCHAR(36)` | SÍ | NULL | — | ID de la entidad afectada (UUID o BIGINT como texto) |
+| `details` | `TEXT` | SÍ | NULL | — | JSON con valores anteriores/nuevos u otro contexto |
+| `ip_address` | `VARCHAR(45)` | SÍ | NULL | — | IP del cliente (IPv4 o IPv6) |
+| `channel` | `audit_channel` | NO | — | — | Canal de origen |
+| `created_at` | `TIMESTAMPTZ` | NO | `now()` | — | **Inmutable**. Instante exacto de la acción. |
+
+**Enums usados:**
+
+```sql
+CREATE TYPE audit_channel AS ENUM ('WEB', 'TELEGRAM', 'SYSTEM');
+```
+
+**PK:** `id BIGSERIAL`
+
+**FKs:**
+
+| Columna | Referencia | ON DELETE | ON UPDATE |
+|---|---|---|---|
+| `user_id` | `users(id)` | SET NULL | NO ACTION |
+
+**Índices:**
+
+| Nombre | Columnas | Tipo | Justificación |
+|---|---|---|---|
+| `audit_log_pkey` | `id` | BTREE UNIQUE | PK automática |
+| `idx_audit_user_id` | `user_id` | BTREE | FK obligatorio |
+| `idx_audit_user_time` | `(user_id, created_at DESC)` | BTREE | Historial de acciones por usuario (admin panel) |
+| `idx_audit_entity` | `(entity_type, entity_id)` | BTREE | Trazabilidad completa de una entidad concreta |
+| `idx_audit_action_time` | `(action, created_at DESC)` | BTREE | Filtrado por tipo de acción en informes |
+
+**Campos de auditoría:** No aplica. Esta tabla ES el log de auditoría. `created_at` es inmutable.
+
+---
+
+### 3.8 `notification_log`
+
+**Propósito:** Registro de cada notificación enviada (email, Telegram directo, Telegram grupo). Permite detectar fallos de entrega, reintentos y trazar el historial de comunicaciones por usuario.
+
+**Tabla SQL:** `notification_log`
+
+**Columnas:**
+
+| Nombre | Tipo SQL | Nullable | Default | Constraint | Descripción |
+|---|---|---|---|---|---|
+| `id` | `BIGSERIAL` | NO | autoincremento | PK | Clave primaria interna |
+| `user_id` | `BIGINT` | SÍ | NULL | FK → `users(id)` | Destinatario registrado. NULL para notificaciones al grupo. |
+| `type` | `notification_type` | NO | — | — | Canal de envío |
+| `recipient` | `VARCHAR(255)` | NO | — | — | Email, teléfono o telegram_group_id |
+| `subject` | `VARCHAR(255)` | SÍ | NULL | — | Asunto del email. NULL para Telegram. |
+| `message` | `TEXT` | NO | — | — | Contenido completo del mensaje enviado |
+| `status` | `notification_status` | NO | `'PENDING'` | — | Estado del envío |
+| `error_message` | `VARCHAR(500)` | SÍ | NULL | — | Detalle del error si `status = 'FAILED'` |
+| `related_entity_type` | `VARCHAR(50)` | SÍ | NULL | — | Entidad relacionada: `RESERVATION`, `PAYMENT`, `USER` |
+| `related_entity_id` | `VARCHAR(36)` | SÍ | NULL | — | ID de la entidad relacionada |
+| `sent_at` | `TIMESTAMPTZ` | SÍ | NULL | — | Instante de entrega confirmada |
+| `created_at` | `TIMESTAMPTZ` | NO | `now()` | — | Instante de creación del registro |
+
+**Enums usados:**
+
+```sql
+CREATE TYPE notification_type   AS ENUM ('EMAIL', 'TELEGRAM_DIRECT', 'TELEGRAM_GROUP');
+CREATE TYPE notification_status AS ENUM ('PENDING', 'SENT', 'FAILED');
+```
+
+**PK:** `id BIGSERIAL`
+
+**FKs:**
+
+| Columna | Referencia | ON DELETE | ON UPDATE |
+|---|---|---|---|
+| `user_id` | `users(id)` | SET NULL | NO ACTION |
+
+**Índices:**
+
+| Nombre | Columnas | Tipo | Justificación |
+|---|---|---|---|
+| `notification_log_pkey` | `id` | BTREE UNIQUE | PK automática |
+| `idx_notif_user_id` | `user_id` | BTREE | FK obligatorio |
+| `idx_notif_user_time` | `(user_id, created_at DESC)` | BTREE | Historial de notificaciones por usuario |
+| `idx_notif_failed` | `status` | BTREE parcial `WHERE status = 'FAILED'` | Detección y reintento de fallos de envío |
+| `idx_notif_entity` | `(related_entity_type, related_entity_id)` | BTREE | Trazabilidad de notificaciones por entidad |
+
+**Campos de auditoría:** `created_at`. No hay `updated_at` porque las entradas son casi inmutables; solo `status` y `sent_at` se actualizan en el job de reintento.
+
+---
+
+### 3.9 `system_config`
+
+**Propósito:** Configuración global del club. Singleton estricto (siempre `id = 1`). Contiene precio, políticas de cancelación, credenciales de integraciones externas (cifradas a nivel aplicación) y configuración de Telegram y SMTP.
+
+**Tabla SQL:** `system_config`
+
+**Columnas:**
+
+| Nombre | Tipo SQL | Nullable | Default | Constraint | Descripción |
+|---|---|---|---|---|---|
+| `id` | `BIGSERIAL` | NO | — | PK, `chk_cfg_singleton` | Siempre `1`. El CHECK garantiza el singleton. |
+| `price_per_hour` | `NUMERIC(12,2)` | NO | — | `chk_cfg_price` | Precio por hora en EUR |
+| `cancellation_deadline_hours` | `INTEGER` | NO | `2` | `chk_cfg_deadline` | Horas mínimas de antelación para cancelar sin penalización |
+| `max_participants` | `INTEGER` | NO | `4` | `chk_cfg_max_part` | Máximo de jugadores por reserva (actualmente 4, RN-03) |
+| `payment_gateway` | `payment_gateway` | NO | `'REDSYS'` | — | Pasarela de pago activa |
+| `redsys_merchant_code` | `VARCHAR(50)` | SÍ | NULL | — | Código de comercio Redsys |
+| `redsys_terminal` | `VARCHAR(5)` | SÍ | NULL | — | Número de terminal Redsys |
+| `redsys_secret_key` | `VARCHAR(255)` | SÍ | NULL | — | Clave HMAC SHA-256 Redsys. **Cifrada AES-256 a nivel aplicación.** |
+| `telegram_bot_token` | `VARCHAR(255)` | SÍ | NULL | — | Token del bot de Telegram. **Cifrado AES-256 a nivel aplicación.** |
+| `telegram_group_id` | `VARCHAR(50)` | SÍ | NULL | — | ID del grupo de Telegram de la comunidad |
+| `smtp_host` | `VARCHAR(100)` | SÍ | NULL | — | Servidor SMTP |
+| `smtp_port` | `INTEGER` | SÍ | NULL | `chk_cfg_smtp_port` | Puerto SMTP (ej. 587) |
+| `smtp_user` | `VARCHAR(100)` | SÍ | NULL | — | Usuario SMTP |
+| `smtp_password` | `VARCHAR(255)` | SÍ | NULL | — | Contraseña SMTP. **Cifrada AES-256 a nivel aplicación.** |
+| `updated_by_id` | `BIGINT` | SÍ | NULL | FK → `users(id)` | Admin que realizó el último cambio |
+| `updated_at` | `TIMESTAMPTZ` | NO | `now()` | — | Última modificación |
+
+**PK:** `id BIGSERIAL`
+
+**FKs:**
+
+| Columna | Referencia | ON DELETE | ON UPDATE |
+|---|---|---|---|
+| `updated_by_id` | `users(id)` | SET NULL | NO ACTION |
+
+**Índices:**
+
+| Nombre | Columnas | Tipo | Justificación |
+|---|---|---|---|
+| `system_config_pkey` | `id` | BTREE UNIQUE | PK automática |
+| `idx_cfg_updated_by_id` | `updated_by_id` | BTREE | FK obligatorio |
+
+**Constraints de negocio:**
+
+```sql
+ALTER TABLE system_config ADD CONSTRAINT chk_cfg_singleton
+  CHECK (id = 1);
+
+ALTER TABLE system_config ADD CONSTRAINT chk_cfg_price
+  CHECK (price_per_hour > 0);
+
+ALTER TABLE system_config ADD CONSTRAINT chk_cfg_deadline
+  CHECK (cancellation_deadline_hours >= 0);
+
+ALTER TABLE system_config ADD CONSTRAINT chk_cfg_max_part
+  CHECK (max_participants BETWEEN 1 AND 4);
+
+ALTER TABLE system_config ADD CONSTRAINT chk_cfg_smtp_port
+  CHECK (smtp_port IS NULL OR smtp_port BETWEEN 1 AND 65535);
+```
+
+**Campos de auditoría:** `updated_at`, `updated_by_id`. Los cambios de configuración también se registran en `audit_log` con `entity_type='CONFIG'`.
+
+**Nota sobre campos sensibles:** `redsys_secret_key`, `telegram_bot_token` y `smtp_password` se cifran mediante AES-256 (clave derivada de una variable de entorno `APP_ENCRYPTION_KEY`) antes de persistirse. El `SystemConfigDTO` cacheado en memoria ya tiene los valores descifrados. Esto es aceptable en un despliegue On-Premise de instancia única.
+
+---
+
+## 4. Relaciones y reglas de integridad
+
+### 4.1 Relaciones principales
+
+| Relación | Cardinalidad | Descripción |
+|---|---|---|
+| `users` → `reservations` | 1 : N | Un usuario puede ser titular de múltiples reservas. FK `owner_id`. |
+| `users` → `participants` | 1 : N (opcional) | Un usuario registrado puede participar en múltiples reservas como jugador. FK `user_id` nullable. |
+| `reservations` → `participants` | 1 : N (1..4) | Una reserva tiene entre 1 y 4 participantes. Exactamente uno tiene `is_owner=true`. |
+| `reservations` → `payments` | 1 : 1 | Cada reserva tiene exactamente un registro de pago creado al mismo tiempo. FK UNIQUE. |
+| `users` → `payments` | 1 : N (opcional) | Un admin puede registrar múltiples pagos en efectivo. FK `registered_by_id` nullable. |
+| `users` → `refresh_tokens` | 1 : N | Un usuario puede tener múltiples tokens activos (distintos dispositivos). ON DELETE CASCADE. |
+| `users` → `otp_codes` | 1 : N | Un usuario puede tener múltiples OTP activos de distintos tipos. ON DELETE CASCADE. |
+| `users` → `audit_log` | 1 : N (opcional) | Un usuario genera múltiples entradas. FK nullable (acciones del sistema). |
+| `users` → `notification_log` | 1 : N (opcional) | Un usuario puede recibir múltiples notificaciones. FK nullable (notificaciones al grupo). |
+| `users` → `system_config` | 1 : 0..1 | El admin que actualizó por última vez la configuración. |
+
+### 4.2 Creación atómica de reserva + pago
+
+Al crear una reserva (`POST /api/reservas`), la capa `Application` realiza en una única transacción `@Transactional`:
+
+1. `INSERT INTO reservations …` → obtiene UUID
+2. `INSERT INTO payments (reservation_id, amount, status='PENDING') …` → crea el registro de pago inmediatamente
+3. `INSERT INTO participants (reservation_id, user_id, slot_position=1, is_owner=true) …` → añade al titular
+
+Si cualquiera de los tres pasos falla, la transacción se revierte completa. No puede existir una reserva sin su registro de pago asociado.
+
+### 4.3 Anti-solapamiento: doble barrera
+
+| Barrera | Mecanismo | Nivel |
+|---|---|---|
+| **Capa Application** | `SELECT FROM reservations WHERE … FOR UPDATE` antes del INSERT | Aplicación |
+| **Capa BD** | `EXCLUDE USING gist (tsrange …) WHERE status <> 'CANCELLED'` | Base de datos |
+
+La barrera de BD es la definitiva: aunque hubiera un bug en Application o acceso directo a la BD, el exclusion constraint rechaza solapamientos con un error de integridad.
+
+### 4.4 Congelación del importe
+
+El campo `payments.amount` se calcula y persiste en el momento de crear la reserva:
+
+```
+amount = system_config.price_per_hour × (reservations.duration_minutes / 60.0)
+```
+
+Cambios posteriores en `system_config.price_per_hour` **no** afectan reservas ya creadas. Esto garantiza que el titular paga el precio vigente en el momento de la reserva (US-024 riesgo técnico).
+
+### 4.5 Ciclo de vida de estados
+
+**`reservations.status`:**
+
+```
+PENDING_CONFIRMATION → CONFIRMED → COMPLETED
+                    ↘               ↗
+                      CANCELLED ←─
+```
+
+- `PENDING_CONFIRMATION`: recién creada (web) o pendiente de OTP (Telegram)
+- `CONFIRMED`: OTP validado o creada directamente desde web sin OTP
+- `COMPLETED`: la pista ya se jugó (transición automática o por admin)
+- `CANCELLED`: cancelada por el titular o el admin
+
+**`payments.status`:**
+
+```
+PENDING → IN_PROGRESS → PAID
+       ↘              ↗
+         FAILED
+       ↘
+         CANCELLED
+PAID → REFUNDED (solo si admin revierte)
+```
+
+### 4.6 Soft-delete y datos históricos
+
+| Entidad | Borrado | Razón |
+|---|---|---|
+| `users` | `status = 'INACTIVE'` | Preservar historial de reservas, auditoría y RGPD (retención) |
+| `reservations` | `status = 'CANCELLED'` | Nunca se borra una reserva; trazabilidad completa |
+| `payments` | Sin borrado. Estados: `CANCELLED`/`REFUNDED` | Trazabilidad fiscal obligatoria |
+| `participants` | Eliminación física permitida solo si la reserva está `CANCELLED` | Excepción controlada |
+| `otp_codes` | Limpieza periódica de `used=true` o `expires_at < NOW()-7d` | Datos técnicos sin valor histórico |
+| `refresh_tokens` | ON DELETE CASCADE o limpieza de `revoked=true` | Infraestructura de seguridad |
+| `audit_log` | Nunca. Retención por política (ver §8) | Inmutable por definición |
+| `notification_log` | Purga tras 2 años | Datos operativos de rotación alta |
+
+---
+
+## 5. Estrategia de migraciones (Flyway)
+
+### 5.1 Convención de nombres
+
+```
+V<n>__<descripcion_snake_case>.sql
+```
+
+Ejemplos:
+
+```
+V1__create_enum_types.sql
+V2__create_users_table.sql
+V3__create_refresh_tokens_table.sql
+V4__create_reservations_table.sql
+V5__create_participants_table.sql
+V6__create_payments_table.sql
+V7__create_otp_codes_table.sql
+V8__create_audit_log_table.sql
+V9__create_notification_log_table.sql
+V10__create_system_config_table.sql
+V11__create_all_indexes.sql
+V12__seed_initial_data.sql
+```
+
+El orden importa: los enums deben existir antes de las tablas que los usan, y las tablas padre antes de las hijo (FKs).
+
+### 5.2 Reglas zero-downtime
+
+| Regla | Descripción | Aplicable a |
+|---|---|---|
+| **Columna nullable primero** | Al añadir una columna a una tabla con datos, declararla `NULLABLE` primero. Luego backfill. Luego `ALTER ... SET NOT NULL`. | Toda `ALTER TABLE ADD COLUMN` |
+| **Índice CONCURRENTLY** | Crear índices nuevos con `CREATE INDEX CONCURRENTLY` para no bloquear lecturas. Nunca en una transacción (Flyway usa `nonTransactional` para estas migraciones). | `CREATE INDEX` en tablas con datos |
+| **DROP después de validar** | No eliminar columnas o tablas en la misma migración que deja de usarlas. Separar en: (1) deprecar en código, (2) deploy, (3) migración de borrado. | `DROP COLUMN`, `DROP TABLE` |
+| **FK diferida** | Al añadir FKs a tablas con datos existentes, usar `NOT VALID` primero y `VALIDATE CONSTRAINT` después para evitar full table scan bloqueante. | `ADD CONSTRAINT FOREIGN KEY` |
+
+### 5.3 Política de migraciones reversibles
+
+Flyway no soporta rollback automático. La estrategia es:
+
+1. **Migraciones aditivas:** siempre reversibles manualmente (DROP COLUMN, DROP TABLE).
+2. **Migraciones destructivas** (rename, type change, DROP): requieren una migración de rollback manual preparada y aprobada antes de ejecutar la original.
+3. **Snapshots:** `pg_dump` antes de cualquier migración en producción. Los backups diarios son la red de seguridad principal.
+
+---
+
+## 6. Datos seed
+
+Los datos seed se aplican en `V12__seed_initial_data.sql` y son los mínimos para que la aplicación arranque en DES/SIT.
+
+```sql
+-- ─────────────────────────────────────────────────────────────────────────
+--  V12__seed_initial_data.sql
+-- ─────────────────────────────────────────────────────────────────────────
+
+-- Enum values están ya creados (V1). Aquí solo insertamos filas.
+
+-- 1. Usuario administrador inicial
+--    Contraseña: "Admin1234!" → hash BCrypt generado por la aplicación en startup
+--    (En producción, cambiar en el primer acceso)
+INSERT INTO users (login, password_hash, first_name, last_name, phone, email, status, role, registered_at, updated_at)
+VALUES (
+  'admin',
+  '$2a$12$PLACEHOLDER_BCRYPT_HASH_GENERATED_AT_BUILD_TIME',  -- ver scripts/gen-admin-hash.sh
+  'Administrador',
+  'Club',
+  '+34600000000',
+  'admin@padelpro.local',
+  'ACTIVE',
+  'ADMIN',
+  now(),
+  now()
+);
+
+-- 2. Configuración inicial del sistema (singleton id=1)
+--    Todos los campos sensibles en NULL hasta que el admin los configure desde la UI
+INSERT INTO system_config (
+  id,
+  price_per_hour,
+  cancellation_deadline_hours,
+  max_participants,
+  payment_gateway,
+  updated_at
+) VALUES (
+  1,
+  15.00,      -- 15 €/h como valor de ejemplo; el admin debe ajustarlo
+  2,          -- 2 horas de antelación mínima para cancelar
+  4,          -- máximo 4 jugadores por pista
+  'REDSYS',
+  now()
+);
+```
+
+**Notas de seed:**
+
+| Campo | Valor DES | Acción en producción |
+|---|---|---|
+| `admin.password_hash` | Hash de `Admin1234!` generado por script | Cambiar en primer acceso |
+| `system_config.price_per_hour` | `15.00` | Ajustar en panel de admin |
+| `system_config.redsys_*` | NULL | Configurar tras contrato con banco |
+| `system_config.telegram_bot_token` | NULL | Configurar con token del bot real |
+| `system_config.smtp_*` | NULL | Configurar con credenciales SMTP reales |
+
+---
+
+## 7. Consideraciones de rendimiento
+
+### 7.1 Consultas de alto volumen
+
+| ID | Consulta | Frecuencia | Índices activos | Tiempo esperado |
+|---|---|---|---|---|
+| Q1 | Comprobación de disponibilidad (anti-solapamiento) | Cada intento de reserva | `idx_res_date_status` + `excl_res_no_overlap` | < 1 ms |
+| Q2 | Calendario semanal (dashboard) | Cada carga de página | `idx_res_date_status`, `idx_res_date_start`, `idx_part_reservation_id` | < 5 ms |
+| Q3 | Reservas incompletas (unirse a partida) | Frecuente | `idx_res_date_status`, `idx_part_reservation_id` | < 5 ms |
+| Q4 | Historial de reservas del usuario | Bajo demanda | `idx_res_owner_date`, `idx_pay_reservation_id` | < 10 ms |
+| Q5 | Pagos pendientes del usuario | Badge en UI | `idx_res_owner_status`, `idx_pay_reservation_id` | < 2 ms |
+| Q6 | Validación de OTP activo | Cada operación crítica | `idx_otp_active` | < 0.5 ms |
+| Q7 | Dashboard de ingresos por mes (admin) | Bajo demanda | `idx_pay_status_paid_at` | < 20 ms |
+| Q8 | Autenticación (lookup por login) | Cada login | `idx_users_login` (UNIQUE) | < 1 ms |
+
+### 7.2 Riesgos N+1 conocidos y mitigación
+
+| Riesgo | Contexto | Mitigación recomendada |
+|---|---|---|
+| `reservations` + `participants` | Al cargar el calendario semanal (Q2), cada reserva puede disparar N queries para cargar sus participantes | Usar `@EntityGraph(attributePaths = {"participants"})` o `JOIN FETCH p.participants` en la query de dominio |
+| `reservations` + `payments` | Al listar reservas del usuario con estado de pago | Incluir JOIN FETCH con `payments` en la misma query; la relación 1:1 garantiza sin duplicados |
+| `participants` + `users` | Al mostrar nombres de participantes registrados | JOIN FETCH en `ReservaJpaAdapter.findWithParticipantsAndUsers()` |
+| `audit_log` paginado | El panel admin puede cargar miles de filas | Paginación obligatoria (`LIMIT/OFFSET` o keyset con `id`); nunca `findAll()` |
+
+**Regla general:** ningún método de repositorio devuelve colecciones sin límite explícito. Todos los métodos que puedan devolver más de 100 filas deben aceptar `Pageable`.
+
+### 7.3 Estrategia de caché (Caffeine, in-JVM)
+
+| Caché | Clave | TTL | Invalidación explícita |
+|---|---|---|---|
+| `system-config` | `'singleton'` | Sin expiración | `@CacheEvict` en `actualizarConfig()` |
+| `available-slots` | `fecha (LocalDate)` | 30 s | `@CacheEvict` en `crearReserva()` y `cancelarReserva()` |
+| `weekly-calendar` | semana (inicio LocalDate) | 30 s | `@CacheEvict` en `crearReserva()` y `cancelarReserva()` |
+| `user-profile` | `userId (Long)` | 5 min | `@CacheEvict` en `actualizarPerfil()` y cambio de estado admin |
+
+Los OTP, pagos en curso y el log de auditoría **no se cachean** (datos de seguridad, webhooks en tiempo real, solo escritura).
+
+---
+
+## 8. Cumplimiento normativo (RGPD)
+
+### 8.1 Campos sujetos a RGPD
+
+| Tabla | Campo | Categoría | Base legal |
+|---|---|---|---|
+| `users` | `first_name`, `last_name` | Dato personal identificativo | Ejecución de contrato (reservas) |
+| `users` | `phone` | Dato de contacto | Ejecución de contrato + interés legítimo (OTP) |
+| `users` | `email` | Dato de contacto | Ejecución de contrato + interés legítimo (notificaciones) |
+| `users` | `telegram_chat_id` | Identificador de servicio de mensajería | Consentimiento (vinculación voluntaria) |
+| `users` | `password_hash` | Credencial de acceso | Ejecución de contrato |
+| `participants` | `external_name`, `external_phone` | Dato personal de tercero (jugador casual) | Interés legítimo mínimo (gestión de la partida) |
+| `audit_log` | `ip_address` | Dato de red identificativo | Interés legítimo (seguridad) |
+| `notification_log` | `recipient`, `message` | Dato de comunicación | Ejecución de contrato |
+| `system_config` | `smtp_password`, `redsys_secret_key`, `telegram_bot_token` | Credencial de sistema (no personal) | — |
+
+### 8.2 Política de retención por tabla
+
+| Tabla | Retención | Estrategia |
+|---|---|---|
+| `users` | Indefinido mientras la cuenta exista. Tras inactivación, 5 años. | Soft-delete; purga física tras 5 años de inactividad. |
+| `reservations` | 5 años (obligación fiscal) | Sin borrado. Archivado opcional tras 5 años. |
+| `payments` | 5 años (obligación fiscal / AEAT) | Nunca se borran. |
+| `participants` | Vinculado a la reserva (5 años) | ON DELETE CASCADE de reserva solo si permitido. |
+| `audit_log` | 2 años | Purga anual por job programado. Partición por año recomendada si > 500k filas. |
+| `notification_log` | 2 años | Purga anual por job programado. |
+| `otp_codes` | 7 días tras expiración | Job nocturno: `DELETE WHERE expires_at < now() - INTERVAL '7 days'`. |
+| `refresh_tokens` | 30 días (TTL del token) + 7 días de gracia | Job nocturno: `DELETE WHERE expires_at < now() - INTERVAL '7 days'`. |
+
+### 8.3 Estrategia de borrado y anonimización
+
+Al ejercer el **derecho al olvido** (Art. 17 RGPD) sobre un usuario:
+
+1. **Anonimizar** en `users`: sobrescribir `first_name='ANONIMIZADO'`, `last_name='ANONIMIZADO'`, `phone=NULL`, `email='deleted_{id}@padelpro.invalid'`, `telegram_chat_id=NULL`, `telegram_linked_at=NULL`.
+2. **Anonimizar** en `participants`: sobrescribir `external_name='ANONIMIZADO'`, `external_phone=NULL` donde `user_id = {id}`.
+3. **No tocar** `reservations`, `payments`, `audit_log` — la trazabilidad fiscal y de seguridad prevalece sobre el derecho al olvido para registros contables (Art. 17.3.b RGPD).
+4. **Registrar** la anonimización en `audit_log` con `action='USER_ANONYMIZED'`.
+5. **Revocar** todos los `refresh_tokens` del usuario (`revoked=true`).
+6. **Invalidar** todos los `otp_codes` activos (`used=true`).
+
+---
+
+## 9. Pendiente / abierto
+
+Las siguientes decisiones de modelado no han podido cerrarse con la información disponible y requieren confirmación:
+
+| # | Decisión abierta | Impacto | Acción requerida |
+|---|---|---|---|
+| P1 | **`users.telegram_chat_id`**: ¿se rellena en el momento del registro (si el admin ya tiene el chat ID) o solo cuando el usuario inicia chat con el bot? | Determina si el campo puede ser `NOT NULL` o debe mantenerse nullable. | Confirmar el flujo de onboarding del bot (US-004). |
+| P2 | **Confirmación OTP en reservas web**: el API spec (`POST /api/reservas`) indica que se envía OTP de tipo `RESERVATION_CONFIRM`, pero el flujo web descrito en CU-01 no requiere OTP (solo el flujo de Telegram lo necesita). ¿Es el OTP obligatorio también en web? | Si no es obligatorio en web, el estado inicial de la reserva sería `CONFIRMED` directamente, no `PENDING_CONFIRMATION`. | Validar la regla de negocio RN-07 para el canal WEB. |
+| P3 | **`participants` y derechos RGPD de jugadores externos**: `external_name`/`external_phone` son datos personales de terceros que no han firmado ningún consentimiento explícito. | Podría requerirse una política de retención más corta para estos campos (ej. anonimizar tras 1 año). | Revisar con asesoría legal. |
+| P4 | **Configuración de horario de apertura**: el sistema no almacena en ninguna tabla el horario de apertura del club (ej. 08:00–22:00). Actualmente no hay restricción en BD sobre `start_time`. | Si se añade, `system_config` necesita columnas `opening_time TIME` y `closing_time TIME`, o una tabla de configuración de franja horaria. | Confirmar si los horarios son un requisito v1.0 o v2. |
+| P5 | **`payments` por participante vs. por reserva**: la regla de negocio (RN-04/RN-12) es clara (1 pago por reserva, a cargo del titular), pero el endpoint `POST /api/admin/pagos/{reservaId}/efectivo` retorna `pagosActualizados: 3`. ¿Se crean múltiples registros de pago o se actualiza solo el estado de los `participants`? El modelo actual asume 1:1 reserva:pago. | Si se confirma que son pagos por participante, la estructura de `payments` cambia a 1:N con `participants`. | Confirmar con el dueño del producto. |

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,2374 @@
+openapi: 3.1.0
+
+info:
+  title: PadelPro API
+  version: 0.1.0
+  description: |
+    API REST para el sistema de gestión de reservas de pádel PadelPro.
+    Sistema On-Premise para instalaciones pequeñas (v1.0).
+
+    ### Autenticación
+    Se usa JWT HS256 con doble token (access + refresh). El access token dura 15 minutos.
+    El refresh token dura 7 días y se almacena en cookie httpOnly.
+
+    ### RBAC
+    - `ADMIN`: acceso total, incluidos endpoints bajo `/api/admin/`.
+    - `USER`: acceso a sus propios recursos (reservas, pagos, perfil).
+    - Endpoints públicos: no requieren autenticación (marcados con `security: []`).
+  contact:
+    name: orquestadoria
+    url: https://github.com/lcasadov/PadelPro
+  license:
+    name: Proprietary
+
+servers:
+  - url: http://localhost:8080/api
+    description: "Entorno de desarrollo local"
+  - url: https://pre.padelpro.local/api
+    description: "Entorno de preproducción"
+  - url: https://padelpro.local/api
+    description: "Entorno de producción"
+
+security:
+  - bearerAuth: []
+
+tags:
+  - name: Autenticación
+    description: Login, registro, refresh de token y gestión de contraseña
+  - name: Usuarios
+    description: Perfil del usuario autenticado y gestión administrativa de cuentas
+  - name: Reservas
+    description: Disponibilidad, creación, consulta y cancelación de reservas
+  - name: Pagos
+    description: Inicio de pago online (Redsys) y consulta de historial de pagos
+  - name: OTP
+    description: Verificación de códigos de un solo uso para operaciones críticas
+  - name: Sistema
+    description: Configuración global del club (singleton, solo ADMIN)
+
+# ---------------------------------------------------------------------------
+# Webhooks (server-to-server, no JWT)
+# ---------------------------------------------------------------------------
+webhooks:
+  redsysNotification:
+    post:
+      tags:
+        - Pagos
+      summary: Notificación de pago Redsys
+      description: |
+        Redsys llama a este endpoint cuando se completa o rechaza una transacción.
+        Validado mediante HMAC SHA-256 (no JWT). La ruta real es `POST /api/pagos/webhook`.
+        Excluida de la especificación pública — solo accesible desde las IPs de Redsys.
+      security:
+        - redsysWebhookSecret: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RedsysWebhookPayload'
+      responses:
+        '200':
+          description: Notificación procesada. Redsys espera siempre 200.
+
+  telegramUpdate:
+    post:
+      tags:
+        - Sistema
+      summary: Update de Telegram Bot API
+      description: |
+        Telegram envía los mensajes del grupo y del chat personal del bot a este endpoint.
+        Validado mediante header `X-Telegram-Bot-Api-Secret-Token`. No usa JWT.
+        La ruta real es `POST /api/bot/telegram`.
+      security:
+        - telegramWebhookSecret: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              description: Objeto TelegramUpdate de la Bot API
+              additionalProperties: true
+      responses:
+        '200':
+          description: Update recibido y procesado.
+        '403':
+          description: Secret token inválido.
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+paths:
+
+  # ─── Autenticación ────────────────────────────────────────────────────────
+
+  /auth/login:
+    post:
+      tags: [Autenticación]
+      operationId: login
+      summary: Iniciar sesión
+      description: |
+        Autentica un usuario con login y contraseña. Devuelve un access token JWT (15 min)
+        y establece el refresh token en una cookie httpOnly (7 días).
+        Si el usuario está en estado PENDING o INACTIVE, devuelve 403.
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginRequest'
+            examples:
+              ejemplo:
+                summary: Login de usuario estándar
+                value:
+                  login: "jdoe"
+                  password: "SecureP4ss!"
+      responses:
+        '200':
+          description: Autenticación correcta
+          headers:
+            Set-Cookie:
+              description: Cookie httpOnly con el refresh token
+              schema:
+                type: string
+                example: "refresh_token=dGhpcy...; HttpOnly; Secure; SameSite=Strict; Path=/api/auth/refresh; Max-Age=604800"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoginResponse'
+              examples:
+                ejemplo:
+                  summary: Respuesta de login exitoso
+                  value:
+                    accessToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                    refreshToken: "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4..."
+                    expiresIn: 900
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /auth/register:
+    post:
+      tags: [Autenticación]
+      operationId: register
+      summary: Auto-registro de usuario
+      description: |
+        Registra un nuevo usuario. La cuenta queda en estado PENDING hasta que un
+        administrador la apruebe con `PATCH /api/admin/usuarios/{id}/aprobar`.
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterRequest'
+      responses:
+        '201':
+          description: Usuario registrado correctamente
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UsuarioResponse'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '409':
+          $ref: '#/components/responses/Conflict'
+
+  /auth/refresh:
+    post:
+      tags: [Autenticación]
+      operationId: refreshToken
+      summary: Renovar access token
+      description: |
+        Obtiene un nuevo access token usando el refresh token almacenado en la cookie httpOnly,
+        o pasándolo explícitamente en el cuerpo. Devuelve nuevos tokens.
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RefreshRequest'
+      responses:
+        '200':
+          description: Tokens renovados correctamente
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoginResponse'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /auth/logout:
+    post:
+      tags: [Autenticación]
+      operationId: logout
+      summary: Cerrar sesión
+      description: Invalida el refresh token del usuario autenticado. El access token expira naturalmente en ≤15 min.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LogoutRequest'
+      responses:
+        '204':
+          description: Sesión cerrada correctamente
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /auth/password/solicitar-reset:
+    post:
+      tags: [Autenticación]
+      operationId: solicitarResetPassword
+      summary: Solicitar restablecimiento de contraseña
+      description: |
+        Inicia el flujo de restablecimiento de contraseña. Envía un OTP de tipo PASSWORD_RESET
+        al Telegram personal del usuario asociado al email. La respuesta es siempre 200 por seguridad
+        (no revela si el email existe en el sistema).
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SolicitarResetRequest'
+      responses:
+        '200':
+          description: Solicitud procesada (respuesta neutral)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessageResponse'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+
+  /auth/password/confirmar-reset:
+    post:
+      tags: [Autenticación]
+      operationId: confirmarResetPassword
+      summary: Confirmar restablecimiento de contraseña
+      description: |
+        Confirma el restablecimiento de contraseña usando el OTP recibido por Telegram.
+        El OTP debe ser de tipo PASSWORD_RESET, no haber sido usado y no haber expirado (TTL 10 min).
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConfirmarResetRequest'
+      responses:
+        '200':
+          description: Contraseña restablecida correctamente
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessageResponse'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '422':
+          description: OTP incorrecto, expirado o ya utilizado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  # ─── Usuarios — perfil propio ──────────────────────────────────────────────
+
+  /usuarios/me:
+    get:
+      tags: [Usuarios]
+      operationId: getMiPerfil
+      summary: Obtener perfil propio
+      description: Devuelve el perfil del usuario autenticado. Requiere ROLE_USER o ROLE_ADMIN.
+      responses:
+        '200':
+          description: Perfil devuelto correctamente
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UsuarioResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+    patch:
+      tags: [Usuarios]
+      operationId: actualizarMiPerfil
+      summary: Actualizar perfil propio
+      description: |
+        Actualiza los campos permitidos del perfil del usuario autenticado (semántica PATCH).
+        No permite modificar `role` ni `status` — esos campos son exclusivos de ADMIN.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UsuarioPatchRequest'
+      responses:
+        '200':
+          description: Perfil actualizado correctamente
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UsuarioResponse'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '409':
+          $ref: '#/components/responses/Conflict'
+
+  # ─── Usuarios — administración ─────────────────────────────────────────────
+
+  /admin/usuarios:
+    get:
+      tags: [Usuarios]
+      operationId: listarUsuarios
+      summary: Listar todos los usuarios (ADMIN)
+      description: Lista todos los usuarios con paginación y filtrado opcional por estado. Requiere ROLE_ADMIN.
+      parameters:
+        - $ref: '#/components/parameters/PageParam'
+        - $ref: '#/components/parameters/PageSizeParam'
+        - name: status
+          in: query
+          description: Filtrar por estado de la cuenta
+          required: false
+          schema:
+            $ref: '#/components/schemas/UserStatus'
+      responses:
+        '200':
+          description: Lista de usuarios devuelta correctamente
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedUsuariosResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+    post:
+      tags: [Usuarios]
+      operationId: crearUsuario
+      summary: Crear usuario (ADMIN)
+      description: |
+        Crea un nuevo usuario directamente sin proceso de aprobación.
+        El usuario se crea con estado ACTIVE. Requiere ROLE_ADMIN.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UsuarioCreateRequest'
+      responses:
+        '201':
+          description: Usuario creado correctamente
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UsuarioResponse'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '409':
+          $ref: '#/components/responses/Conflict'
+
+  /admin/usuarios/{id}:
+    get:
+      tags: [Usuarios]
+      operationId: getUsuario
+      summary: Obtener usuario por ID (ADMIN)
+      description: Devuelve los datos completos de un usuario. Requiere ROLE_ADMIN.
+      parameters:
+        - $ref: '#/components/parameters/UserIdParam'
+      responses:
+        '200':
+          description: Usuario encontrado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UsuarioResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    patch:
+      tags: [Usuarios]
+      operationId: actualizarUsuario
+      summary: Actualizar usuario (ADMIN)
+      description: |
+        Actualiza los datos de un usuario concreto, incluyendo rol y estado.
+        Requiere ROLE_ADMIN.
+      parameters:
+        - $ref: '#/components/parameters/UserIdParam'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UsuarioAdminPatchRequest'
+      responses:
+        '200':
+          description: Usuario actualizado correctamente
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UsuarioResponse'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+
+    delete:
+      tags: [Usuarios]
+      operationId: desactivarUsuario
+      summary: Desactivar usuario (ADMIN)
+      description: |
+        Borrado lógico: el estado pasa a INACTIVE. El registro permanece en base de datos.
+        Un administrador no puede desactivarse a sí mismo.
+        Requiere ROLE_ADMIN.
+      parameters:
+        - $ref: '#/components/parameters/UserIdParam'
+      responses:
+        '204':
+          description: Usuario desactivado correctamente
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          description: No se puede desactivar el propio usuario administrador activo
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /admin/usuarios/{id}/aprobar:
+    patch:
+      tags: [Usuarios]
+      operationId: aprobarUsuario
+      summary: Aprobar cuenta pendiente (ADMIN)
+      description: |
+        Aprueba una cuenta de usuario en estado PENDING, cambiando su estado a ACTIVE.
+        Requiere ROLE_ADMIN.
+      parameters:
+        - $ref: '#/components/parameters/UserIdParam'
+      responses:
+        '200':
+          description: Cuenta aprobada correctamente
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AprobarResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          description: El usuario no estaba en estado PENDING
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  # ─── Reservas ─────────────────────────────────────────────────────────────
+
+  /reservas/disponibles:
+    get:
+      tags: [Reservas]
+      operationId: getDisponibilidad
+      summary: Consultar disponibilidad de la pista
+      description: |
+        Devuelve los tramos horarios disponibles para una fecha concreta.
+        Solo se devuelven tramos con al menos una plaza libre.
+        Requiere autenticación (USER o ADMIN).
+      parameters:
+        - name: fecha
+          in: query
+          description: Fecha para la que se consulta disponibilidad (formato YYYY-MM-DD)
+          required: true
+          schema:
+            type: string
+            format: date
+            example: "2025-06-15"
+      responses:
+        '200':
+          description: Disponibilidad calculada correctamente
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DisponibilidadResponse'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /reservas:
+    get:
+      tags: [Reservas]
+      operationId: listarMisReservas
+      summary: Listar reservas del usuario autenticado
+      description: |
+        Lista las reservas en las que el usuario autenticado es propietario o participante,
+        con paginación. Requiere ROLE_USER o ROLE_ADMIN.
+      parameters:
+        - $ref: '#/components/parameters/PageParam'
+        - $ref: '#/components/parameters/PageSizeParam'
+      responses:
+        '200':
+          description: Lista devuelta correctamente
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedReservasResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+    post:
+      tags: [Reservas]
+      operationId: crearReserva
+      summary: Crear reserva
+      description: |
+        Crea una nueva reserva. El usuario autenticado es automáticamente añadido
+        como primer participante (titular). Se envía OTP de tipo RESERVATION_CONFIRM
+        al creador vía Telegram si la reserva proviene del canal Telegram.
+        Requiere ROLE_USER o ROLE_ADMIN.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReservaRequest'
+            examples:
+              ejemplo:
+                summary: Reserva de 60 min con un participante adicional externo
+                value:
+                  reservationDate: "2025-06-15"
+                  startTime: "09:00"
+                  durationMinutes: 60
+                  notes: "Reserva para partido de entrenamiento"
+                  participantesAdicionales:
+                    - externalName: "Carlos García"
+      responses:
+        '201':
+          description: Reserva creada correctamente
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReservaResponse'
+              examples:
+                ejemplo:
+                  summary: Reserva creada en estado PENDING_CONFIRMATION
+                  value:
+                    id: "550e8400-e29b-41d4-a716-446655440000"
+                    reservationDate: "2025-06-15"
+                    startTime: "09:00"
+                    durationMinutes: 60
+                    status: "PENDING_CONFIRMATION"
+                    ownerId: 5
+                    ownerName: "John Doe"
+                    priceTotal: 15.00
+                    notes: "Reserva para partido de entrenamiento"
+                    participants:
+                      - id: 1
+                        userId: 5
+                        nombre: "John Doe"
+                        statusPago: "PENDING"
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          description: Número máximo de participantes superado o regla de negocio incumplida
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /reservas/{id}:
+    get:
+      tags: [Reservas]
+      operationId: getReserva
+      summary: Obtener detalle de reserva
+      description: |
+        Devuelve el detalle de una reserva. Un USER solo puede acceder si es propietario
+        o participante. ADMIN puede acceder a cualquier reserva.
+      parameters:
+        - $ref: '#/components/parameters/ReservationIdParam'
+      responses:
+        '200':
+          description: Reserva encontrada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReservaResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    delete:
+      tags: [Reservas]
+      operationId: cancelarReserva
+      summary: Cancelar reserva
+      description: |
+        Cancela una reserva. Solo puede hacerlo el propietario (o ADMIN).
+        La cancelación debe realizarse con al menos `cancellation_deadline_hours` de antelación.
+        Se envía OTP de tipo CANCELLATION_CONFIRM al propietario vía Telegram.
+      parameters:
+        - $ref: '#/components/parameters/ReservationIdParam'
+      responses:
+        '204':
+          description: Reserva cancelada correctamente
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          description: La cancelación está fuera del plazo permitido
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /reservas/{id}/unirse:
+    post:
+      tags: [Reservas]
+      operationId: unirseAReserva
+      summary: Unirse a una reserva como participante
+      description: |
+        Permite a un usuario autenticado unirse a una reserva existente que tiene huecos disponibles.
+        Un usuario no puede unirse dos veces a la misma reserva.
+        La reserva debe estar en estado PENDING_CONFIRMATION o CONFIRMED.
+        Requiere ROLE_USER o ROLE_ADMIN.
+      parameters:
+        - $ref: '#/components/parameters/ReservationIdParam'
+      responses:
+        '200':
+          description: Usuario añadido como participante
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnirseResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          description: La reserva está completa o no admite nuevos participantes
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  # ─── Reservas — administración ─────────────────────────────────────────────
+
+  /admin/reservas:
+    get:
+      tags: [Reservas]
+      operationId: listarTodasReservas
+      summary: Listar todas las reservas (ADMIN)
+      description: Lista todas las reservas con filtros y paginación. Requiere ROLE_ADMIN.
+      parameters:
+        - name: fecha
+          in: query
+          description: Filtrar por fecha de reserva (YYYY-MM-DD)
+          required: false
+          schema:
+            type: string
+            format: date
+        - name: status
+          in: query
+          description: Filtrar por estado de la reserva
+          required: false
+          schema:
+            $ref: '#/components/schemas/ReservationStatus'
+        - $ref: '#/components/parameters/PageParam'
+        - $ref: '#/components/parameters/PageSizeParam'
+      responses:
+        '200':
+          description: Lista de reservas devuelta correctamente
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedReservasResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /admin/reservas/{id}/estado:
+    patch:
+      tags: [Reservas]
+      operationId: cambiarEstadoReserva
+      summary: Cambiar estado de reserva (ADMIN)
+      description: |
+        Cambia el estado de una reserva. Transiciones permitidas:
+        PENDING_CONFIRMATION → CONFIRMED, CONFIRMED → COMPLETED, CONFIRMED → CANCELLED.
+        Requiere ROLE_ADMIN.
+      parameters:
+        - $ref: '#/components/parameters/ReservationIdParam'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReservaEstadoRequest'
+      responses:
+        '200':
+          description: Estado actualizado correctamente
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReservaEstadoResponse'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          description: La transición de estado no está permitida
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  # ─── Pagos ────────────────────────────────────────────────────────────────
+
+  /pagos:
+    get:
+      tags: [Pagos]
+      operationId: listarMisPagos
+      summary: Listar pagos del usuario autenticado
+      description: |
+        Lista los pagos vinculados al usuario autenticado con paginación.
+        Solo se devuelven pagos del propio usuario.
+        Requiere ROLE_USER o ROLE_ADMIN.
+      parameters:
+        - $ref: '#/components/parameters/PageParam'
+        - $ref: '#/components/parameters/PageSizeParam'
+      responses:
+        '200':
+          description: Lista de pagos devuelta correctamente
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedPagosResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /pagos/iniciar:
+    post:
+      tags: [Pagos]
+      operationId: iniciarPago
+      summary: Iniciar pago online (Redsys)
+      description: |
+        Inicia el proceso de pago de una reserva vía Redsys. Devuelve la URL del TPV virtual
+        y los parámetros firmados con HMAC SHA-256 para el formulario de redirección.
+        El importe se calcula en backend; nunca proviene del frontend.
+        El participante debe ser el usuario autenticado.
+        Requiere ROLE_USER o ROLE_ADMIN.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IniciarPagoRequest'
+      responses:
+        '200':
+          description: Pago iniciado, URL de redirección devuelta
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IniciarPagoResponse'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          description: La reserva no está en un estado que admite pagos
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /admin/pagos/{reservaId}/efectivo:
+    post:
+      tags: [Pagos]
+      operationId: registrarPagoEfectivo
+      summary: Registrar pago en efectivo (ADMIN)
+      description: |
+        Registra el pago en efectivo de la reserva. Solo el administrador puede usar este endpoint.
+        Actualiza el estado del pago asociado a la reserva.
+        Requiere ROLE_ADMIN.
+      parameters:
+        - name: reservaId
+          in: path
+          description: UUID de la reserva
+          required: true
+          schema:
+            type: string
+            format: uuid
+            example: "550e8400-e29b-41d4-a716-446655440000"
+      responses:
+        '200':
+          description: Pago en efectivo registrado correctamente
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EfectivoPagoResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          description: La reserva ya tiene todos los pagos completados
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /admin/pagos:
+    get:
+      tags: [Pagos]
+      operationId: listarTodosPagos
+      summary: Listar todos los pagos (ADMIN)
+      description: Lista todos los pagos del sistema con filtros y paginación. Requiere ROLE_ADMIN.
+      parameters:
+        - $ref: '#/components/parameters/PageParam'
+        - $ref: '#/components/parameters/PageSizeParam'
+        - name: status
+          in: query
+          description: Filtrar por estado del pago
+          required: false
+          schema:
+            $ref: '#/components/schemas/PaymentStatus'
+      responses:
+        '200':
+          description: Lista de pagos devuelta correctamente
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedPagosResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  # ─── OTP ──────────────────────────────────────────────────────────────────
+
+  /otp/verificar:
+    post:
+      tags: [OTP]
+      operationId: verificarOtp
+      summary: Verificar código OTP
+      description: |
+        Verifica un código OTP enviado por Telegram para el usuario autenticado.
+        El OTP debe ser de tipo correcto, no haber sido usado y no haber expirado (TTL 10 min).
+        Tras la verificación exitosa, el campo `used` se establece a `true`.
+        Requiere ROLE_USER o ROLE_ADMIN.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OtpVerificarRequest'
+      responses:
+        '200':
+          description: OTP verificado correctamente
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OtpVerificarResponse'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '422':
+          description: OTP incorrecto, expirado o ya utilizado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  # ─── Sistema ──────────────────────────────────────────────────────────────
+
+  /admin/sistema/config:
+    get:
+      tags: [Sistema]
+      operationId: getSystemConfig
+      summary: Obtener configuración del sistema (ADMIN)
+      description: |
+        Devuelve la configuración global del club (singleton). Los campos sensibles
+        (redsys_secret_key, telegram_bot_token, smtp_password) no se devuelven en claro.
+        Requiere ROLE_ADMIN.
+      responses:
+        '200':
+          description: Configuración devuelta correctamente
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SystemConfigResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+    patch:
+      tags: [Sistema]
+      operationId: actualizarSystemConfig
+      summary: Actualizar configuración del sistema (ADMIN)
+      description: |
+        Actualiza la configuración global del club (semántica PATCH). Solo los campos
+        incluidos en el cuerpo se actualizan. Invalida la caché de `system-config`.
+        Requiere ROLE_ADMIN.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SystemConfigUpdateRequest'
+      responses:
+        '200':
+          description: Configuración actualizada correctamente
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SystemConfigResponse'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+# ---------------------------------------------------------------------------
+# Components
+# ---------------------------------------------------------------------------
+components:
+
+  # ─── Security Schemes ─────────────────────────────────────────────────────
+
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: |
+        Token JWT HS256 obtenido en POST /auth/login o POST /auth/refresh.
+        Incluir en la cabecera: `Authorization: Bearer <token>`.
+        Lifetime: 15 minutos.
+
+    redsysWebhookSecret:
+      type: apiKey
+      in: header
+      name: X-Redsys-Signature
+      description: Firma HMAC SHA-256 de Redsys para validar el origen del webhook de notificación de pago.
+
+    telegramWebhookSecret:
+      type: apiKey
+      in: header
+      name: X-Telegram-Bot-Api-Secret-Token
+      description: Secret token configurado al registrar el webhook del bot de Telegram.
+
+  # ─── Reusable Parameters ──────────────────────────────────────────────────
+
+  parameters:
+    PageParam:
+      name: page
+      in: query
+      description: Índice de la página (base 0)
+      required: false
+      schema:
+        type: integer
+        minimum: 0
+        default: 0
+
+    PageSizeParam:
+      name: pageSize
+      in: query
+      description: Número de elementos por página (máximo 100)
+      required: false
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+        default: 20
+
+    ReservationIdParam:
+      name: id
+      in: path
+      description: UUID de la reserva
+      required: true
+      schema:
+        type: string
+        format: uuid
+        example: "550e8400-e29b-41d4-a716-446655440000"
+
+    UserIdParam:
+      name: id
+      in: path
+      description: Identificador del usuario (BIGINT)
+      required: true
+      schema:
+        type: integer
+        format: int64
+        example: 42
+
+  # ─── Reusable Responses ───────────────────────────────────────────────────
+
+  responses:
+    Unauthorized:
+      description: Token ausente, expirado o inválido
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          examples:
+            tokenExpirado:
+              summary: Token expirado
+              value:
+                code: "UNAUTHORIZED"
+                message: "El token de acceso ha expirado."
+                errors: []
+
+    Forbidden:
+      description: El usuario autenticado no tiene permisos para esta operación
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          examples:
+            sinRol:
+              summary: Rol insuficiente
+              value:
+                code: "FORBIDDEN"
+                message: "No tiene permisos para realizar esta operación."
+                errors: []
+
+    NotFound:
+      description: Recurso no encontrado
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          examples:
+            noEncontrado:
+              summary: Recurso no encontrado
+              value:
+                code: "NOT_FOUND"
+                message: "El recurso solicitado no existe."
+                errors: []
+
+    ValidationError:
+      description: Error de validación de parámetros o cuerpo de la petición
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          examples:
+            campoInvalido:
+              summary: Campo con formato inválido
+              value:
+                code: "VALIDATION_ERROR"
+                message: "Los datos de la solicitud no son válidos."
+                errors:
+                  - field: "email"
+                    message: "El formato del email no es válido."
+
+    Conflict:
+      description: Conflicto (p.ej. franja ya reservada, email duplicado)
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          examples:
+            franjaOcupada:
+              summary: Franja horaria ya ocupada
+              value:
+                code: "CONFLICT"
+                message: "La franja horaria seleccionada ya está reservada."
+                errors: []
+
+    InternalError:
+      description: Error interno del servidor
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+
+  # ─── Schemas ──────────────────────────────────────────────────────────────
+
+  schemas:
+
+    # --- Enums ---------------------------------------------------------------
+
+    UserStatus:
+      type: string
+      description: Estado de la cuenta de usuario
+      enum:
+        - PENDING
+        - ACTIVE
+        - INACTIVE
+      example: ACTIVE
+
+    UserRole:
+      type: string
+      description: Rol del usuario en la plataforma
+      enum:
+        - ADMIN
+        - USER
+      example: USER
+
+    ReservationStatus:
+      type: string
+      description: Estado del ciclo de vida de una reserva
+      enum:
+        - PENDING_CONFIRMATION
+        - CONFIRMED
+        - CANCELLED
+        - COMPLETED
+      example: CONFIRMED
+
+    ReservationChannel:
+      type: string
+      description: Canal por el que se creó o se unió a la reserva
+      enum:
+        - WEB
+        - TELEGRAM
+      example: WEB
+
+    PaymentStatus:
+      type: string
+      description: Estado del ciclo de pago
+      enum:
+        - PENDING
+        - IN_PROGRESS
+        - PAID
+        - FAILED
+        - CANCELLED
+        - REFUNDED
+      example: PAID
+
+    PaymentMethod:
+      type: string
+      description: Método de pago utilizado
+      enum:
+        - REDSYS
+        - CASH
+      example: REDSYS
+
+    OtpType:
+      type: string
+      description: Tipo de operación que confirma el OTP
+      enum:
+        - RESERVATION_CONFIRM
+        - CANCELLATION_CONFIRM
+        - PASSWORD_RESET
+      example: RESERVATION_CONFIRM
+
+    # --- Comunes -------------------------------------------------------------
+
+    ErrorResponse:
+      type: object
+      description: Respuesta de error estándar de la API
+      required:
+        - code
+        - message
+        - errors
+      properties:
+        code:
+          type: string
+          description: Código de error de aplicación
+          example: VALIDATION_ERROR
+        message:
+          type: string
+          description: Descripción legible del error
+          example: "Los datos de la solicitud no son válidos."
+        errors:
+          type: array
+          description: Lista de errores de campo (vacía si el error no es de validación)
+          items:
+            $ref: '#/components/schemas/FieldError'
+      examples:
+        validacionFallida:
+          summary: Error de validación de campos
+          value:
+            code: "VALIDATION_ERROR"
+            message: "Los datos de la solicitud no son válidos."
+            errors:
+              - field: "email"
+                message: "El formato del email no es válido."
+
+    FieldError:
+      type: object
+      description: Detalle de un error de campo específico
+      required:
+        - field
+        - message
+      properties:
+        field:
+          type: string
+          description: Nombre del campo con error
+          example: email
+        message:
+          type: string
+          description: Descripción del error de validación del campo
+          example: "El formato del email no es válido."
+
+    MessageResponse:
+      type: object
+      description: Respuesta genérica con un mensaje informativo
+      required:
+        - message
+      properties:
+        message:
+          type: string
+          description: Mensaje informativo al cliente
+          example: "Operación completada correctamente."
+
+    PaginatedResponseMeta:
+      type: object
+      description: Metadatos de paginación compartidos por todas las respuestas paginadas
+      required:
+        - total
+        - page
+        - pageSize
+      properties:
+        total:
+          type: integer
+          format: int64
+          description: Total de elementos en la colección completa
+          example: 47
+        page:
+          type: integer
+          description: Índice de la página actual (base 0)
+          example: 0
+        pageSize:
+          type: integer
+          description: Número de elementos por página
+          example: 20
+
+    # --- Autenticación -------------------------------------------------------
+
+    LoginRequest:
+      type: object
+      description: Credenciales para iniciar sesión
+      required:
+        - login
+        - password
+      properties:
+        login:
+          type: string
+          description: Nombre de usuario (login)
+          example: jdoe
+        password:
+          type: string
+          format: password
+          description: Contraseña del usuario
+          example: "SecureP4ss!"
+
+    LoginResponse:
+      type: object
+      description: Respuesta de autenticación con los tokens JWT
+      required:
+        - accessToken
+        - refreshToken
+        - expiresIn
+      properties:
+        accessToken:
+          type: string
+          description: Token JWT de acceso (HS256, duración 15 min)
+          example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+        refreshToken:
+          type: string
+          description: Token JWT de refresco (duración 7 días). También enviado en cookie httpOnly.
+          example: "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4..."
+        expiresIn:
+          type: integer
+          description: Segundos hasta la expiración del access token
+          example: 900
+
+    RefreshRequest:
+      type: object
+      description: Token de refresco para obtener un nuevo access token
+      required:
+        - refreshToken
+      properties:
+        refreshToken:
+          type: string
+          description: Refresh token obtenido en el login
+          example: "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4..."
+
+    LogoutRequest:
+      type: object
+      description: Refresh token a invalidar en el logout
+      required:
+        - refreshToken
+      properties:
+        refreshToken:
+          type: string
+          description: Refresh token a revocar
+          example: "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4..."
+
+    RegisterRequest:
+      type: object
+      description: Datos para el auto-registro de un nuevo usuario
+      required:
+        - login
+        - email
+        - phone
+        - name
+        - password
+      properties:
+        login:
+          type: string
+          description: Nombre de usuario (solo alfanumérico y guión bajo, 3-50 chars)
+          minLength: 3
+          maxLength: 50
+          pattern: '^[a-zA-Z0-9_]+$'
+          example: jdoe
+        email:
+          type: string
+          format: email
+          description: Correo electrónico del usuario
+          example: jdoe@example.com
+        phone:
+          type: string
+          description: Teléfono en formato E.164
+          pattern: '^\+[1-9]\d{7,14}$'
+          example: "+34612345678"
+        name:
+          type: string
+          description: Nombre completo del usuario
+          minLength: 2
+          maxLength: 100
+          example: "John Doe"
+        password:
+          type: string
+          format: password
+          description: Contraseña (mínimo 8 chars, al menos 1 mayúscula y 1 número)
+          minLength: 8
+          example: "SecureP4ss!"
+
+    SolicitarResetRequest:
+      type: object
+      description: Email del usuario que solicita el reset de contraseña
+      required:
+        - email
+      properties:
+        email:
+          type: string
+          format: email
+          description: Email asociado a la cuenta
+          example: jdoe@example.com
+
+    ConfirmarResetRequest:
+      type: object
+      description: Datos para confirmar el restablecimiento de contraseña
+      required:
+        - email
+        - codigo
+        - nuevaPassword
+      properties:
+        email:
+          type: string
+          format: email
+          description: Email de la cuenta
+          example: jdoe@example.com
+        codigo:
+          type: string
+          description: Código OTP de 6 dígitos recibido por Telegram
+          pattern: '^\d{6}$'
+          example: "482910"
+        nuevaPassword:
+          type: string
+          format: password
+          description: Nueva contraseña
+          minLength: 8
+          example: "NuevaP4ss!"
+
+    # --- Usuarios ------------------------------------------------------------
+
+    UsuarioResponse:
+      type: object
+      description: Datos completos de un usuario del sistema
+      required:
+        - id
+        - login
+        - email
+        - phone
+        - role
+        - status
+        - telegramLinked
+        - registeredAt
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: Identificador único del usuario (BIGSERIAL)
+          example: 1
+        login:
+          type: string
+          description: Nombre de usuario para login
+          example: jdoe
+        email:
+          type: string
+          format: email
+          description: Correo electrónico
+          example: jdoe@example.com
+        phone:
+          type: string
+          description: Teléfono en formato E.164
+          example: "+34612345678"
+        firstName:
+          type: string
+          description: Nombre de pila
+          example: "John"
+        lastName:
+          type: string
+          description: Apellidos
+          example: "Doe"
+        role:
+          $ref: '#/components/schemas/UserRole'
+        status:
+          $ref: '#/components/schemas/UserStatus'
+        telegramLinked:
+          type: boolean
+          description: Indica si el usuario tiene su cuenta de Telegram vinculada
+          example: true
+        telegramLinkedAt:
+          type: string
+          format: date-time
+          description: Instante en que se vinculó Telegram (null si no está vinculado)
+          nullable: true
+          example: "2025-03-10T14:22:00Z"
+        registeredAt:
+          type: string
+          format: date-time
+          description: Fecha y hora de registro del usuario
+          example: "2025-01-15T10:00:00Z"
+        updatedAt:
+          type: string
+          format: date-time
+          description: Última modificación del perfil
+          example: "2025-03-10T14:22:00Z"
+
+    UsuarioPatchRequest:
+      type: object
+      description: |
+        Campos actualizables por el propio usuario (semántica PATCH — todos opcionales).
+        No permite modificar `role` ni `status`.
+      properties:
+        email:
+          type: string
+          format: email
+          description: Nuevo correo electrónico
+          example: nuevoemail@example.com
+        phone:
+          type: string
+          description: Nuevo teléfono en formato E.164
+          pattern: '^\+[1-9]\d{7,14}$'
+          example: "+34698765432"
+        firstName:
+          type: string
+          description: Nuevo nombre de pila
+          minLength: 2
+          maxLength: 100
+          example: "John"
+        lastName:
+          type: string
+          description: Nuevos apellidos
+          minLength: 2
+          maxLength: 100
+          example: "Doe"
+        password:
+          type: string
+          format: password
+          description: Nueva contraseña
+          minLength: 8
+          example: "NuevaP4ss!"
+
+    UsuarioCreateRequest:
+      type: object
+      description: Datos para crear un usuario directamente (ADMIN). El usuario se crea como ACTIVE.
+      required:
+        - login
+        - email
+        - phone
+        - firstName
+        - lastName
+        - password
+        - role
+      properties:
+        login:
+          type: string
+          minLength: 3
+          maxLength: 50
+          pattern: '^[a-zA-Z0-9_]+$'
+          example: jdoe
+        email:
+          type: string
+          format: email
+          example: jdoe@example.com
+        phone:
+          type: string
+          pattern: '^\+[1-9]\d{7,14}$'
+          example: "+34612345678"
+        firstName:
+          type: string
+          minLength: 2
+          maxLength: 100
+          example: "John"
+        lastName:
+          type: string
+          minLength: 2
+          maxLength: 100
+          example: "Doe"
+        password:
+          type: string
+          format: password
+          minLength: 8
+          example: "SecureP4ss!"
+        role:
+          $ref: '#/components/schemas/UserRole'
+
+    UsuarioAdminPatchRequest:
+      type: object
+      description: |
+        Campos actualizables por el ADMIN (semántica PATCH — todos opcionales).
+        Permite modificar rol y estado además de datos personales.
+      properties:
+        email:
+          type: string
+          format: email
+          example: nuevoemail@example.com
+        phone:
+          type: string
+          pattern: '^\+[1-9]\d{7,14}$'
+          example: "+34698765432"
+        firstName:
+          type: string
+          minLength: 2
+          maxLength: 100
+          example: "John"
+        lastName:
+          type: string
+          minLength: 2
+          maxLength: 100
+          example: "Doe"
+        role:
+          $ref: '#/components/schemas/UserRole'
+        status:
+          $ref: '#/components/schemas/UserStatus'
+        password:
+          type: string
+          format: password
+          minLength: 8
+          example: "NuevaP4ss!"
+
+    AprobarResponse:
+      type: object
+      description: Respuesta de aprobación de cuenta de usuario
+      required:
+        - id
+        - login
+        - status
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 5
+        login:
+          type: string
+          example: jdoe
+        status:
+          type: string
+          enum:
+            - ACTIVE
+          example: ACTIVE
+
+    PaginatedUsuariosResponse:
+      allOf:
+        - $ref: '#/components/schemas/PaginatedResponseMeta'
+        - type: object
+          required:
+            - data
+          properties:
+            data:
+              type: array
+              description: Lista de usuarios de la página actual
+              items:
+                $ref: '#/components/schemas/UsuarioResponse'
+      examples:
+        paginaDeUsuarios:
+          summary: Primera página de usuarios
+          value:
+            total: 42
+            page: 0
+            pageSize: 20
+            data:
+              - id: 1
+                login: jdoe
+                email: jdoe@example.com
+                phone: "+34612345678"
+                firstName: "John"
+                lastName: "Doe"
+                role: USER
+                status: ACTIVE
+                telegramLinked: true
+                telegramLinkedAt: "2025-03-10T14:22:00Z"
+                registeredAt: "2025-01-15T10:00:00Z"
+                updatedAt: "2025-03-10T14:22:00Z"
+
+    # --- Reservas ------------------------------------------------------------
+
+    ParticipanteRequest:
+      type: object
+      description: |
+        Participante adicional para una reserva. Exactamente uno de `userId` o `externalName`
+        debe estar presente (no ambos, no ninguno).
+      properties:
+        userId:
+          type: integer
+          format: int64
+          description: ID del usuario registrado en el sistema
+          nullable: true
+          example: 7
+        externalName:
+          type: string
+          description: Nombre del participante externo sin cuenta en el sistema
+          nullable: true
+          maxLength: 100
+          example: "Carlos García"
+
+    ParticipanteResponse:
+      type: object
+      description: Información de un participante en la reserva
+      required:
+        - id
+        - nombre
+        - statusPago
+        - isOwner
+        - joinedAt
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: Identificador del registro de participante
+          example: 3
+        userId:
+          type: integer
+          format: int64
+          description: ID del usuario registrado (null si es participante externo)
+          nullable: true
+          example: 7
+        nombre:
+          type: string
+          description: Nombre del participante (registrado o externo)
+          example: "Carlos García"
+        statusPago:
+          $ref: '#/components/schemas/PaymentStatus'
+        isOwner:
+          type: boolean
+          description: Indica si este participante es el titular de la reserva
+          example: false
+        slotPosition:
+          type: integer
+          description: Posición en la reserva (1 = titular, 2-4 = resto)
+          minimum: 1
+          maximum: 4
+          example: 2
+        joinedAt:
+          type: string
+          format: date-time
+          description: Instante en que se incorporó a la reserva
+          example: "2025-06-14T18:30:00Z"
+
+    ReservaRequest:
+      type: object
+      description: Datos para crear una nueva reserva
+      required:
+        - reservationDate
+        - startTime
+        - durationMinutes
+      properties:
+        reservationDate:
+          type: string
+          format: date
+          description: Fecha de la reserva (no puede ser en el pasado)
+          example: "2025-06-15"
+        startTime:
+          type: string
+          description: Hora de inicio (en punto o en media hora, formato HH:mm)
+          pattern: '^([01]\d|2[0-3]):[0-5]\d$'
+          example: "09:00"
+        durationMinutes:
+          type: integer
+          description: "Duración en minutos. Valores permitidos: 60, 90, 120, 150, 180"
+          enum:
+            - 60
+            - 90
+            - 120
+            - 150
+            - 180
+          example: 60
+        notes:
+          type: string
+          description: Observaciones libres del titular
+          nullable: true
+          maxLength: 500
+          example: "Reserva para partido de entrenamiento"
+        participantesAdicionales:
+          type: array
+          description: Participantes adicionales (máx. 3 — el creador ocupa el slot 1)
+          items:
+            $ref: '#/components/schemas/ParticipanteRequest'
+          maxItems: 3
+
+    ReservaResponse:
+      type: object
+      description: Datos completos de una reserva
+      required:
+        - id
+        - reservationDate
+        - startTime
+        - durationMinutes
+        - status
+        - channel
+        - priceTotal
+        - participants
+        - createdAt
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Identificador único de la reserva (UUID)
+          example: "550e8400-e29b-41d4-a716-446655440000"
+        reservationDate:
+          type: string
+          format: date
+          description: Fecha de la reserva
+          example: "2025-06-15"
+        startTime:
+          type: string
+          description: Hora de inicio (HH:mm)
+          example: "09:00"
+        endTime:
+          type: string
+          description: Hora de fin calculada (HH:mm)
+          example: "10:00"
+        durationMinutes:
+          type: integer
+          description: Duración en minutos
+          example: 60
+        status:
+          $ref: '#/components/schemas/ReservationStatus'
+        channel:
+          $ref: '#/components/schemas/ReservationChannel'
+        ownerId:
+          type: integer
+          format: int64
+          description: ID del titular de la reserva
+          example: 5
+        ownerName:
+          type: string
+          description: Nombre completo del titular
+          example: "John Doe"
+        priceTotal:
+          type: number
+          format: double
+          description: Importe total congelado en el momento de crear la reserva
+          example: 15.00
+        notes:
+          type: string
+          description: Observaciones libres del titular
+          nullable: true
+          example: "Reserva para partido de entrenamiento"
+        participants:
+          type: array
+          description: Lista de participantes (incluye el titular como slot 1)
+          items:
+            $ref: '#/components/schemas/ParticipanteResponse'
+        telegramMessageId:
+          type: string
+          description: ID del mensaje publicado en el grupo de Telegram (null si no aplica)
+          nullable: true
+          example: "12345"
+        createdAt:
+          type: string
+          format: date-time
+          description: Instante de creación de la reserva
+          example: "2025-06-14T18:00:00Z"
+        updatedAt:
+          type: string
+          format: date-time
+          description: Última modificación de la reserva
+          example: "2025-06-14T18:00:00Z"
+
+    ReservaEstadoRequest:
+      type: object
+      description: Nuevo estado para una reserva (solo ADMIN)
+      required:
+        - status
+      properties:
+        status:
+          type: string
+          description: Estado destino de la transición
+          enum:
+            - CONFIRMED
+            - CANCELLED
+            - COMPLETED
+          example: CONFIRMED
+
+    ReservaEstadoResponse:
+      type: object
+      description: Confirmación del cambio de estado de una reserva
+      required:
+        - id
+        - status
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: "550e8400-e29b-41d4-a716-446655440000"
+        status:
+          $ref: '#/components/schemas/ReservationStatus'
+
+    DisponibilidadResponse:
+      type: object
+      description: Tramos horarios disponibles para una fecha concreta
+      required:
+        - fecha
+        - tramosDisponibles
+      properties:
+        fecha:
+          type: string
+          format: date
+          description: Fecha consultada
+          example: "2025-06-15"
+        tramosDisponibles:
+          type: array
+          description: Lista de tramos con plazas libres
+          items:
+            $ref: '#/components/schemas/TramoDisponible'
+
+    TramoDisponible:
+      type: object
+      description: Un tramo horario disponible con sus plazas libres
+      required:
+        - horaInicio
+        - duracionMinutos
+        - plazasLibres
+      properties:
+        horaInicio:
+          type: string
+          description: Hora de inicio del tramo (HH:mm)
+          example: "09:00"
+        duracionMinutos:
+          type: integer
+          description: Duración del tramo en minutos
+          example: 60
+        plazasLibres:
+          type: integer
+          description: Número de plazas disponibles en este tramo
+          minimum: 1
+          maximum: 4
+          example: 3
+
+    UnirseResponse:
+      type: object
+      description: Confirmación de incorporación a una reserva
+      required:
+        - participanteId
+        - reservaId
+        - userId
+        - nombre
+        - statusPago
+      properties:
+        participanteId:
+          type: integer
+          format: int64
+          description: ID del registro de participante creado
+          example: 8
+        reservaId:
+          type: string
+          format: uuid
+          description: UUID de la reserva a la que se ha unido
+          example: "550e8400-e29b-41d4-a716-446655440000"
+        userId:
+          type: integer
+          format: int64
+          description: ID del usuario que se ha unido
+          example: 3
+        nombre:
+          type: string
+          description: Nombre del usuario incorporado
+          example: "Jane Smith"
+        statusPago:
+          $ref: '#/components/schemas/PaymentStatus'
+
+    PaginatedReservasResponse:
+      allOf:
+        - $ref: '#/components/schemas/PaginatedResponseMeta'
+        - type: object
+          required:
+            - data
+          properties:
+            data:
+              type: array
+              description: Lista de reservas de la página actual
+              items:
+                $ref: '#/components/schemas/ReservaResponse'
+
+    # --- Pagos ---------------------------------------------------------------
+
+    PagoResponse:
+      type: object
+      description: Datos de un pago asociado a una reserva
+      required:
+        - id
+        - reservaId
+        - amount
+        - status
+        - createdAt
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Identificador único del pago (UUID)
+          example: "7c9e6679-7425-40de-944b-e07fc1f90ae7"
+        reservaId:
+          type: string
+          format: uuid
+          description: UUID de la reserva asociada
+          example: "550e8400-e29b-41d4-a716-446655440000"
+        amount:
+          type: number
+          format: double
+          description: Importe del pago en EUR
+          example: 15.00
+        method:
+          $ref: '#/components/schemas/PaymentMethod'
+        status:
+          $ref: '#/components/schemas/PaymentStatus'
+        redsysOrderId:
+          type: string
+          description: Referencia de orden Redsys (Ds_Merchant_Order)
+          nullable: true
+          example: "ORDER-20250615-001"
+        paymentUrl:
+          type: string
+          format: uri
+          description: URL del TPV virtual Redsys (solo disponible mientras el pago está en curso)
+          nullable: true
+          example: "https://sis-t.redsys.es:25443/sis/realizarPago"
+        gateway:
+          type: string
+          description: Pasarela de pago utilizada
+          nullable: true
+          enum:
+            - REDSYS
+            - STRIPE
+            - PAYPAL
+          example: REDSYS
+        transactionId:
+          type: string
+          description: Código de autorización del banco (Ds_AuthorisationCode)
+          nullable: true
+          example: "123456"
+        paidAt:
+          type: string
+          format: date-time
+          description: Instante de confirmación del pago
+          nullable: true
+          example: "2025-06-14T10:30:00Z"
+        createdAt:
+          type: string
+          format: date-time
+          description: Instante de creación del registro de pago
+          example: "2025-06-14T09:00:00Z"
+        updatedAt:
+          type: string
+          format: date-time
+          description: Última modificación del pago
+          example: "2025-06-14T10:30:00Z"
+
+    IniciarPagoRequest:
+      type: object
+      description: Datos para iniciar un pago online vía Redsys
+      required:
+        - reservaId
+        - participanteId
+      properties:
+        reservaId:
+          type: string
+          format: uuid
+          description: UUID de la reserva a pagar
+          example: "550e8400-e29b-41d4-a716-446655440000"
+        participanteId:
+          type: integer
+          format: int64
+          description: ID del participante que realiza el pago (debe corresponder al usuario autenticado)
+          example: 3
+
+    IniciarPagoResponse:
+      type: object
+      description: Datos para redirigir al usuario al TPV virtual de Redsys
+      required:
+        - pagoId
+        - redsysOrderId
+        - redsysUrl
+        - amount
+        - status
+      properties:
+        pagoId:
+          type: string
+          format: uuid
+          description: UUID del registro de pago creado
+          example: "7c9e6679-7425-40de-944b-e07fc1f90ae7"
+        redsysOrderId:
+          type: string
+          description: Referencia de orden generada para Redsys
+          example: "ORDER-20250615-001"
+        redsysUrl:
+          type: string
+          format: uri
+          description: URL del TPV virtual Redsys al que redirigir al usuario
+          example: "https://sis-t.redsys.es:25443/sis/realizarPago"
+        amount:
+          type: number
+          format: double
+          description: Importe del pago en EUR
+          example: 15.00
+        status:
+          type: string
+          enum:
+            - IN_PROGRESS
+          description: Estado inicial del pago tras iniciar el proceso
+          example: IN_PROGRESS
+
+    EfectivoPagoResponse:
+      type: object
+      description: Confirmación del registro de pago en efectivo
+      required:
+        - reservaId
+        - pagosActualizados
+        - totalCobrado
+      properties:
+        reservaId:
+          type: string
+          format: uuid
+          description: UUID de la reserva
+          example: "550e8400-e29b-41d4-a716-446655440000"
+        pagosActualizados:
+          type: integer
+          description: Número de registros de pago actualizados
+          example: 1
+        totalCobrado:
+          type: number
+          format: double
+          description: Importe total cobrado en efectivo
+          example: 15.00
+
+    PaginatedPagosResponse:
+      allOf:
+        - $ref: '#/components/schemas/PaginatedResponseMeta'
+        - type: object
+          required:
+            - data
+          properties:
+            data:
+              type: array
+              description: Lista de pagos de la página actual
+              items:
+                $ref: '#/components/schemas/PagoResponse'
+      examples:
+        historialPagos:
+          summary: Página de pagos de un usuario
+          value:
+            total: 8
+            page: 0
+            pageSize: 20
+            data:
+              - id: "7c9e6679-7425-40de-944b-e07fc1f90ae7"
+                reservaId: "550e8400-e29b-41d4-a716-446655440000"
+                amount: 15.00
+                method: REDSYS
+                status: PAID
+                redsysOrderId: "ORDER-20250615-001"
+                paymentUrl: null
+                gateway: REDSYS
+                transactionId: "123456"
+                paidAt: "2025-06-14T10:30:00Z"
+                createdAt: "2025-06-14T09:00:00Z"
+                updatedAt: "2025-06-14T10:30:00Z"
+
+    # --- OTP -----------------------------------------------------------------
+
+    OtpVerificarRequest:
+      type: object
+      description: Código OTP y tipo de operación a verificar
+      required:
+        - codigo
+        - tipo
+      properties:
+        codigo:
+          type: string
+          description: Código OTP de 6 dígitos recibido por Telegram
+          pattern: '^\d{6}$'
+          example: "482910"
+        tipo:
+          $ref: '#/components/schemas/OtpType'
+
+    OtpVerificarResponse:
+      type: object
+      description: Resultado de la verificación del OTP
+      required:
+        - verificado
+        - tipo
+        - message
+      properties:
+        verificado:
+          type: boolean
+          description: Indica si el OTP fue verificado con éxito
+          example: true
+        tipo:
+          $ref: '#/components/schemas/OtpType'
+        message:
+          type: string
+          description: Mensaje informativo sobre el resultado
+          example: "Código OTP verificado correctamente."
+
+    # --- Sistema -------------------------------------------------------------
+
+    SystemConfigResponse:
+      type: object
+      description: |
+        Configuración global del club (singleton). Los campos sensibles (redsys_secret_key,
+        telegram_bot_token, smtp_password) no se devuelven en claro por seguridad.
+      required:
+        - pricePerHour
+        - cancellationDeadlineHours
+        - maxParticipants
+        - paymentGateway
+        - updatedAt
+      properties:
+        pricePerHour:
+          type: number
+          format: double
+          description: Precio por hora en EUR
+          example: 15.00
+        cancellationDeadlineHours:
+          type: integer
+          description: Horas mínimas de antelación para cancelar sin penalización
+          example: 2
+        maxParticipants:
+          type: integer
+          description: Número máximo de participantes por reserva
+          minimum: 1
+          maximum: 4
+          example: 4
+        paymentGateway:
+          type: string
+          description: Pasarela de pago activa
+          enum:
+            - REDSYS
+            - STRIPE
+            - PAYPAL
+          example: REDSYS
+        redsysMerchantCode:
+          type: string
+          description: Código de comercio Redsys (null si no configurado)
+          nullable: true
+          example: "123456789"
+        redsysTerminal:
+          type: string
+          description: Número de terminal Redsys (null si no configurado)
+          nullable: true
+          example: "001"
+        redsysConfigured:
+          type: boolean
+          description: Indica si las credenciales Redsys están configuradas (sin revelar el secret)
+          example: true
+        telegramGroupId:
+          type: string
+          description: ID del grupo de Telegram de la comunidad (null si no configurado)
+          nullable: true
+          example: "-1001234567890"
+        telegramBotConfigured:
+          type: boolean
+          description: Indica si el bot de Telegram está configurado (sin revelar el token)
+          example: true
+        smtpHost:
+          type: string
+          description: Servidor SMTP (null si no configurado)
+          nullable: true
+          example: "smtp.gmail.com"
+        smtpPort:
+          type: integer
+          description: Puerto SMTP (null si no configurado)
+          nullable: true
+          example: 587
+        smtpUser:
+          type: string
+          description: Usuario SMTP (null si no configurado)
+          nullable: true
+          example: "noreply@padelpro.local"
+        updatedAt:
+          type: string
+          format: date-time
+          description: Última actualización de la configuración
+          example: "2025-05-01T10:00:00Z"
+        updatedById:
+          type: integer
+          format: int64
+          description: ID del admin que realizó el último cambio
+          nullable: true
+          example: 1
+
+    SystemConfigUpdateRequest:
+      type: object
+      description: Campos actualizables de la configuración del sistema (semántica PATCH — todos opcionales)
+      properties:
+        pricePerHour:
+          type: number
+          format: double
+          description: Nuevo precio por hora en EUR
+          minimum: 0.01
+          example: 18.00
+        cancellationDeadlineHours:
+          type: integer
+          description: Nuevas horas mínimas de antelación para cancelar
+          minimum: 0
+          example: 4
+        maxParticipants:
+          type: integer
+          description: Nuevo máximo de participantes por reserva
+          minimum: 1
+          maximum: 4
+          example: 4
+        paymentGateway:
+          type: string
+          description: Pasarela de pago a activar
+          enum:
+            - REDSYS
+            - STRIPE
+            - PAYPAL
+          example: REDSYS
+        redsysMerchantCode:
+          type: string
+          description: Código de comercio Redsys
+          nullable: true
+          example: "123456789"
+        redsysTerminal:
+          type: string
+          description: Número de terminal Redsys
+          nullable: true
+          example: "001"
+        redsysSecretKey:
+          type: string
+          format: password
+          description: Clave HMAC SHA-256 Redsys (se cifra AES-256 antes de persistir)
+          nullable: true
+          example: "XXXXXXXXXXXXXXXXXX"
+        telegramBotToken:
+          type: string
+          format: password
+          description: Token del bot de Telegram (se cifra AES-256 antes de persistir)
+          nullable: true
+          example: "123456:ABCDEF..."
+        telegramGroupId:
+          type: string
+          description: ID del grupo de Telegram de la comunidad
+          nullable: true
+          example: "-1001234567890"
+        smtpHost:
+          type: string
+          description: Servidor SMTP
+          nullable: true
+          example: "smtp.gmail.com"
+        smtpPort:
+          type: integer
+          description: Puerto SMTP
+          nullable: true
+          minimum: 1
+          maximum: 65535
+          example: 587
+        smtpUser:
+          type: string
+          description: Usuario SMTP
+          nullable: true
+          example: "noreply@padelpro.local"
+        smtpPassword:
+          type: string
+          format: password
+          description: Contraseña SMTP (se cifra AES-256 antes de persistir)
+          nullable: true
+          example: "smtp_secret_password"
+
+    # --- Webhooks ------------------------------------------------------------
+
+    RedsysWebhookPayload:
+      type: object
+      description: Payload de notificación de pago enviado por Redsys al webhook del backend
+      required:
+        - Ds_SignatureVersion
+        - Ds_MerchantParameters
+        - Ds_Signature
+      properties:
+        Ds_SignatureVersion:
+          type: string
+          description: Versión del algoritmo de firma
+          example: "HMAC_SHA256_V1"
+        Ds_MerchantParameters:
+          type: string
+          description: Parámetros de la transacción en Base64
+          example: "eyJEU19NRVJDSEF..."
+        Ds_Signature:
+          type: string
+          description: Firma HMAC SHA-256 del payload
+          example: "WJExynZ+..."

--- a/docs/security-design.md
+++ b/docs/security-design.md
@@ -1,0 +1,1023 @@
+# PadelPro — Diseño de Seguridad
+
+> **Versión:** 1.0 · **Fecha:** 2026-05-22
+>
+> Este documento es la referencia normativa de seguridad para `backend-architect` (implementación), `api-tester` (pruebas OWASP), `verification-specialist` y `reality-checker` (validación).
+> Cada control incluye el apartado **"Cómo se prueba"** para que `api-tester` pueda derivar casos directamente.
+
+---
+
+## 1. Modelo de amenazas (STRIDE)
+
+PadelPro es una aplicación de gestión de reservas de pádel para instalaciones pequeñas. El perfil de riesgo es **medio**: no almacena tarjetas de crédito, pero sí datos personales (RGPD), gestiona transacciones económicas reales (Redsys) y tiene un canal de mensajería público (Telegram) que puede recibir mensajes de actores no autenticados.
+
+### 1.1 Activos críticos e inventario de amenazas
+
+| Activo | Amenaza STRIDE | Vector concreto | Mitigación principal |
+|---|---|---|---|
+| **Credenciales de usuario** (`users.password_hash`) | Spoofing | Fuerza bruta o credential stuffing contra `POST /auth/login` | Rate limiting 5 intentos/min/IP + bloqueo temporal tras 10 fallos |
+| **Credenciales de usuario** | Information Disclosure | Timing attack al comparar passwords | BCrypt `checkpw()` — tiempo constante nativo |
+| **Credenciales de usuario** | Tampering | Inyección SQL en el login | Prepared statements (Spring Data JPA) |
+| **JWT access token** | Spoofing | Token robado por XSS | Access token en memoria, no en localStorage |
+| **JWT refresh token** | Spoofing | Cookie robada por red no cifrada | `httpOnly + Secure + SameSite=Strict`; solo HTTPS |
+| **Reservas** | Repudiation | Usuario niega haber creado/cancelado la reserva | `audit_log` inmutable con acción, usuario, IP y timestamp |
+| **Reservas** | Tampering | Usuario modifica la reserva de otro | Validación de `owner_id` en `ReservaApplicationService` + `@PreAuthorize` |
+| **Reservas** | Elevation of Privilege | Usuario regular accede a endpoint admin (`/api/admin/*`) | RBAC en Spring Security; `@PreAuthorize("hasRole('ADMIN')")` |
+| **Pagos Redsys** | Tampering | Manipulación del importe en el formulario de pago | El importe se calcula **solo en backend**; firma HMAC SHA-256 previene alteración |
+| **Pagos Redsys** | Repudiation | Webhook Redsys recibido dos veces (replay) | Idempotencia: `payments.redsys_order_id UNIQUE`; si ya existe y `status=PAID` → ignorar |
+| **Pagos Redsys** | Spoofing | Webhook falso que simula pago aprobado | Validación HMAC del webhook antes de procesar |
+| **Bot Telegram** | Spoofing | Mensaje falso al webhook del bot (no proviene de Telegram) | `X-Telegram-Bot-Api-Secret-Token` header obligatorio |
+| **Bot Telegram** | Spoofing | Suplantación de usuario en comandos del grupo | Vinculación previa `telegram_chat_id` ↔ cuenta PadelPro; comandos verificados por chat_id |
+| **OTP** | Spoofing | Fuerza bruta de 6 dígitos (10^6 combinaciones) | TTL 10 min + máximo 3 intentos por OTP; invalidación automática tras expiración |
+| **Datos personales** (`first_name`, `last_name`, `phone`, `email`) | Information Disclosure | Usuario accede a datos de otro usuario | Ownership check en todos los endpoints de lectura; RBAC estricto |
+| **System config** (`redsys_secret_key`, `telegram_bot_token`, `smtp_password`) | Information Disclosure | Endpoint admin expone secrets en claro | Campos cifrados en BD (AES-256); DTO no serializa secrets completos |
+| **Servidor On-Premise** | Denial of Service | Flood de requests a la API | Rate limiting en NGINX (límite de conexiones + requests por IP) |
+| **PostgreSQL** | Information Disclosure | Acceso directo a BD si se expone el puerto | Escucha solo en red Docker interna; nunca puerto 5432 expuesto al exterior |
+
+### 1.2 Riesgos residuales aceptados
+
+| Riesgo | Razón de aceptación |
+|---|---|
+| Disponibilidad del bot Telegram si cae la plataforma Telegram | Riesgo externo fuera del control del sistema; canal secundario (email) como fallback |
+| Disponibilidad del servidor único On-Premise | Contexto declarado: sin HA en v1.0; backups diarios como mitigación |
+| Phishing de credenciales fuera del sistema | Fuera del alcance técnico; mitigado con 2FA OTP |
+
+---
+
+## 2. Autenticación
+
+### 2.1 Mecanismo: JWT con doble token
+
+Se usa el modelo de **access token + refresh token**:
+
+- **Access token**: JWT de corta duración para autenticar cada request.
+- **Refresh token**: token opaco de larga duración, almacenado en BD, para obtener nuevos access tokens sin requerir credenciales.
+
+**Justificación del doble token vs sesión en servidor:** El sistema es stateless por diseño (arquitectura hexagonal, On-Premise). Un modelo de sesión en servidor requeriría Redis o sticky sessions, añadiendo complejidad operacional innecesaria para una instalación única.
+
+### 2.2 Algoritmo de firma JWT: HS256
+
+**Decisión:** `HS256` (HMAC con SHA-256) con secret de mínimo 256 bits.
+
+**Justificación:** PadelPro tiene **una sola instancia de backend** como único verificador de tokens. `RS256` está diseñado para arquitecturas distribuidas donde múltiples servicios independientes verifican tokens usando la clave pública sin compartir secretos. En un sistema monolítico On-Premise de instancia única, `RS256` añade complejidad de gestión de certificados (rotación, trust store) sin beneficio de seguridad adicional. `HS256` con un secret de 256+ bits almacenado como variable de entorno es criptográficamente sólido para este contexto.
+
+**Generación del secret:**
+```bash
+# En el servidor, al inicializar:
+openssl rand -hex 32  # Genera 256 bits en hexadecimal
+# Almacenar en APP_JWT_SECRET (variable de entorno, nunca en código ni en .env commiteado)
+```
+
+### 2.3 Lifetimes de tokens
+
+| Token | Lifetime | Justificación |
+|---|---|---|
+| **Access token** | **15 minutos** | Ventana de exposición mínima si el token es robado. El frontend renueva automáticamente con el refresh token antes del vencimiento. |
+| **Refresh token** | **7 días** | Equilibrio entre usabilidad (no forzar re-login frecuente en una app de club deportivo) y seguridad. Revocable individualmente. |
+
+> **Nota:** El README (sección 3.7) indica 8h para el access token. Se corrige a 15 minutos por seguridad. La experiencia de usuario se mantiene con la renovación automática por el refresh token.
+
+### 2.4 Payload del access token
+
+```json
+{
+  "sub": "42",
+  "login": "jdoe",
+  "role": "USER",
+  "iat": 1700000000,
+  "exp": 1700000900,
+  "jti": "uuid-único-por-token"
+}
+```
+
+El `jti` (JWT ID) permite blacklisting puntual si fuera necesario sin invalidar todos los tokens del usuario.
+
+### 2.5 Almacenamiento en cliente
+
+| Token | Almacenamiento | Justificación |
+|---|---|---|
+| **Access token** | **Memoria JavaScript** (variable en el closure del módulo de auth) | Evita persistencia entre pestañas/reinicios; no accesible por XSS (localStorage sería vulnerable) |
+| **Refresh token** | **Cookie `httpOnly + Secure + SameSite=Strict`** | Inaccesible desde JavaScript (protege contra XSS). `Secure` obliga HTTPS. `SameSite=Strict` elimina riesgo CSRF. |
+
+**Atributos de la cookie de refresh:**
+```
+Set-Cookie: refresh_token=<valor>; HttpOnly; Secure; SameSite=Strict; Path=/api/auth/refresh; Max-Age=604800
+```
+El `Path` restringido a `/api/auth/refresh` evita que la cookie viaje en cada request de la API.
+
+### 2.6 Política de contraseñas
+
+| Requisito | Valor | Justificación |
+|---|---|---|
+| Longitud mínima | **8 caracteres** | Según README; aceptable para una app de club |
+| Complejidad mínima | **1 mayúscula + 1 número** | Según README |
+| Longitud máxima | **128 caracteres** | Previene DoS por hash de passwords largas en BCrypt |
+| Hash | **BCrypt, cost factor 12** | Cost 12 ~250ms en hardware moderno (2024); equilibrio entre seguridad y UX |
+| Prohibición de reuso | No implementado en v1.0 | Decisión: complejidad no justificada para el contexto |
+
+### 2.7 Bloqueo de cuenta (protección anti-fuerza-bruta)
+
+| Evento | Umbral | Acción | Duración |
+|---|---|---|---|
+| Intentos fallidos por **IP** | **10 intentos en 10 min** | Bloqueo temporal de la IP en NGINX | 15 minutos |
+| Intentos fallidos por **usuario** | **10 intentos en 10 min** | Estado de cuenta `LOCKED` temporal | 15 minutos (automático unlock) |
+| Intentos fallidos de **OTP** | **3 intentos** | Invalidar OTP inmediatamente (`used=true`) | Requiere solicitar nuevo OTP |
+
+> El estado `LOCKED` es temporal y se gestiona en cache (no persiste en BD para no contaminar `users.status`). Se libera automáticamente pasados 15 minutos sin necesidad de intervención del admin.
+
+**Implementación en Spring:**
+```java
+// En AuthApplicationService, antes de BCrypt.checkpw():
+loginAttemptService.checkBlocked(ip, login);  // Lanza LoginBlockedException si bloqueado
+// Tras fallo:
+loginAttemptService.registerFailure(ip, login);
+```
+
+### 2.8 Rate limiting por endpoint de auth
+
+| Endpoint | Límite | Por |
+|---|---|---|
+| `POST /api/auth/login` | 5 req/min | IP |
+| `POST /api/auth/register` | 3 req/min | IP |
+| `POST /api/auth/password/solicitar-reset` | 3 req/min | IP |
+| `POST /api/auth/password/confirmar-reset` | 5 req/10min | IP + email |
+| `POST /api/auth/refresh` | 10 req/min | IP |
+
+Implementado en NGINX (`limit_req_zone`) como primera barrera, y en Spring con Bucket4j como segunda barrera (más granular).
+
+### 2.9 Flujo OTP vía Telegram (2FA para operaciones críticas)
+
+El OTP actúa como **segundo factor** para operaciones de alto impacto: confirmación de reserva desde Telegram, cancelación de reserva, y reset de contraseña.
+
+```
+1. Usuario solicita operación crítica (crear reserva, cancelar, reset password)
+2. Backend → OtpApplicationService.generar(userId, tipo)
+   a. Genera código de 6 dígitos (SecureRandom, no Math.random())
+   b. Persiste en otp_codes: {user_id, code_HASHED (SHA-256), type, expires_at=now()+10min, used=false}
+      ← El código se hashea en BD para proteger contra read-access a la BD
+   c. Envía código en claro al Telegram personal del usuario (TelegramClientAdapter)
+3. Usuario recibe OTP en Telegram y lo introduce en la app/bot
+4. Backend → OtpApplicationService.validar(userId, tipo, codigoIntroducido)
+   a. Consulta otp_codes WHERE user_id=? AND type=? AND used=false AND expires_at > now()
+   b. Compara SHA-256(codigoIntroducido) con code_hash almacenado
+   c. Si válido: UPDATE used=true, procede con la operación
+   d. Si inválido: incrementa contador de intentos; tras 3 fallos → UPDATE used=true (invalida)
+5. OTP expirado o usado nunca puede reutilizarse
+```
+
+> **Nota sobre hasheo del OTP:** Aunque el OTP es de corta duración (10 min), almacenarlo como SHA-256 protege contra un atacante con acceso de lectura a la BD que podría suplantar al usuario durante esa ventana.
+
+**Cómo se prueba:** `api-tester` debe verificar:
+- OTP expirado (>10 min) → 422
+- OTP ya usado → 422
+- OTP de otro usuario → 422 (no filtra si existe)
+- Cuarto intento fallido → OTP invalidado automáticamente
+
+---
+
+## 3. Autorización (RBAC)
+
+### 3.1 Roles del sistema
+
+Extraídos del README y backlog:
+
+| Rol | Descripción | Fuente |
+|---|---|---|
+| `ADMIN` | Administrador del club. Acceso total. Gestiona usuarios, reservas, pagos y configuración. | README §1.4, backlog EP-05 |
+| `USER` | Jugador registrado. Gestiona sus propias reservas y pagos. | README §2.x |
+
+> **Roles sin implementar en v1.0 (marcado para validación):** No existe rol `MANAGER_CLUB` o `INVITADO`. El usuario casual (sin cuenta) que participa en reservas via Telegram **no tiene acceso a la API web** y no necesita rol.
+
+### 3.2 Matriz RBAC completa
+
+| Recurso / Acción | PUBLIC | USER | ADMIN | SYSTEM |
+|---|:---:|:---:|:---:|:---:|
+| `POST /api/auth/login` | ✅ | ✅ | ✅ | — |
+| `POST /api/auth/register` | ✅ | — | — | — |
+| `POST /api/auth/refresh` | ✅ | ✅ | ✅ | — |
+| `POST /api/auth/logout` | — | ✅ | ✅ | — |
+| `POST /api/auth/password/solicitar-reset` | ✅ | ✅ | ✅ | — |
+| `POST /api/auth/password/confirmar-reset` | ✅ | ✅ | ✅ | — |
+| `GET /api/usuarios/me` | — | ✅ | ✅ | — |
+| `PATCH /api/usuarios/me` | — | ✅ | ✅ | — |
+| `GET /api/admin/usuarios` | — | ❌ | ✅ | — |
+| `POST /api/admin/usuarios` | — | ❌ | ✅ | — |
+| `GET /api/admin/usuarios/{id}` | — | ❌ | ✅ | — |
+| `PATCH /api/admin/usuarios/{id}` | — | ❌ | ✅ | — |
+| `PATCH /api/admin/usuarios/{id}/aprobar` | — | ❌ | ✅ | — |
+| `DELETE /api/admin/usuarios/{id}` | — | ❌ | ✅ | — |
+| `GET /api/reservas/disponibles` | — | ✅ | ✅ | — |
+| `GET /api/reservas` | — | ✅ (propias) | ✅ | — |
+| `POST /api/reservas` | — | ✅ | ✅ | — |
+| `GET /api/reservas/{id}` | — | ✅ (si owner o participante) | ✅ | — |
+| `DELETE /api/reservas/{id}` | — | ✅ (solo si owner) | ✅ | — |
+| `POST /api/reservas/{id}/unirse` | — | ✅ | ✅ | — |
+| `GET /api/admin/reservas` | — | ❌ | ✅ | — |
+| `PATCH /api/admin/reservas/{id}/estado` | — | ❌ | ✅ | — |
+| `GET /api/pagos` | — | ✅ (propios) | ✅ | — |
+| `POST /api/pagos/iniciar` | — | ✅ (si owner) | ✅ | — |
+| `POST /api/admin/pagos/{reservaId}/efectivo` | — | ❌ | ✅ | — |
+| `GET /api/admin/pagos` | — | ❌ | ✅ | — |
+| `POST /api/otp/verificar` | — | ✅ | ✅ | — |
+| `POST /api/bot/telegram` (webhook Telegram) | — | — | — | ✅ (Telegram) |
+| `POST /api/pagos/webhook` (webhook Redsys) | — | — | — | ✅ (Redsys) |
+
+**Leyenda:** ✅ = ALLOW · ❌ = DENY explícito · — = No aplica · SYSTEM = validación por header, no JWT
+
+### 3.3 Reglas de negocio que requieren autorización fina (más allá del rol)
+
+Estas reglas no se pueden expresar solo con RBAC y requieren validación a nivel de servicio:
+
+| ID | Regla | Implementación |
+|---|---|---|
+| **RN-AUTH-01** | Un `USER` solo puede ver (`GET /api/reservas/{id}`) una reserva si es `owner_id` o aparece en `participants` | `ReservaApplicationService.obtenerReserva()` verifica ownership + participación antes de devolver |
+| **RN-AUTH-02** | Un `USER` solo puede cancelar (`DELETE /api/reservas/{id}`) su propia reserva (`owner_id = authenticatedUserId`) | `ReservaApplicationService.cancelarReserva()` verifica `reservation.ownerId == authenticatedUserId` |
+| **RN-AUTH-03** | Un `USER` no puede unirse dos veces a la misma reserva | `ReservaApplicationService.unirseAReserva()` verifica unicidad en `participants` para ese `user_id` |
+| **RN-AUTH-04** | Un `USER` solo puede iniciar pago de una reserva de la que es `owner_id` | `PagoApplicationService.iniciarPago()` verifica `reservation.ownerId == authenticatedUserId` |
+| **RN-AUTH-05** | Un `ADMIN` no puede desactivarse a sí mismo | `UsuarioApplicationService.desactivar()` verifica `targetId != authenticatedUserId` |
+
+### 3.4 Implementación técnica en Spring Security
+
+```java
+// SecurityConfig.java
+http
+  .authorizeHttpRequests(auth -> auth
+    .requestMatchers("/api/auth/**").permitAll()
+    .requestMatchers("/api/bot/telegram").permitAll()  // Verificado por header, ver §7
+    .requestMatchers("/api/pagos/webhook").permitAll()  // Verificado por HMAC, ver §6
+    .requestMatchers("/api/admin/**").hasRole("ADMIN")
+    .anyRequest().authenticated()
+  )
+  .sessionManagement(s -> s.sessionCreationPolicy(STATELESS))
+  .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
+
+// Autorización fina — en la capa Application (no en Controller):
+// NO usar @PreAuthorize con lógica de ownership en Controllers.
+// La validación de ownership siempre en el ApplicationService para mantener
+// la lógica de negocio en el dominio.
+```
+
+---
+
+## 4. Gestión de sesiones
+
+### 4.1 Estrategia: Stateless con JWT + revocación selectiva por refresh token
+
+El acceso es **completamente stateless** a nivel de access token: el backend no mantiene ningún estado de sesión. La revocación granular se gestiona a través del refresh token almacenado en BD.
+
+**Justificación frente a sesión en servidor:** El sistema es de instancia única On-Premise; no hay balanceador que requiera sticky sessions. El modelo stateless simplifica el despliegue Docker Compose y elimina la dependencia de Redis para sesiones.
+
+### 4.2 Revocación de tokens
+
+| Tipo | Revocación |
+|---|---|
+| **Access token** | No revocable individualmente (stateless). Expiración natural en 15 min. Si se requiere revocación inmediata (ej. logout, cambio de contraseña), el refresh token se invalida y los access tokens quedan "huérfanos" expirando en ≤15 min. Este riesgo es aceptado dado el lifetime corto. |
+| **Refresh token** | Revocable individualmente: `UPDATE refresh_tokens SET revoked=true WHERE token_hash=SHA256(token)`. La invalidación es inmediata — el próximo intento de refresh devuelve 401. |
+
+### 4.3 Logout efectivo
+
+```
+POST /api/auth/logout:
+1. Leer refresh_token de la cookie httpOnly
+2. Computar SHA-256(token) → token_hash
+3. UPDATE refresh_tokens SET revoked=true WHERE token_hash=?
+4. Set-Cookie: refresh_token=; Max-Age=0; HttpOnly; Secure; Path=/api/auth/refresh
+5. El access token expira en ≤15 min (riesgo residual aceptado)
+```
+
+Para escenarios de compromiso de cuenta (ej. admin detecta sesión sospechosa), el admin puede revocar todos los refresh tokens del usuario:
+
+```sql
+UPDATE refresh_tokens SET revoked=true WHERE user_id = :userId;
+```
+
+### 4.4 Rotación de refresh tokens
+
+Opcional en v1.0 (se documenta como decisión abierta). Si se implementa: al usar el refresh token, se genera uno nuevo y se invalida el anterior. Detecta reutilización de tokens robados (el segundo uso del token original falla).
+
+---
+
+## 5. Protección frente a OWASP API Security Top 10
+
+### API1 — Broken Object Level Authorization (BOLA)
+
+**Riesgo en PadelPro:** Un `USER` podría acceder a `GET /api/reservas/99` siendo 99 una reserva de otro usuario si el backend no verifica ownership.
+
+**Mitigación:**
+- Todos los endpoints con `{id}` en la ruta verifican ownership en la capa Application antes de devolver datos (RN-AUTH-01, RN-AUTH-04).
+- Se usa el `userId` del JWT (no un parámetro de la petición) como origen del ownership check.
+
+**Cómo se prueba:** `api-tester` crea reserva con usuario A (id=1), luego intenta `GET /api/reservas/{id}` con token de usuario B. Debe responder 403, no 200 ni 404.
+
+---
+
+### API2 — Broken Authentication
+
+**Riesgo en PadelPro:** Credenciales débiles, tokens de larga duración, almacenamiento inseguro del refresh token.
+
+**Mitigación:**
+- BCrypt cost 12 en passwords (§2.6).
+- Access token 15 min; refresh token 7 días.
+- Refresh token en cookie `httpOnly+Secure+SameSite=Strict` (§2.5).
+- Rate limiting + bloqueo anti-fuerza-bruta (§2.7, §2.8).
+- `refresh_tokens` almacena hash SHA-256 del token, no el token en claro.
+
+**Cómo se prueba:**
+- Intentar 11 logins fallidos seguidos → verificar bloqueo (429 o 403).
+- Intentar usar un refresh token revocado → 401.
+- Intentar pasar el refresh token como Bearer en Authorization header → 401.
+
+---
+
+### API3 — Broken Object Property Level Authorization
+
+**Riesgo en PadelPro:** Un `USER` podría enviar en `PATCH /api/usuarios/me` el campo `role: "ADMIN"` o `status: "ACTIVE"` y que el backend lo acepte.
+
+**Mitigación:**
+- Los DTOs de entrada de endpoints USER usan `@JsonIgnoreProperties` y solo exponen los campos permitidos (`email`, `phone`, `name`, `password`). Spring Jackson no mapea campos no declarados en el DTO.
+- La asignación de `role` y `status` solo es posible desde `PATCH /api/admin/usuarios/{id}`.
+
+**Cómo se prueba:** `api-tester` envía `PATCH /api/usuarios/me` con body `{"role":"ADMIN"}` con token USER. Verificar que el rol no cambia en BD.
+
+---
+
+### API4 — Unrestricted Resource Consumption
+
+**Riesgo en PadelPro:** Flood de requests de creación de reservas, generación masiva de OTPs, o paginación sin límites.
+
+**Mitigación:**
+- Rate limiting en NGINX y Bucket4j (§2.8).
+- Todas las listas devueltas están paginadas (`page + pageSize`, máximo 100 por página).
+- La generación de OTP invalida automáticamente el OTP anterior del mismo tipo antes de crear uno nuevo (no se acumulan OTPs activos del mismo tipo).
+- El importe del pago siempre se calcula en backend; no hay loop de complejidad O(n) en queries sin límite.
+
+**Cómo se prueba:** Enviar 100 OTPs de tipo RESERVATION_CONFIRM en 1 minuto para el mismo usuario → verificar que el rate limiter actúa.
+
+---
+
+### API5 — Broken Function Level Authorization
+
+**Riesgo en PadelPro:** Un `USER` accede a endpoints `POST /api/admin/usuarios` o `GET /api/admin/pagos`.
+
+**Mitigación:**
+- Todos los endpoints bajo `/api/admin/**` requieren `hasRole('ADMIN')` en `SecurityConfig` (§3.4).
+- El prefijo `/api/admin/` es la barrera explícita; no hay función admin fuera de ese prefijo.
+- Los webhooks (Telegram, Redsys) tienen su propia validación por header, nunca JWT.
+
+**Cómo se prueba:** `api-tester` intenta `GET /api/admin/usuarios` con token USER → debe responder 403, no 200.
+
+---
+
+### API6 — Unrestricted Access to Sensitive Business Flows
+
+**Riesgo en PadelPro:** Un script automatizado reserva todas las franjas disponibles; un actor malicioso genera OTPs masivos para saturar el servicio de Telegram.
+
+**Mitigación:**
+- Rate limiting específico en `POST /api/reservas`: 5 req/min/usuario.
+- Rate limiting en generación de OTP: 1 OTP por tipo cada 60 segundos por usuario.
+- Un usuario `INACTIVE` o `PENDING` no puede crear reservas (validado en `UsuarioApplicationService`).
+- El bloqueo de cuenta (§2.7) previene automatización de login.
+
+**Cómo se prueba:** Intentar crear 10 reservas seguidas con el mismo usuario → verificar que el rate limiter actúa tras la 5ª.
+
+---
+
+### API7 — Server Side Request Forgery (SSRF)
+
+**Riesgo en PadelPro:** Bajo. PadelPro no hace requests a URLs controladas por el usuario. Los únicos outbound HTTP son a Redsys (URL hardcodeada en config), Telegram API (URL fija), y SMTP. Sin embargo, el `payment_url` de Redsys se genera en backend y no acepta entrada del usuario para construirlo.
+
+**Mitigación:**
+- Las URLs de Redsys y Telegram API son constantes en `application.yml`, nunca provienen de input de usuario.
+- El webhook de Redsys que llega al servidor no puede disparar requests salientes desde el backend.
+- Whitelist de IPs de Redsys para el endpoint `POST /api/pagos/webhook` en NGINX (ver §6.4).
+
+**Cómo se prueba:** Verificar que ningún endpoint acepta un parámetro `url` o `redirect` que el backend consuma para hacer requests salientes.
+
+---
+
+### API8 — Security Misconfiguration
+
+**Riesgo en PadelPro:** Endpoints de actuator expuestos, Swagger UI en producción, headers HTTP por defecto de Spring Boot sin hardening.
+
+**Mitigación:**
+- `Spring Actuator` limitado a `health` y `info` en producción; resto deshabilitados.
+- `Swagger UI` (`/swagger-ui.html`) deshabilitado en perfil `prod`; solo disponible en `dev`.
+- Cabeceras de seguridad configuradas (ver §8).
+- Puerto 5432 (PostgreSQL) no expuesto fuera de la red Docker.
+- Puerto 8080 (backend) no expuesto directamente; solo accesible via NGINX en :443.
+
+**Cómo se prueba:** `api-tester` verifica: `/actuator/env` → 404 en prod. `/swagger-ui.html` → 404 en prod. Respuesta incluye cabeceras `X-Content-Type-Options`, `X-Frame-Options`, `Strict-Transport-Security`.
+
+---
+
+### API9 — Improper Inventory Management
+
+**Riesgo en PadelPro:** Versiones anteriores de la API expuestas accidentalmente; el webhook de Telegram accesible sin validación de secret.
+
+**Mitigación:**
+- Solo existe `/api/v1/` (o sin versión en v1.0). No hay endpoints legacy.
+- El webhook de Telegram (`POST /api/bot/telegram`) solo acepta requests con `X-Telegram-Bot-Api-Secret-Token` válido.
+- El webhook de Redsys (`POST /api/pagos/webhook`) solo acepta IPs de Redsys (whitelist en NGINX).
+- OpenAPI spec generada automáticamente; solo documenta endpoints activos.
+
+**Cómo se prueba:** `api-tester` verifica que `POST /api/bot/telegram` sin el header secret responde 403.
+
+---
+
+### API10 — Unsafe Consumption of APIs
+
+**Riesgo en PadelPro:** El backend consume Telegram API y Redsys. Si Telegram devuelve datos maliciosos (JSON inesperado), podría causar comportamiento no esperado.
+
+**Mitigación:**
+- Las respuestas de Telegram API se deserializan en DTOs tipados con `@JsonIgnoreProperties(ignoreUnknown = true)`. Ningún campo de la respuesta de Telegram se ejecuta como código.
+- La respuesta del webhook de Redsys se valida HMAC antes de procesar cualquier campo.
+- Timeouts configurados en los clientes HTTP salientes: 5s connect, 10s read (evita que un servicio externo lento bloquee threads).
+- El contenido de mensajes Telegram (texto libre del usuario) se sanitiza antes de cualquier uso en queries (prepared statements) o en UI.
+
+**Cómo se prueba:** Enviar un webhook de Telegram con JSON malformado o campos extra → verificar que el backend responde 200 (absorbe el error) sin lanzar excepción no controlada.
+
+---
+
+## 6. Pasarela de pago Redsys
+
+### 6.1 Flujo HMAC SHA-256 paso a paso
+
+Redsys usa un esquema de firma basado en 3DES + HMAC-SHA256. Todo el proceso ocurre **exclusivamente en el backend**.
+
+```
+BACKEND (PagoApplicationService):
+
+1. Preparar parámetros de la transacción:
+   {
+     "DS_MERCHANT_AMOUNT":    "1500",           ← Importe en céntimos (NUMERIC(12,2) × 100)
+     "DS_MERCHANT_ORDER":     "ORDER-<uuid>",   ← redsys_order_id (único, UUID truncado a 12 chars)
+     "DS_MERCHANT_MERCHANTCODE": "<code>",
+     "DS_MERCHANT_TERMINAL":  "001",
+     "DS_MERCHANT_TRANSACTIONTYPE": "0",        ← 0 = pago estándar
+     "DS_MERCHANT_CURRENCY":  "978",            ← EUR
+     "DS_MERCHANT_URLOK":     "https://padelpro.local/pago/ok",
+     "DS_MERCHANT_URLKO":     "https://padelpro.local/pago/ko",
+     "DS_MERCHANT_URL":       "https://padelpro.local/api/pagos/webhook"
+   }
+
+2. DS_MERCHANT_PARAMETERS = Base64(JSON.stringify(params))
+   ← Encoding URL-safe, sin padding alterado
+
+3. Derivar clave de sesión Kc:
+   Kc = 3DES-CBC(key=Base64Decode(MERCHANT_SECRET_KEY), data=DS_MERCHANT_ORDER)
+   ← MERCHANT_SECRET_KEY viene de system_config.redsys_secret_key (descifrado AES-256)
+
+4. Calcular firma:
+   DS_SIGNATURE = Base64(HMAC-SHA256(key=Kc, data=DS_MERCHANT_PARAMETERS))
+
+5. Enviar al frontend solo: {DS_MERCHANT_PARAMETERS, DS_SIGNATURE, DS_SIGNATUREVERION="HMAC_SHA256_V1"}
+   ← El frontend solo recibe los parámetros firmados para mostrar el formulario de redirección
+   ← Nunca se envía el secret al frontend
+
+6. El usuario completa el pago en el TPV virtual de Redsys (redirección externa)
+```
+
+### 6.2 Validación del webhook de notificación
+
+```
+REDSYS → POST /api/pagos/webhook:
+{
+  "Ds_SignatureVersion": "HMAC_SHA256_V1",
+  "Ds_MerchantParameters": "<base64>",
+  "Ds_Signature": "<base64>"
+}
+
+BACKEND (PagoWebhookAdapter):
+
+1. VALIDACIÓN ORIGEN (primera barrera):
+   - Verificar que la IP del request está en la whitelist de IPs de Redsys (NGINX)
+   - Si no pasa: responder 403, registrar en audit_log
+
+2. VALIDACIÓN HMAC (segunda barrera):
+   a. Decodificar Ds_MerchantParameters (Base64 → JSON)
+   b. Extraer DS_MERCHANT_ORDER del JSON
+   c. Derivar Kc = 3DES-CBC(MERCHANT_SECRET_KEY, DS_MERCHANT_ORDER)
+   d. Calcular expected_sig = Base64(HMAC-SHA256(Kc, Ds_MerchantParameters))
+   e. Comparar Ds_Signature == expected_sig (comparación de strings constante en tiempo)
+   f. Si no coincide: responder 200 (no revelar fallo), registrar en audit_log con alerta
+
+3. IDEMPOTENCIA:
+   a. Buscar payments WHERE redsys_order_id = Ds_Merchant_Order
+   b. Si ya está en status=PAID: responder 200 sin reprocesar (replay attack)
+   c. Si no existe: ERROR — inconsistencia (registrar alerta)
+
+4. VALIDACIÓN DE NEGOCIO:
+   a. Extraer Ds_Response del JSON (código de respuesta Redsys)
+   b. Si Ds_Response IN ('0000'..'0099'): pago aprobado
+   c. Cualquier otro valor: pago rechazado/error
+
+5. TRANSICIÓN DE ESTADO (en @Transactional):
+   a. UPDATE payments SET status='PAID', paid_at=now(), transaction_id=Ds_AuthorisationCode
+   b. INSERT audit_log (action='PAYMENT_CONFIRMED', entity_id=payment_id)
+   c. Notify usuario via Telegram (asíncrono, no bloquea la respuesta)
+
+6. Responder 200 OK a Redsys (siempre, incluso en error — Redsys reintentará si no recibe 200)
+```
+
+### 6.3 Qué se almacena vs. qué NO (PCI-DSS lite)
+
+PadelPro **no procesa ni almacena datos de tarjeta**. Todo ocurre en el entorno de Redsys.
+
+| Campo | Almacenado | Dónde |
+|---|---|---|
+| `Ds_Merchant_Order` (referencia de orden) | ✅ Sí | `payments.redsys_order_id` |
+| `Ds_AuthorisationCode` (autorización banco) | ✅ Sí | `payments.transaction_id` |
+| Número de tarjeta (PAN) | ❌ Nunca | — |
+| CVV / CVC | ❌ Nunca | — |
+| Fecha de caducidad | ❌ Nunca | — |
+| Titular de la tarjeta | ❌ Nunca | — |
+| `Ds_MerchantParameters` completo | ⚠️ Solo en audit_log con PII eliminado | `audit_log.details` |
+
+### 6.4 Reconciliación: qué pasa si el webhook no llega
+
+| Escenario | Detección | Acción |
+|---|---|---|
+| Webhook retrasado (Redsys reintenta hasta 10 veces en 24h) | `payments.status=IN_PROGRESS` y `paid_at IS NULL` pasadas 2h | Job de reconciliación: consulta estado de la orden en Redsys API cada hora |
+| Webhook nunca llega tras 24h | `payments.status=IN_PROGRESS` y `created_at < now()-24h` | Alerta al admin en dashboard; el admin puede verificar manualmente y registrar como efectivo |
+| Pago aprobado en Redsys pero BD en PENDING | Dashboard de pagos pendientes con fecha antigua | Admin consulta en portal Redsys y actualiza manualmente o espera reconciliación |
+
+---
+
+## 7. Bot Telegram
+
+### 7.1 Verificación de origen de los mensajes
+
+Telegram permite configurar un `secret_token` al registrar el webhook. Este token se envía en el header `X-Telegram-Bot-Api-Secret-Token` en cada llamada al webhook.
+
+```java
+// BotTelegramAdapter.java
+@PostMapping("/api/bot/telegram")
+public ResponseEntity<Void> handleUpdate(
+    @RequestHeader("X-Telegram-Bot-Api-Secret-Token") String secretToken,
+    @RequestBody TelegramUpdate update) {
+
+  if (!secretToken.equals(appProperties.getTelegramWebhookSecret())) {
+    auditService.registrar("TELEGRAM_WEBHOOK_INVALID_SECRET", ...);
+    return ResponseEntity.status(403).build();
+  }
+  // Procesar update
+}
+```
+
+El `TELEGRAM_WEBHOOK_SECRET` es una cadena aleatoria de 256 bits generada al registrar el bot y almacenada en `system_config.telegram_bot_token` (cifrado). Nunca se expone en logs.
+
+### 7.2 Flujo OTP completo para operaciones vía bot
+
+```
+1. Usuario escribe en el GRUPO: "reserva de pista 15/06/2025 18:00 90min"
+2. Bot recibe el mensaje (webhook validado por secret_token)
+3. BotTelegramAdapter identifica el chat_id del remitente
+4. MensajeriaApplicationService busca en users WHERE telegram_chat_id = chat_id
+   → Si no existe: responde "Vincula primero tu cuenta en padelpro.local/perfil"
+   → Si existe: procede
+5. Verifica disponibilidad (ReservaUseCase.listarDisponibles)
+6. OtpApplicationService.generar(userId, 'RESERVATION_CONFIRM')
+7. TelegramClientAdapter.enviarDirecto(chat_id_del_usuario, "Tu código: XXXXXX")
+   ← Envío al CHAT PERSONAL del usuario, no al grupo
+8. Bot responde en el grupo: "✅ Código enviado a tu Telegram personal. Tienes 10 minutos."
+9. Usuario responde en el grupo: el OTP
+10. Bot valida OTP (OtpApplicationService.validar)
+11. Si válido: INSERT reserva, publica confirmación en el grupo
+12. Si inválido (3 intentos): OTP invalidado, respuesta de error en el grupo
+```
+
+### 7.3 Vinculación cuenta PadelPro ↔ chat_id Telegram
+
+La vinculación es el paso de seguridad más delicado: garantiza que el `chat_id` de Telegram corresponde a la cuenta correcta de PadelPro.
+
+**Flujo de vinculación:**
+
+```
+1. Usuario accede a su perfil en la web (autenticado con JWT)
+2. Pulsa "Vincular Telegram"
+3. Backend genera un código de vinculación temporal (6 dígitos, TTL 15 min):
+   INSERT otp_codes (user_id, code_hash, type='TELEGRAM_LINK', expires_at=now()+15min)
+4. La web muestra: "Envía este código al bot @PadelProBot: /vincular XXXXXX"
+5. Usuario abre Telegram y envía: /vincular XXXXXX al bot (@PadelProBot)
+6. Bot recibe el chat_id del usuario y el código
+7. Backend valida el OTP tipo TELEGRAM_LINK:
+   SELECT ... WHERE code_hash=SHA256(XXXXXX) AND type='TELEGRAM_LINK' AND used=false AND expires_at>now()
+8. Si válido:
+   UPDATE users SET telegram_chat_id=:chatId, telegram_linked_at=now() WHERE id=:userId
+   UPDATE otp_codes SET used=true WHERE id=:otpId
+   Bot responde: "✅ Cuenta vinculada correctamente"
+9. Si ya existe otro usuario con ese chat_id:
+   Bot responde: "Este Telegram ya está vinculado a otra cuenta. Contacta con el administrador."
+```
+
+**Revocación de la vinculación:**
+
+```
+PATCH /api/usuarios/me con body {"telegramUnlink": true}
+→ UPDATE users SET telegram_chat_id=NULL, telegram_linked_at=NULL WHERE id=:userId
+→ Invalida todos los OTP activos del usuario
+→ Registra en audit_log
+```
+
+### 7.4 Comandos sensibles en el grupo y validación de permisos
+
+| Comando en el grupo | Validación requerida |
+|---|---|
+| `reserva de pista DD/MM/AA HH:MM dur` | `telegram_chat_id` vinculado + `users.status=ACTIVE` |
+| `cancelacion reserva DD/MM/AA HH:MM` | `telegram_chat_id` vinculado + `owner_id` de la reserva = `user_id` de la cuenta |
+| Unirse a reserva (respuesta al mensaje del grupo) | Sin cuenta requerida; solo `external_name` registrado |
+
+El bot **nunca ejecuta acciones administrativas** (crear usuarios, cambiar precios, etc.) independientemente de quién escriba en el grupo. Los comandos admin solo están disponibles en la interfaz web con autenticación JWT.
+
+---
+
+## 8. CORS, CSP y cabeceras de seguridad
+
+### 8.1 Política CORS
+
+```java
+// CorsConfig.java (Spring)
+@Bean
+public CorsConfigurationSource corsConfigurationSource() {
+  CorsConfiguration config = new CorsConfiguration();
+
+  // Orígenes por entorno (inyectados desde application.yml)
+  config.setAllowedOrigins(allowedOrigins);  // Ver tabla inferior
+  config.setAllowedMethods(List.of("GET","POST","PATCH","DELETE","OPTIONS"));
+  config.setAllowedHeaders(List.of("Authorization","Content-Type","X-Requested-With"));
+  config.setAllowCredentials(true);  // Necesario para cookies httpOnly
+  config.setMaxAge(3600L);
+
+  UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+  source.registerCorsConfiguration("/api/**", config);
+  return source;
+}
+```
+
+| Entorno | Orígenes permitidos |
+|---|---|
+| **DES** | `http://localhost:3000`, `http://localhost:5173` |
+| **PRE** | `https://pre.padelpro.local` |
+| **PRO** | `https://padelpro.local` |
+
+> Los webhooks de Telegram y Redsys **no tienen restricción CORS** (son llamadas server-to-server, no requests de navegador).
+
+### 8.2 Cabeceras de seguridad HTTP
+
+Configuradas en NGINX (primera barrera) y en Spring Security (segunda barrera):
+
+```nginx
+# nginx.conf — bloque server
+add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; form-action 'self' https://sis-t.redsys.es https://sis.redsys.es;" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header X-Frame-Options "DENY" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+add_header Permissions-Policy "geolocation=(), camera=(), microphone=()" always;
+```
+
+| Cabecera | Valor | Protección |
+|---|---|---|
+| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains; preload` | Fuerza HTTPS durante 1 año |
+| `Content-Security-Policy` | Ver arriba | XSS, clickjacking, inyección de recursos |
+| `X-Content-Type-Options` | `nosniff` | MIME sniffing |
+| `X-Frame-Options` | `DENY` | Clickjacking |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` | Fuga de URLs privadas |
+| `Permissions-Policy` | `geolocation=(), camera=(), microphone=()` | APIs de navegador no necesarias |
+
+**Nota CSP para Redsys:** El `form-action` incluye los dominios de Redsys (`sis-t.redsys.es` para tests, `sis.redsys.es` para producción) porque el pago se inicia con un formulario POST redirigido.
+
+---
+
+## 9. Cifrado
+
+### 9.1 En tránsito
+
+- **TLS 1.2 mínimo, 1.3 preferido.** Configurado en NGINX.
+- **HSTS** activo con `preload` (ver §8.2).
+- Certificado SSL: **Let's Encrypt** vía Certbot, renovación automática.
+- Comunicación entre contenedores Docker (backend ↔ PostgreSQL): red Docker interna; no requiere TLS (mismo host).
+- Comunicación saliente (backend → Telegram API, backend → Redsys): HTTPS obligatorio; el cliente HTTP valida el certificado del servidor (no deshabilitar `ssl.verify=false`).
+
+**Suites de cifrado TLS permitidas en NGINX:**
+
+```nginx
+ssl_protocols TLSv1.2 TLSv1.3;
+ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305';
+ssl_prefer_server_ciphers off;
+```
+
+### 9.2 En reposo
+
+| Dato | Cifrado | Implementación |
+|---|---|---|
+| `system_config.redsys_secret_key` | AES-256-GCM | `@Convert(converter = EncryptedStringConverter.class)` en JPA |
+| `system_config.telegram_bot_token` | AES-256-GCM | Idem |
+| `system_config.smtp_password` | AES-256-GCM | Idem |
+| `users.password_hash` | BCrypt | BCrypt no es reversible; no requiere gestión de clave |
+| `otp_codes.code_hash` | SHA-256 | Hash de un solo sentido; no requiere gestión de clave |
+| `refresh_tokens.token_hash` | SHA-256 | Idem |
+| Resto de la BD | Sin cifrado de columna | Protección por acceso restringido al servidor (red Docker) |
+
+**Clave de cifrado AES-256:** Almacenada en `APP_ENCRYPTION_KEY` (variable de entorno del contenedor backend). Generada con `openssl rand -base64 32`. Nunca en el código ni en archivos commiteados.
+
+**Cifrado de BD a nivel de tablespace:** No implementado en v1.0 (se confía en el control de acceso al servidor On-Premise). Si el servidor es compartido o el riesgo físico es relevante, usar `pgcrypto` o cifrado de disco completo (luks/dm-crypt en el host Linux).
+
+### 9.3 Gestión de secrets
+
+| Secret | Almacenamiento DES | Almacenamiento PRO |
+|---|---|---|
+| `APP_JWT_SECRET` | `.env` (no commiteado, en `.gitignore`) | Variable de entorno del container (Docker Compose `.env` en servidor, acceso restringido) |
+| `APP_ENCRYPTION_KEY` | `.env` | Idem |
+| `REDSYS_SECRET_KEY` | `system_config` en BD (cifrado AES) | Idem |
+| `TELEGRAM_BOT_TOKEN` | `system_config` en BD (cifrado AES) | Idem |
+| `SMTP_PASSWORD` | `system_config` en BD (cifrado AES) | Idem |
+| `DB_PASSWORD` | `.env` | Variable de entorno del container |
+
+**Reglas de secrets:**
+1. Ningún secret en código fuente ni en repositorio Git.
+2. `.env` en `.gitignore`; `.env.example` con placeholders en el repo.
+3. Rotación semestral de `APP_JWT_SECRET` (invalida todos los refresh tokens activos; usuarios deben re-autenticarse).
+4. Rotación de `REDSYS_SECRET_KEY` coordinada con el banco.
+
+---
+
+## 10. Auditoría y logging
+
+### 10.1 Eventos auditados
+
+Todos los eventos se persisten en la tabla `audit_log` (ver `docs/data-model.md §3.7`).
+
+| Evento | `action` en audit_log | Prioridad |
+|---|---|---|
+| Login exitoso | `USER_LOGIN_SUCCESS` | Alta |
+| Fallo de login | `USER_LOGIN_FAILED` | Alta |
+| Bloqueo de cuenta | `USER_ACCOUNT_LOCKED` | Alta |
+| Registro de usuario | `USER_REGISTERED` | Alta |
+| Aprobación de cuenta (admin) | `USER_APPROVED` | Alta |
+| Desactivación de usuario (admin) | `USER_DEACTIVATED` | Alta |
+| Cambio de contraseña | `PASSWORD_CHANGED` | Alta |
+| Reset de contraseña | `PASSWORD_RESET` | Alta |
+| Cambio de rol (admin) | `USER_ROLE_CHANGED` | Alta |
+| Vinculación Telegram | `TELEGRAM_LINKED` | Media |
+| Desvinculación Telegram | `TELEGRAM_UNLINKED` | Media |
+| OTP generado | `OTP_GENERATED` | Media |
+| OTP validado (OK) | `OTP_VALIDATED` | Media |
+| OTP fallido | `OTP_FAILED` | Alta |
+| Creación de reserva | `RESERVATION_CREATED` | Media |
+| Cancelación de reserva | `RESERVATION_CANCELLED` | Media |
+| Unión a reserva | `RESERVATION_JOINED` | Media |
+| Cambio de estado de reserva (admin) | `RESERVATION_STATUS_CHANGED` | Alta |
+| Inicio de pago | `PAYMENT_INITIATED` | Alta |
+| Confirmación de pago (webhook) | `PAYMENT_CONFIRMED` | Alta |
+| Pago rechazado (webhook) | `PAYMENT_REJECTED` | Alta |
+| Pago efectivo registrado (admin) | `PAYMENT_CASH_REGISTERED` | Alta |
+| Webhook Redsys con firma inválida | `PAYMENT_WEBHOOK_INVALID_SIGNATURE` | Crítica |
+| Webhook Telegram con secret inválido | `TELEGRAM_WEBHOOK_INVALID_SECRET` | Crítica |
+| Actualización de system_config | `CONFIG_UPDATED` | Alta |
+| Anonimización de usuario (RGPD) | `USER_ANONYMIZED` | Crítica |
+| Acceso admin a datos de usuario | `ADMIN_USER_DATA_ACCESS` | Alta |
+
+### 10.2 Qué sí / qué NO se loguea
+
+| Categoría | ¿Se loguea? | Razón |
+|---|---|---|
+| Contraseñas (en claro o hash) | ❌ Nunca | Dato sensible; su log constituye brecha |
+| Tokens JWT (access o refresh) | ❌ Nunca | Si el log se compromete, los tokens son válidos |
+| Códigos OTP en claro | ❌ Nunca | Equivalente a publicar el segundo factor |
+| `redsys_secret_key`, `telegram_bot_token` | ❌ Nunca | Credenciales críticas |
+| PAN / CVV (nunca llegan al backend) | ❌ Nunca | PCI-DSS |
+| IPs de origen | ✅ Sí | Investigación de incidentes; retención 2 años |
+| User-Agent | ✅ Sí | Contexto de incidentes |
+| `entity_id` de la entidad afectada | ✅ Sí | Trazabilidad |
+| Detalle de cambios (JSON diff) | ✅ Sí, sin datos sensibles | Trazabilidad en `audit_log.details` |
+| Respuesta de la pasarela Redsys | ✅ `Ds_Response` y `Ds_AuthorisationCode` | Reconciliación financiera |
+
+### 10.3 Logging en aplicación (SLF4J + Logback)
+
+```
+Niveles por entorno:
+  DES:  DEBUG
+  PRE:  INFO
+  PRO:  WARN (+ ERROR siempre)
+
+NO usar Logger.debug() para datos de usuario en código de producción.
+Usar MDC para propagar userId, requestId en todos los logs del request.
+```
+
+### 10.4 Centralización de logs
+
+En v1.0 On-Premise: logs de Docker Compose en `/var/log/padelpro/` con rotación diaria (7 días de retención en fichero, 2 años en `audit_log` de BD).
+
+Si se escala: ELK stack o Loki/Grafana en el mismo servidor. No se envían logs a servicios cloud externos en v1.0 (datos personales on-premise).
+
+---
+
+## 11. RGPD
+
+### 11.1 Datos personales identificados
+
+Referencia cruzada con `docs/data-model.md §8`:
+
+| Tabla | Campo | Categoría RGPD | Base legal |
+|---|---|---|---|
+| `users` | `first_name`, `last_name` | Dato identificativo | Ejecución de contrato |
+| `users` | `phone` | Dato de contacto | Ejecución de contrato + interés legítimo (OTP) |
+| `users` | `email` | Dato de contacto | Ejecución de contrato |
+| `users` | `telegram_chat_id` | Identificador de cuenta de mensajería | Consentimiento (vinculación voluntaria) |
+| `users` | `password_hash` | Credencial de acceso | Ejecución de contrato |
+| `participants` | `external_name` | Dato de tercero (jugador casual) | Interés legítimo mínimo |
+| `participants` | `external_phone` | Dato de contacto de tercero | Interés legítimo mínimo |
+| `audit_log` | `ip_address` | Dato de red | Interés legítimo (seguridad) |
+| `notification_log` | `recipient`, `message` | Dato de comunicación | Ejecución de contrato |
+
+### 11.2 Derechos del titular y procedimiento
+
+| Derecho (Art. RGPD) | Endpoint / Procedimiento | SLA de respuesta |
+|---|---|---|
+| **Acceso** (Art. 15) | `GET /api/usuarios/me` devuelve datos propios. Para datos de `audit_log` y `notification_log`: proceso manual vía email a admin. | 30 días |
+| **Rectificación** (Art. 16) | `PATCH /api/usuarios/me` — nombre, email, teléfono. | Inmediato vía UI |
+| **Supresión** (Art. 17) | Proceso de anonimización definido en `docs/data-model.md §8.3`. Endpoint: `DELETE /api/admin/usuarios/{id}` → anonimiza campos personales, no borra reservas/pagos (obligación fiscal). | 30 días |
+| **Portabilidad** (Art. 20) | No hay endpoint en v1.0. Proceso manual: admin exporta `SELECT` de datos del usuario en CSV. **Decisión abierta P-RGPD-01.** | 30 días |
+| **Oposición al tratamiento** (Art. 21) | Desvinculación de Telegram: `PATCH /api/usuarios/me`. Desactivación de cuenta: contactar al admin. | Variable |
+| **Limitación del tratamiento** (Art. 18) | Proceso manual: admin marca el usuario como `INACTIVE` y no procesa sus datos. | Variable |
+
+### 11.3 Política de retención
+
+Ver `docs/data-model.md §8.2` para la tabla completa. Resumen de categorías RGPD:
+
+| Categoría | Retención | Base |
+|---|---|---|
+| Datos de cuenta (`users`) | Vida de la cuenta + 5 años tras inactivación | Prescripción civil |
+| Reservas y pagos | 5 años | Obligación fiscal (AEAT) |
+| Logs de auditoría | 2 años | Interés legítimo seguridad + RGPD art. 5.1.e |
+| Logs de notificación | 2 años | Interés legítimo |
+| OTP codes | 7 días tras expiración | Datos técnicos mínimos |
+
+### 11.4 Encargados de tratamiento
+
+| Encargado | Servicio | Datos transferidos | Medida contractual |
+|---|---|---|---|
+| **Telegram** (Telegram FZ-LLC, Dubái) | Bot API — OTP, notificaciones | Número de teléfono, contenido de mensajes | Términos de servicio Telegram (no DPA disponible para bots gratuitos). **Riesgo declarado.** |
+| **Redsys** (Red Nacional de Intercambio, S.A.) | Pasarela de pago | Solo importe y referencia de pedido. PadelPro **no transfiere datos de tarjeta**. | Contrato de adhesión Redsys + medidas PCI-DSS del banco |
+| **Hosting On-Premise** | Servidor del cliente | Todos los datos | El cliente es el responsable del tratamiento; no hay tercero aquí |
+| **SMTP** (servidor de email) | Notificaciones email | Email del usuario, contenido del mensaje | Contrato de servicio SMTP |
+
+### 11.5 Registro de actividades de tratamiento (RAT)
+
+El responsable del tratamiento (el club) debe mantener el RAT según Art. 30 RGPD. PadelPro genera los datos; el club es el responsable. Se recomienda que el admin rellene el RAT con las actividades: gestión de reservas, gestión de pagos, comunicaciones con jugadores.
+
+---
+
+## 12. Vulnerabilidades del stack
+
+### 12.1 Java 21 + Spring Boot 3.2
+
+**Gestión de dependencias:**
+- `OWASP Dependency-Check` integrado en el pipeline Maven (`mvn dependency-check:check`). Falla el build si hay CVE Critical/High sin suprimir justificación.
+- `Dependabot` en GitHub: PRs automáticas para actualizaciones de seguridad.
+
+**CVEs relevantes conocidos (2024):**
+- Spring Framework < 6.1.x: vulnerabilidades en serialización y SPEL. Spring Boot 3.2 usa Spring Framework 6.1.x — mantener actualizado.
+- Log4j: PadelPro usa **SLF4J + Logback** (no Log4j). No afectado por Log4Shell.
+- Netty (si se usa WebFlux): PadelPro usa Tomcat (Spring MVC) — revisar si se añade WebFlux en el futuro.
+
+**Configuraciones de hardening Spring:**
+```yaml
+spring:
+  jpa:
+    open-in-view: false  # Evita LazyLoadingException fuera de transacción + SqlInjection vectores
+  mvc:
+    pathmatch:
+      use-suffix-pattern: false  # Deshabilitar extensiones en URLs (CVE-2022-22965 Spring4Shell)
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "health,info"  # Solo estos dos en producción
+  endpoint:
+    health:
+      show-details: "when_authorized"
+```
+
+### 12.2 React 18
+
+**XSS:**
+- React escapa el contenido de JSX por defecto. **Nunca usar `dangerouslySetInnerHTML`** salvo contenido propio sanitizado con `DOMPurify`.
+- El contenido de mensajes de Telegram que llega al frontend (nombre de participante, etc.) siempre se renderiza como texto React, no como HTML.
+- `npm audit` en CI; fallar pipeline si hay vulnerabilidades High/Critical.
+
+**Dependencias:**
+- Dependabot activo para el frontend también.
+- No usar `eval()` ni `new Function()` en ningún lugar del código.
+
+**Almacenamiento seguro:**
+- Nunca `localStorage.setItem('token', ...)`. Access token en memoria únicamente.
+- Nada sensible en `sessionStorage` (accesible por scripts del mismo origen).
+
+### 12.3 PostgreSQL 15
+
+**Hardening básico:**
+
+```sql
+-- Crear usuario de aplicación con permisos mínimos
+CREATE ROLE padelpro_app LOGIN PASSWORD 'STRONG_PASSWORD_FROM_ENV';
+GRANT CONNECT ON DATABASE padelpro TO padelpro_app;
+GRANT USAGE ON SCHEMA public TO padelpro_app;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO padelpro_app;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO padelpro_app;
+
+-- El usuario de la aplicación NO tiene SUPERUSER ni CREATEDB
+-- El usuario postgres (superuser) solo se usa para migraciones Flyway
+```
+
+**Red:**
+```yaml
+# docker-compose.yml — PostgreSQL no expone puerto al host
+db:
+  image: postgres:15
+  networks:
+    - padelpro-network
+  # NO mapear puertos al host: sin "ports: - 5432:5432"
+```
+
+**Backups:**
+- `pg_dump` diario (cron en el host) al directorio `/backups/padelpro/`.
+- Retención 7 días local.
+- Copia semanal a almacenamiento externo (USB, NAS, o cloud) recomendada.
+
+---
+
+## 13. Plan de respuesta a incidentes
+
+### 13.1 Criterios de activación
+
+| Evento | Nivel | Activación |
+|---|---|---|
+| Acceso no autorizado a datos de usuarios | Crítico | Inmediata |
+| Pago procesado con firma HMAC inválida | Crítico | Inmediata |
+| Token de bot Telegram comprometido | Alto | < 1h |
+| Ataque de fuerza bruta detectado (>100 IPs bloqueadas) | Medio | < 4h |
+| Dependencia con CVE Critical sin parchear | Medio | < 24h |
+| Fallo de backup 3 días consecutivos | Bajo | < 24h |
+
+### 13.2 Procedimiento (primeras 24 horas)
+
+```
+FASE 1 — CONTENCIÓN (0-2h):
+  1. Identificar el vector de ataque (logs de auditoría, NGINX access log)
+  2. Si hay brecha de datos: desconectar temporalmente el servicio (docker-compose stop backend)
+  3. Si hay token comprometido:
+     a. JWT: rotar APP_JWT_SECRET (invalida todos los tokens)
+     b. Telegram bot: generar nuevo token en @BotFather, actualizar system_config
+     c. Redsys: contactar al banco para revocar y regenerar el secret
+  4. Revocar todos los refresh_tokens: UPDATE refresh_tokens SET revoked=true
+
+FASE 2 — EVALUACIÓN (2-8h):
+  5. Determinar alcance: ¿qué datos han sido accedidos/exfiltrados?
+  6. Revisar audit_log del periodo de la brecha
+  7. Identificar usuarios afectados
+  8. Documentar el incidente (timeline, evidencias)
+
+FASE 3 — NOTIFICACIÓN (RGPD Art. 33/34):
+  9. Si hay brecha de datos personales:
+     a. Notificar a la AEPD en < 72h desde detección (formulario en aepd.es)
+     b. Evaluar si el riesgo es alto → notificar también a los afectados (Art. 34)
+  10. Comunicar internamente al responsable del club
+
+FASE 4 — RECUPERACIÓN (8-24h):
+  11. Aplicar el parche o corrección
+  12. Restaurar desde backup si es necesario
+  13. Verificar integridad de datos antes de reactivar el servicio
+  14. Monitorizar de forma intensiva las primeras 48h post-incidente
+
+FASE 5 — LECCIONES APRENDIDAS (post-incidente):
+  15. Documentar el incidente completo
+  16. Actualizar este plan de respuesta
+  17. Verificar si se requieren controles adicionales
+```
+
+### 13.3 Contactos y referencias
+
+| Recurso | URL / Contacto |
+|---|---|
+| AEPD — Notificación de brecha | https://sedeagpd.gob.es/sede-electronica-web/ |
+| Redsys — Soporte urgente | Contacto del banco gestor del comercio |
+| Telegram — Compromiso de bot | @BotFather (regenerar token), reportar en security@telegram.org |
+| Let's Encrypt — Cert revocación | `certbot revoke --cert-path /etc/letsencrypt/live/...` |
+
+---
+
+## 14. Decisiones abiertas
+
+Las siguientes decisiones requieren confirmación del propietario del producto o del cliente antes de implementar:
+
+| # | Decisión | Impacto | Acción requerida |
+|---|---|---|---|
+| **D-SEC-01** | **Rotación de refresh tokens**: ¿implementar en v1.0? Si se implementa, cada uso del refresh token genera uno nuevo e invalida el anterior. Detecta reutilización de tokens robados pero complica la lógica de cliente. | Seguridad vs. complejidad de implementación | Confirmar si el nivel de seguridad adicional justifica el esfuerzo en v1.0 |
+| **D-SEC-02** | **OTP hasheado en BD**: El prompt del data-model indica que el OTP se almacena en claro (campo `code VARCHAR(6)`). Este documento propone almacenarlo como SHA-256. ¿Confirmamos el almacenamiento como hash? | Protege contra acceso de lectura a BD; implica actualizar el data-model | Confirmar y actualizar `docs/data-model.md` si se aprueba |
+| **D-SEC-03** | **Portabilidad de datos (Art. 20 RGPD)**: No hay endpoint de exportación en v1.0. ¿Se implementa un `GET /api/usuarios/me/exportar` que devuelva un JSON con todos los datos del usuario? | Cumplimiento RGPD; esfuerzo ~3 SP | Confirmar si es requisito para la fecha de lanzamiento |
+| **D-SEC-04** | **Whitelist de IPs de Redsys en NGINX**: Las IPs de los servidores de notificación de Redsys son proporcionadas por el banco y pueden cambiar. ¿Se gestiona como variable de entorno o se externaliza la validación al filtro HMAC exclusivamente? | Si las IPs cambian sin actualizar la whitelist, los webhooks fallan | Coordinar con el banco la lista de IPs y la política de cambio |
+| **D-SEC-05** | **Telegram DPA**: Telegram no ofrece DPA (Data Processing Agreement) para bots gratuitos. El envío de OTPs implica transferencia de datos personales (número de teléfono como identificador implícito) a Telegram FZ-LLC (Dubái). ¿El club acepta este riesgo explícitamente? | Riesgo legal RGPD transferencia internacional | Decisión del responsable del tratamiento (el club) documentada por escrito |
+| **D-SEC-06** | **Account lockout vs. CAPTCHA**: El bloqueo temporal de cuenta (§2.7) puede usarse como vector DoS contra usuarios específicos (un atacante bloquea la cuenta del admin). ¿Se prefiere CAPTCHA en el login en lugar de bloqueo de cuenta? | UX vs. seguridad | Confirmar preferencia; el CAPTCHA es más robusto frente al DoS dirigido |
+| **D-SEC-07** | **Lifetime del access token**: Este documento propone 15 min. El README indica 8h. ¿Se confirma el cambio a 15 min? Si se elige 8h, la ventana de exposición ante robo de token es mayor. | Seguridad vs. UX (renovación transparente necesaria en frontend) | Confirmar el lifetime definitivo |

--- a/docs/ux/README.md
+++ b/docs/ux/README.md
@@ -1,0 +1,308 @@
+# PadelPro · Sistema UX · Documentación de pantallas
+
+Índice completo de las 24 pantallas del sistema de diseño de PadelPro.
+Cada pantalla es un fichero HTML autónomo que enlaza a `_shared/styles.css`.
+
+---
+
+## Tabla resumen
+
+| # | Nombre | Categoría | Capability | Endpoint | Permisos | Device | Archivo |
+|---|--------|-----------|-----------|---------|---------|--------|---------|
+| 01 | Splash & bienvenida | Auth | auth-local | — | Público | Mobile | [07-splash.html](./mockups/07-splash.html) |
+| 02 | Login | Auth | auth-local | POST /api/v1/auth/login | Público | Mobile | [01-login.html](./mockups/01-login.html) |
+| 03 | Crear cuenta | Auth | auth-local, usuarios | POST /api/v1/auth/register | Público | Mobile | [08-crear-cuenta.html](./mockups/08-crear-cuenta.html) |
+| 04 | Recuperar contraseña | Auth | auth-local | POST /api/v1/auth/forgot-password | Público | Mobile | [09-recuperar-password.html](./mockups/09-recuperar-password.html) |
+| 05 | Nueva contraseña | Auth | auth-local | POST /api/v1/auth/reset-password | Token reset | Mobile | [10-nueva-password.html](./mockups/10-nueva-password.html) |
+| 06 | Home jugador | Reservas | reservas, disponibilidad-pistas | GET /api/v1/reservas/mias | JUGADOR | Mobile | [02-home-jugador.html](./mockups/02-home-jugador.html) |
+| 07 | Buscar disponibilidad | Reservas | disponibilidad-pistas | GET /api/v1/pistas/disponibilidad | JUGADOR / INVITADO | Mobile | [03-buscar-disponibilidad.html](./mockups/03-buscar-disponibilidad.html) |
+| 08 | Confirmar reserva | Reservas | reservas, pagos-redsys | POST /api/v1/reservas | JUGADOR | Mobile | [04-confirmar-reserva.html](./mockups/04-confirmar-reserva.html) |
+| 09 | Checkout Redsys | Pagos | pagos-redsys | POST /api/v1/pagos/iniciar | JUGADOR | Mobile | [11-checkout-redsys.html](./mockups/11-checkout-redsys.html) |
+| 10 | Pago confirmado | Pagos | pagos-redsys, reservas, notificaciones | Webhook callback | JUGADOR | Mobile | [12-pago-confirmado.html](./mockups/12-pago-confirmado.html) |
+| 11 | Mis reservas | Reservas | reservas | GET /api/v1/reservas/mias | JUGADOR | Mobile | [05-mis-reservas.html](./mockups/05-mis-reservas.html) |
+| 12 | Detalle de reserva | Reservas | reservas | GET /api/v1/reservas/{id} | JUGADOR | Mobile | [13-detalle-reserva.html](./mockups/13-detalle-reserva.html) |
+| 13 | Mi perfil | Perfil | usuarios, auth-otp-telegram | GET /api/v1/users/me | JUGADOR | Mobile | [14-mi-perfil.html](./mockups/14-mi-perfil.html) |
+| 14 | Vincular Telegram | Telegram | auth-otp-telegram | POST /api/v1/telegram/link/initiate | JUGADOR | Mobile | [15-vincular-telegram.html](./mockups/15-vincular-telegram.html) |
+| 15 | Introducir OTP | Telegram | auth-otp-telegram | POST /api/v1/telegram/link/verify | JUGADOR | Mobile | [16-otp-telegram.html](./mockups/16-otp-telegram.html) |
+| 16 | Partidas abiertas | Partidas | partidas | GET /api/v1/partidas/abiertas | JUGADOR | Mobile | [21-partidas-abiertas.html](./mockups/21-partidas-abiertas.html) |
+| 17 | Crear partida pública | Partidas | partidas | POST /api/v1/partidas | JUGADOR | Mobile | [20-crear-partida.html](./mockups/20-crear-partida.html) |
+| 18 | Confirmar unión | Partidas | partidas, pagos-redsys | POST /api/v1/partidas/{id}/unirse | JUGADOR | Mobile | [22-confirmar-union.html](./mockups/22-confirmar-union.html) |
+| 19 | Mis datos y privacidad | RGPD | exportaciones-rgpd | POST /api/v1/users/me/export | JUGADOR | Mobile | [23-mis-datos.html](./mockups/23-mis-datos.html) |
+| 20 | Confirmar eliminación | RGPD | exportaciones-rgpd, auditoria | DELETE /api/v1/users/me | JUGADOR | Mobile | [24-eliminar-cuenta.html](./mockups/24-eliminar-cuenta.html) |
+| 21 | Dashboard club | Admin | administracion-club | GET /api/v1/admin/dashboard | MANAGER_CLUB · ADMIN | Desktop | [06-dashboard-club.html](./mockups/06-dashboard-club.html) |
+| 22 | Calendario semanal | Admin | reservas, disponibilidad-pistas | GET /api/v1/admin/reservas?semana=N | MANAGER_CLUB · ADMIN | Desktop | [18-calendario-semanal.html](./mockups/18-calendario-semanal.html) |
+| 23 | Reservas del club | Admin | reservas, pagos-redsys | GET /api/v1/admin/reservas | MANAGER_CLUB · ADMIN | Desktop | [19-reservas-club.html](./mockups/19-reservas-club.html) |
+| 24 | Gestión de pistas | Admin | pistas | GET /api/v1/admin/pistas | MANAGER_CLUB · ADMIN | Desktop | [17-gestion-pistas.html](./mockups/17-gestion-pistas.html) |
+
+---
+
+## Pantallas por categoría
+
+### Auth & Onboarding (01–05)
+
+#### 01 · Splash & bienvenida
+- **Archivo:** [mockups/07-splash.html](./mockups/07-splash.html)
+- **Capability:** auth-local
+- **Endpoint:** —
+- **Permisos:** Público
+- **Device:** Mobile
+- **Descripción:** Pantalla de bienvenida de pantalla completa con el glifo PP en modo oscuro y esfera lima. Anclaje de marca previo al login.
+
+#### 02 · Login
+- **Archivo:** [mockups/01-login.html](./mockups/01-login.html)
+- **Capability:** auth-local
+- **Endpoint:** POST /api/v1/auth/login
+- **Permisos:** Público
+- **Device:** Mobile
+- **Descripción:** Formulario de inicio de sesión con email y contraseña. Links a registro y recuperación. Diseño limpio con CTA lima prominente.
+
+#### 03 · Crear cuenta
+- **Archivo:** [mockups/08-crear-cuenta.html](./mockups/08-crear-cuenta.html)
+- **Capability:** auth-local, usuarios
+- **Endpoint:** POST /api/v1/auth/register
+- **Permisos:** Público
+- **Device:** Mobile
+- **Descripción:** Formulario de registro con nombre, apellido, email, teléfono, contraseña y checkbox RGPD. Campos marcados como obligatorios.
+
+#### 04 · Recuperar contraseña
+- **Archivo:** [mockups/09-recuperar-password.html](./mockups/09-recuperar-password.html)
+- **Capability:** auth-local
+- **Endpoint:** POST /api/v1/auth/forgot-password
+- **Permisos:** Público
+- **Device:** Mobile
+- **Descripción:** Formulario de recuperación por email. Estado de éxito con mensaje de confirmación tras envío.
+
+#### 05 · Nueva contraseña
+- **Archivo:** [mockups/10-nueva-password.html](./mockups/10-nueva-password.html)
+- **Capability:** auth-local
+- **Endpoint:** POST /api/v1/auth/reset-password
+- **Permisos:** Token reset
+- **Device:** Mobile
+- **Descripción:** Formulario de nueva contraseña con barra de fortaleza y lista de requisitos visuales (longitud, mayúscula, número, símbolo).
+
+---
+
+### Reservas · Jugador (06–12)
+
+#### 06 · Home jugador
+- **Archivo:** [mockups/02-home-jugador.html](./mockups/02-home-jugador.html)
+- **Capability:** reservas, disponibilidad-pistas
+- **Endpoint:** GET /api/v1/reservas/mias
+- **Permisos:** JUGADOR autenticado
+- **Device:** Mobile
+- **Descripción:** Pantalla principal del jugador. Muestra la próxima reserva destacada, botón de buscar pista y acceso rápido a reservas anteriores. Tab bar inferior con 4 secciones.
+
+#### 07 · Buscar disponibilidad
+- **Archivo:** [mockups/03-buscar-disponibilidad.html](./mockups/03-buscar-disponibilidad.html)
+- **Capability:** disponibilidad-pistas
+- **Endpoint:** GET /api/v1/pistas/disponibilidad
+- **Permisos:** JUGADOR / INVITADO
+- **Device:** Mobile
+- **Descripción:** Selector de fecha + hora con franja horaria. Grid de pistas disponibles con slots de tiempo. Filtros por tipo de superficie (cristal/muro) e interior/exterior.
+
+#### 08 · Confirmar reserva
+- **Archivo:** [mockups/04-confirmar-reserva.html](./mockups/04-confirmar-reserva.html)
+- **Capability:** reservas, pagos-redsys
+- **Endpoint:** POST /api/v1/reservas
+- **Permisos:** JUGADOR autenticado
+- **Device:** Mobile
+- **Descripción:** Vista de detalle de la pista seleccionada con hero olive. Resumen de fecha, hora, duración e importe. Footer sticky con CTA de reserva.
+
+#### 09 · Checkout Redsys
+- **Archivo:** [mockups/11-checkout-redsys.html](./mockups/11-checkout-redsys.html)
+- **Capability:** pagos-redsys
+- **Endpoint:** POST /api/v1/pagos/iniciar
+- **Permisos:** JUGADOR autenticado
+- **Device:** Mobile
+- **Descripción:** Previsualización de la tarjeta guardada con número parcial. Formulario de datos de tarjeta. Branding de seguridad Redsys. CTA de pago con importe.
+
+#### 10 · Pago confirmado
+- **Archivo:** [mockups/12-pago-confirmado.html](./mockups/12-pago-confirmado.html)
+- **Capability:** pagos-redsys, reservas, notificaciones
+- **Endpoint:** Webhook callback
+- **Permisos:** JUGADOR autenticado
+- **Device:** Mobile
+- **Descripción:** Pantalla oscura de éxito con icono de check lima. Código de reserva, detalle de pista y hora. Acceso a "Ver reserva" y aviso de notificación Telegram.
+
+#### 11 · Mis reservas
+- **Archivo:** [mockups/05-mis-reservas.html](./mockups/05-mis-reservas.html)
+- **Capability:** reservas
+- **Endpoint:** GET /api/v1/reservas/mias
+- **Permisos:** JUGADOR autenticado
+- **Device:** Mobile
+- **Descripción:** Listado de reservas del jugador con tabs "Próximas" y "Pasadas". Cards con estado (confirmada/cancelada), pista, fecha, hora e importe. Acceso al detalle de cada reserva.
+
+#### 12 · Detalle de reserva
+- **Archivo:** [mockups/13-detalle-reserva.html](./mockups/13-detalle-reserva.html)
+- **Capability:** reservas
+- **Endpoint:** GET /api/v1/reservas/{id}
+- **Permisos:** JUGADOR (propias)
+- **Device:** Mobile
+- **Descripción:** Detalle completo de una reserva con hero oscuro. Código único, jugadores confirmados (chips de avatar), grid de info-pills (horario, pista, superficie, importe). Botón de cancelación.
+
+---
+
+### Perfil & Telegram (13–15)
+
+#### 13 · Mi perfil
+- **Archivo:** [mockups/14-mi-perfil.html](./mockups/14-mi-perfil.html)
+- **Capability:** usuarios, auth-otp-telegram
+- **Endpoint:** GET /api/v1/users/me
+- **Permisos:** JUGADOR autenticado
+- **Device:** Mobile
+- **Descripción:** Perfil con avatar inicial, nombre y email. Tres secciones: Cuenta (datos + seguridad), Conexiones (Telegram vinculado + métodos de pago), Privacidad (RGPD).
+
+#### 14 · Vincular Telegram
+- **Archivo:** [mockups/15-vincular-telegram.html](./mockups/15-vincular-telegram.html)
+- **Capability:** auth-otp-telegram
+- **Endpoint:** POST /api/v1/telegram/link/initiate
+- **Permisos:** JUGADOR autenticado
+- **Device:** Mobile
+- **Descripción:** Flujo de vinculación en 3 pasos numerados: abrir bot, enviar /vincular, introducir código. Icono azul Telegram, nombre del bot en monospace. CTA "Abrir Telegram".
+
+#### 15 · Introducir OTP
+- **Archivo:** [mockups/16-otp-telegram.html](./mockups/16-otp-telegram.html)
+- **Capability:** auth-otp-telegram
+- **Endpoint:** POST /api/v1/telegram/link/verify
+- **Permisos:** JUGADOR autenticado
+- **Device:** Mobile
+- **Descripción:** 6 cajas individuales para el código OTP. Estado activo con cursor animado. Timer de caducidad en monospace. Link de reenvío de código.
+
+---
+
+### Partidas / Fase 2 (16–18)
+
+#### 16 · Partidas abiertas
+- **Archivo:** [mockups/21-partidas-abiertas.html](./mockups/21-partidas-abiertas.html)
+- **Capability:** partidas
+- **Endpoint:** GET /api/v1/partidas/abiertas
+- **Permisos:** JUGADOR autenticado
+- **Device:** Mobile
+- **Descripción:** Listado de partidas que buscan jugador. Tabs Hoy / Mañana / Semana. Cards con hora, nivel (coloreado), avatares de jugadores y huecos vacíos, precio por jugador, botón "Unirme".
+
+#### 17 · Crear partida pública
+- **Archivo:** [mockups/20-crear-partida.html](./mockups/20-crear-partida.html)
+- **Capability:** partidas
+- **Endpoint:** POST /api/v1/partidas
+- **Permisos:** JUGADOR autenticado
+- **Device:** Mobile
+- **Descripción:** Formulario de creación en 3 secciones: reserva base (card oscura), tipo (switches público + pago compartido), nivel (grid de 4 opciones: Inicia, Medio, Avanz., Pro).
+
+#### 18 · Confirmar unión
+- **Archivo:** [mockups/22-confirmar-union.html](./mockups/22-confirmar-union.html)
+- **Capability:** partidas, pagos-redsys
+- **Endpoint:** POST /api/v1/partidas/{id}/unirse
+- **Permisos:** JUGADOR autenticado
+- **Device:** Mobile
+- **Descripción:** Detalle de la partida con layout resdet. Jugadores confirmados + hueco "Tú". Grid de info-pills con horario, nivel, tu parte y total. Nota de política de cancelación automática.
+
+---
+
+### RGPD & Privacidad (19–20)
+
+#### 19 · Mis datos y privacidad
+- **Archivo:** [mockups/23-mis-datos.html](./mockups/23-mis-datos.html)
+- **Capability:** exportaciones-rgpd
+- **Endpoint:** POST /api/v1/users/me/export · DELETE /api/v1/users/me
+- **Permisos:** JUGADOR autenticado
+- **Device:** Mobile
+- **Descripción:** 3 bloques RGPD con referencia al artículo legal: descargar datos (Art. 15), editar datos (Art. 16), eliminar cuenta (Art. 17). Icono rojo para la acción destructiva.
+
+#### 20 · Confirmar eliminación
+- **Archivo:** [mockups/24-eliminar-cuenta.html](./mockups/24-eliminar-cuenta.html)
+- **Capability:** exportaciones-rgpd, auditoria
+- **Endpoint:** DELETE /api/v1/users/me
+- **Permisos:** JUGADOR autenticado
+- **Device:** Mobile
+- **Descripción:** Card de advertencia negro+rojo. Lista de consecuencias explícitas. Campo de confirmación tipo-tu-nombre ("ELIMINAR LAURA"). Botón rojo destructivo.
+
+---
+
+### Admin Club (21–24)
+
+#### 21 · Dashboard club
+- **Archivo:** [mockups/06-dashboard-club.html](./mockups/06-dashboard-club.html)
+- **Capability:** administracion-club
+- **Endpoint:** GET /api/v1/admin/dashboard
+- **Permisos:** MANAGER_CLUB · ADMIN
+- **Device:** Desktop
+- **Descripción:** Panel admin con sidebar de navegación. KPIs en grid (reservas, ingresos, ocupación, cancelaciones). Timeline de próximas reservas. Sidebar lateral de pagos recientes.
+
+#### 22 · Calendario semanal
+- **Archivo:** [mockups/18-calendario-semanal.html](./mockups/18-calendario-semanal.html)
+- **Capability:** reservas, disponibilidad-pistas
+- **Endpoint:** GET /api/v1/admin/reservas?semana=N
+- **Permisos:** MANAGER_CLUB · ADMIN
+- **Device:** Desktop
+- **Descripción:** Vista semanal de 7 columnas (Lun–Dom) con franjas horarias de 9:00 a 18:00. Eventos posicionados absolutamente (olive, alt-olive, lima, rojo mantenimiento). Selector de pista en topbar.
+
+#### 23 · Reservas del club
+- **Archivo:** [mockups/19-reservas-club.html](./mockups/19-reservas-club.html)
+- **Capability:** reservas, pagos-redsys
+- **Endpoint:** GET /api/v1/admin/reservas
+- **Permisos:** MANAGER_CLUB · ADMIN
+- **Device:** Desktop
+- **Descripción:** Tabla de reservas con filter-chips (Todas / Confirmadas / Pendientes / Canceladas) y buscador. Columnas: código, jugador (avatar + email), día/hora, pista, importe, estado (pill). Exportar CSV.
+
+#### 24 · Gestión de pistas
+- **Archivo:** [mockups/17-gestion-pistas.html](./mockups/17-gestion-pistas.html)
+- **Capability:** pistas
+- **Endpoint:** GET /api/v1/admin/pistas
+- **Permisos:** MANAGER_CLUB · ADMIN
+- **Device:** Desktop
+- **Descripción:** Grid de tarjetas de pista con icono tipo cancha, badge de estado (Activa / Mantenimiento), KPIs de ocupación y tarifa por hora. Tarjeta "+" para añadir pista nueva.
+
+---
+
+## Estructura de ficheros
+
+```
+docs/ux/
+├── README.md                    ← este fichero
+├── flujos.md                    ← 6 diagramas Mermaid de flujos de usuario
+├── components.md                ← catálogo de ≥19 componentes reutilizables
+├── design-tokens.md             ← paleta, tipografía, espaciado, sombras
+└── mockups/
+    ├── index.html               ← grid visual de 24 tarjetas
+    ├── _shared/
+    │   ├── styles.css           ← sistema de diseño unificado
+    │   └── fonts.html           ← snippet Google Fonts
+    ├── 01-login.html
+    ├── 02-home-jugador.html
+    ├── 03-buscar-disponibilidad.html
+    ├── 04-confirmar-reserva.html
+    ├── 05-mis-reservas.html
+    ├── 06-dashboard-club.html
+    ├── 07-splash.html
+    ├── 08-crear-cuenta.html
+    ├── 09-recuperar-password.html
+    ├── 10-nueva-password.html
+    ├── 11-checkout-redsys.html
+    ├── 12-pago-confirmado.html
+    ├── 13-detalle-reserva.html
+    ├── 14-mi-perfil.html
+    ├── 15-vincular-telegram.html
+    ├── 16-otp-telegram.html
+    ├── 17-gestion-pistas.html
+    ├── 18-calendario-semanal.html
+    ├── 19-reservas-club.html
+    ├── 20-crear-partida.html
+    ├── 21-partidas-abiertas.html
+    ├── 22-confirmar-union.html
+    ├── 23-mis-datos.html
+    └── 24-eliminar-cuenta.html
+```
+
+---
+
+## Discrepancias detectadas
+
+Las siguientes diferencias se encontraron entre la tabla de tareas proporcionada por el orquestador y los metadatos reales de los ficheros HTML fuente. Los metadatos HTML son la fuente de verdad.
+
+| Pantalla | Campo | Valor en tabla | Valor real (HTML) |
+|----------|-------|---------------|-------------------|
+| 10 (Pago confirmado) | Endpoint | POST callback | Webhook callback (no hay método POST explícito) |
+| 21 (Admin calendar) | Capability tabla origen | reservas | reservas, disponibilidad-pistas |
+| Admin sidebar (pantallas 17–19) | Nav items | Variable | Pantalla 17 incluye item "Política" en sidebar; pantallas 18–19 no lo incluyen |
+
+Ninguna discrepancia afecta a capability, endpoint principal o permisos de forma material.

--- a/docs/ux/components.md
+++ b/docs/ux/components.md
@@ -1,0 +1,387 @@
+# PadelPro · Catálogo de componentes
+
+Inventario de los componentes reutilizables del sistema de diseño.
+Todos los estilos se definen en `mockups/_shared/styles.css`.
+
+---
+
+## Componentes de acción
+
+### 1. `p-btn` — Botón primario
+
+Botón de acción principal. Variantes por modificador de color.
+
+**Clases:**
+- `.p-btn` — base: fondo olive, texto crema, border-radius 14px, ancho completo
+- `.p-btn.lime` — fondo lima (acción positiva: reservar, verificar, crear)
+- `.p-btn.danger` — fondo danger rojo (eliminación de cuenta)
+- `.p-btn:disabled` — opacidad reducida, cursor not-allowed
+
+**Uso:** Pantallas 01–05, 11, 13, 16, 20, 22–24.
+
+**Snippet:**
+```html
+<button class="p-btn lime">Reservar · 16€ <span class="arrow">→</span></button>
+<button class="p-btn danger">Eliminar cuenta para siempre</button>
+```
+
+---
+
+### 2. `admin-btn` — Botón admin
+
+Botón compacto para acciones en el panel de administración.
+
+**Clases:**
+- `.admin-btn` — base: borde ink, fondo transparente, texto ink
+- `.admin-btn.dark` — fondo ink, texto lime (acción primaria del topbar)
+
+**Uso:** Pantallas 06, 17, 18, 19.
+
+---
+
+### 3. `join-btn` — Botón unirse a partida
+
+Botón inline en cards de partida abierta. Fondo ink, texto lime.
+
+**Uso:** Pantalla 21.
+
+---
+
+### 4. `action-btn` — Botón de acción RGPD
+
+Botón de ancho completo dentro de bloques RGPD.
+
+**Clases:**
+- `.action-btn` — base: borde ink, texto ink
+- `.action-btn.danger` — borde danger, texto danger
+
+**Uso:** Pantalla 23.
+
+---
+
+## Componentes de formulario
+
+### 5. `p-input` — Campo de texto
+
+Campo de formulario estándar con label flotante o sobre el campo.
+
+**Estructura:**
+```html
+<div class="p-field">
+  <label>Email</label>
+  <input class="p-input" type="email" placeholder="tu@email.com">
+</div>
+```
+
+**Uso:** Pantallas 01–04, 09, 11.
+
+---
+
+### 6. `otp-box` — Caja OTP
+
+Caja individual para entrada de un dígito del código de 6 cifras.
+
+**Clases:**
+- `.otp-box` — base: cuadrado 44px, borde line, fondo crema
+- `.otp-box.filled` — con dígito introducido, borde ink
+- `.otp-box.active` — caja actual, sombra olive, contiene `.cursor`
+
+**Uso:** Pantalla 16.
+
+---
+
+### 7. `toggle-row` — Fila con switch
+
+Fila de opción binaria con nombre, descripción y switch visual.
+
+**Estructura:**
+```html
+<div class="toggle-row">
+  <div>
+    <div class="name">Partida pública</div>
+    <div class="sub">Otros jugadores pueden unirse</div>
+  </div>
+  <div class="switch"></div>
+</div>
+```
+
+**Uso:** Pantalla 20.
+
+---
+
+### 8. `level-pick` — Selector de nivel
+
+Grid de 4 opciones de nivel de juego con número y etiqueta.
+
+**Clases:**
+- `.level-pick` — contenedor grid
+- `.opt` — opción individual
+- `.opt.active` — opción seleccionada (fondo ink, texto lime)
+
+**Uso:** Pantalla 20.
+
+---
+
+## Componentes de navegación
+
+### 9. `p-tabbar` / `p-tab` — Barra de navegación inferior
+
+Tab bar fija en la parte inferior de pantallas mobile del jugador.
+
+**Estructura:**
+```html
+<div class="p-tabbar">
+  <div class="p-tab active">
+    <svg>...</svg>
+    Inicio
+  </div>
+  <div class="p-tab">...</div>
+</div>
+```
+
+**Tabs disponibles:** Inicio, Buscar, Reservas, Perfil.
+
+**Uso:** Pantallas 02, 05, 14, 21.
+
+---
+
+### 10. `admin-nav` / `admin-nav-item` — Navegación admin sidebar
+
+Sidebar de navegación del panel de administración con secciones.
+
+**Estructura:**
+```html
+<div class="admin-nav-section">Operación</div>
+<div class="admin-nav">
+  <div class="admin-nav-item active">
+    <svg>...</svg>Dashboard
+  </div>
+</div>
+```
+
+**Items:** Dashboard, Calendario, Reservas, Pagos, Pistas, Usuarios, Política.
+
+**Uso:** Pantallas 06, 17, 18, 19.
+
+---
+
+### 11. `partidas-tabs` / `partidas-tab` — Tabs de partidas
+
+Selector de período temporal en la pantalla de partidas abiertas.
+
+**Clases:** `.partidas-tabs` (contenedor), `.partidas-tab`, `.partidas-tab.active`.
+
+**Uso:** Pantalla 21.
+
+---
+
+## Componentes de tarjeta
+
+### 12. `reserva-card` — Tarjeta de reserva
+
+Tarjeta de reserva en listado "Mis reservas". Muestra estado, pista, fecha y hora.
+
+**Clases:**
+- `.reserva-card` — base
+- `.reserva-card .badge` — pill de estado (confirmada en olive, cancelada en danger)
+
+**Uso:** Pantalla 05.
+
+---
+
+### 13. `partida-card` — Tarjeta de partida abierta
+
+Tarjeta de partida pública en el listado de partidas abiertas.
+
+**Estructura:** cabecera (hora + nivel), nombre de pista, row de avatares + huecos, footer (precio + botón).
+
+**Sub-clases de nivel:**
+- `.level.med` — nivel medio, fondo info azul
+- `.level.adv` — nivel avanzado, fondo danger rojo
+
+**Uso:** Pantalla 21.
+
+---
+
+### 14. `court-card` — Tarjeta de pista
+
+Tarjeta de pista en el panel admin. Icono tipo cancha, badge de estado, KPIs de ocupación y tarifa.
+
+**Clases:**
+- `.court-card` — base
+- `.court-card .badge.active` — pista activa (olive)
+- `.court-card .badge.maint` — mantenimiento (warn)
+- `.court-card.add` — tarjeta de "Añadir pista" (dashed, sin contenido)
+
+**Uso:** Pantalla 17.
+
+---
+
+### 15. `home-next` — Card de próxima reserva
+
+Hero card en la pantalla de inicio del jugador con la próxima reserva.
+
+**Uso:** Pantalla 02.
+
+---
+
+## Componentes de datos / display
+
+### 16. `info-pill` — Píldora de información
+
+Píldora de dos líneas (label + valor) en el detalle de reserva y de partida.
+
+**Estructura:**
+```html
+<div class="info-pill">
+  <div class="lab">Horario</div>
+  <div class="val">18:30 — 20:00</div>
+</div>
+```
+
+**Uso:** Pantallas 13, 22.
+
+---
+
+### 17. `player-chip` — Chip de jugador
+
+Chip con avatar y nombre del jugador en el detalle de reserva o partida.
+
+**Clases:**
+- `.player-chip` — jugador confirmado
+- `.player-chip.empty` — hueco vacío (borde discontinuo, avatar "?")
+
+**Uso:** Pantallas 13, 22.
+
+---
+
+### 18. `kpi` — Tarjeta de KPI admin
+
+Tarjeta de métrica clave en el dashboard del club.
+
+**Estructura:** valor principal (Bricolage Grotesque, grande) + etiqueta + variación porcentual.
+
+**Uso:** Pantalla 06.
+
+---
+
+### 19. `cal-event` — Evento de calendario
+
+Bloque de evento en la vista semanal del calendario admin. Posicionado absolutamente dentro de `.cal-col`.
+
+**Clases:**
+- `.cal-event` — reserva estándar (olive)
+- `.cal-event.alt` — reserva alternativa (olive oscuro)
+- `.cal-event.lime` — reserva destacada (lime)
+- `.cal-event.maint` — mantenimiento (danger rojo)
+
+**Uso:** Pantalla 18.
+
+---
+
+### 20. `chip` / `slot` — Slot de disponibilidad
+
+Slot horario en la pantalla de búsqueda de disponibilidad.
+
+**Clases:**
+- `.slot` — slot disponible
+- `.slot.taken` — slot ocupado
+- `.slot.selected` — slot seleccionado por el usuario
+
+**Uso:** Pantalla 03.
+
+---
+
+## Componentes de estado y feedback
+
+### 21. `success-ico` — Icono de éxito
+
+Circulo con check mark en color lima. Usado en pantalla de pago confirmado.
+
+**Uso:** Pantalla 12.
+
+---
+
+### 22. `delete-warn` — Bloque de advertencia de eliminación
+
+Card oscura con icono de alerta blanco y texto de advertencia crítica.
+
+**Estructura:** `.delete-warn` → `.ico` (svg) + `h1` + `p`.
+
+**Uso:** Pantalla 24.
+
+---
+
+### 23. `rgpd-block` — Bloque de acción RGPD
+
+Bloque con cabecera (icono + nombre de derecho + referencia legal), descripción y botón de acción.
+
+**Estructura:** `.rgpd-block` → `.head` (`.ico` + `.info`) + `.desc` + `.action-btn`.
+
+**Uso:** Pantalla 23.
+
+---
+
+### 24. `filter-chip` — Chip de filtro
+
+Chip de filtro tabular con contador de resultados.
+
+**Clases:**
+- `.filter-chip` — base (borde, fondo blanco)
+- `.filter-chip.active` — seleccionado (fondo ink, texto lime)
+- `.filter-chip .count` — badge numérico interno
+
+**Uso:** Pantalla 19.
+
+---
+
+### 25. `table-head` / `table-row` — Tabla de reservas admin
+
+Fila de cabecera y fila de datos de la tabla de reservas del club.
+
+**Uso:** Pantalla 19.
+
+---
+
+## Componentes de layout
+
+### 26. `resdet` — Layout de detalle (hero oscuro)
+
+Layout de pantalla completa con hero dark (`.resdet-hero`) que contiene estado, título, metadatos y código; y cuerpo claro (`.resdet-body`) con secciones y footer sticky (`.resdet-footer`).
+
+**Uso:** Pantallas 13, 22.
+
+---
+
+### 27. `phone` — Frame de teléfono
+
+Contenedor del mockup mobile con notch y barra de estado.
+
+**Sub-elementos:**
+- `.phone-notch` — notch superior
+- `.phone-status` / `.phone-status.dark` — barra de estado (hora + señal)
+- `.phone-content` — área de scroll de contenido
+
+---
+
+### 28. `desktop` + `admin` — Frame de escritorio admin
+
+Contenedor del mockup desktop. `.admin` añade el layout sidebar + main.
+
+**Sub-elementos:** `.admin-sidebar`, `.admin-main`, `.admin-topbar`, `.admin-content`.
+
+---
+
+## Resumen de recuento
+
+| Categoría | Componentes |
+|-----------|-------------|
+| Acción | p-btn, admin-btn, join-btn, action-btn |
+| Formulario | p-input, otp-box, toggle-row, level-pick |
+| Navegación | p-tabbar/p-tab, admin-nav/item, partidas-tabs |
+| Tarjeta | reserva-card, partida-card, court-card, home-next |
+| Datos / display | info-pill, player-chip, kpi, cal-event, chip/slot |
+| Estado / feedback | success-ico, delete-warn, rgpd-block, filter-chip, table-head/row |
+| Layout | resdet, phone, desktop+admin |
+
+**Total: 28 componentes catalogados** (superando el mínimo de 19 requerido).

--- a/docs/ux/design-tokens.md
+++ b/docs/ux/design-tokens.md
@@ -1,0 +1,168 @@
+# PadelPro · Design Tokens
+
+Referencia completa de los tokens del sistema de diseño.
+Todos los tokens se definen como custom properties CSS en `:root` dentro de `mockups/_shared/styles.css`.
+
+---
+
+## Paleta de colores
+
+### Colores base (backgrounds e ink)
+
+| Token | Valor hex | Uso |
+|-------|-----------|-----|
+| `--bg-cream` | `#FAFAF5` | Fondo de pantallas mobile y contenido principal |
+| `--bg-warm` | `#F4F2EA` | Fondo de la aplicación mockup (stage background) |
+| `--ink` | `#0A0A0A` | Texto principal, fondos de hero, botones primarios oscuros |
+| `--ink-soft` | `#2A2A28` | Separadores sobre fondo oscuro, bordes de nav |
+
+### Texto muted
+
+| Token | Valor hex | Uso |
+|-------|-----------|-----|
+| `--muted` | `#6B6B66` | Labels secundarios, subtítulos, texto descriptivo |
+| `--muted-light` | `#A8A8A0` | Placeholder, metadata, números de línea horaria |
+
+### Bordes y líneas
+
+| Token | Valor hex | Uso |
+|-------|-----------|-----|
+| `--line` | `#E5E3D8` | Bordes de cards, separadores de sección, tablas |
+| `--line-soft` | `#EFEDE3` | Separadores sutiles, divisiones internas de cards |
+
+### Colores de marca
+
+| Token | Valor hex | Descripción | Uso |
+|-------|-----------|-------------|-----|
+| `--olive` | `#3F4A2E` | Verde oscuro tierra · color primario de marca | Fondos hero, eventos de calendario, botones `p-btn` base |
+| `--olive-dark` | `#2A3220` | Variante más oscura de olive | Hover states, eventos alternos en calendario |
+| `--lime` | `#C8FF3D` | Verde lima fluorescente · acento primario | CTAs positivos (`p-btn.lime`), nav activo, dot de marca, badges de capability |
+| `--lime-soft` | `#E8FFA0` | Lima suave | Fondos de badges de estado "vinculado", highlights |
+
+### Colores semánticos
+
+| Token | Valor hex | Significado | Uso |
+|-------|-----------|-------------|-----|
+| `--danger` | `#C7472D` | Error, destrucción, riesgo alto | Botón eliminar cuenta, mantenimiento en calendario, icono RGPD eliminar |
+| `--warn` | `#E8A33C` | Advertencia, pendiente de acción | Pill "Pago pendiente" en tabla de reservas admin |
+| `--info` | `#4A6FA5` | Información, contexto externo (Telegram) | Icono y avatar Telegram, nivel "medio" en partidas |
+
+---
+
+## Tipografía
+
+### Familias
+
+| Familia | Fuente | Uso |
+|---------|--------|-----|
+| `'Bricolage Grotesque'` | Google Fonts | Display, títulos principales, números grandes (KPIs, hora) |
+| `'Geist'` | Google Fonts | Cuerpo de texto, labels, UI general |
+| `'Geist Mono'` | Google Fonts | Datos estructurados, códigos de reserva, timers OTP, metadata técnica |
+
+**Fallbacks:** `sans-serif` para Bricolage Grotesque y Geist; `monospace` para Geist Mono.
+
+**Subsets importados:**
+- Bricolage Grotesque: `opsz` 12–96, pesos 400/500/600/700/800
+- Geist: pesos 300/400/500/600/700
+- Geist Mono: pesos 400/500
+
+### Escala de tamaños
+
+| Uso | Tamaño | Familia | Peso | Letter-spacing |
+|-----|--------|---------|------|---------------|
+| Stage title (mockup) | 42px | Bricolage Grotesque | 700 | -0.03em |
+| Título H1 mobile | 28–32px | Bricolage Grotesque | 800 | -0.03em |
+| Título H1 admin desktop | 22–24px | Bricolage Grotesque | 700 | -0.02em |
+| Número KPI grande | 28–32px | Bricolage Grotesque | 800 | -0.03em |
+| Número de hora (partida) | 24px | Bricolage Grotesque | 700 | -0.02em |
+| Subtítulo H2/H3 | 13–15px | Geist | 600 | — |
+| Cuerpo de texto | 13–14px | Geist | 400 | — |
+| Label pequeño | 11–12px | Geist | 400/500 | — |
+| Código / monospace | 11–13px | Geist Mono | 400/500 | 0.04–0.1em |
+| Micro label (metadata) | 9–10px | Geist Mono | 400 | 0.06–0.12em |
+
+### Line heights
+
+| Contexto | Valor |
+|----------|-------|
+| Títulos display | `1` / `1.1` |
+| Cuerpo de texto | `1.5` |
+| Descripciones largas | `1.6` |
+
+---
+
+## Espaciado
+
+El sistema de espaciado es libre (no usa escala de tokens nombrados), pero los valores recurrentes son:
+
+| Valor | Uso habitual |
+|-------|-------------|
+| `4px` | Gap entre badges, separación mínima entre elementos inline |
+| `6px` | Padding interno de badges pequeños |
+| `8px` | Margen entre label y valor, separación de iconos |
+| `12px` | Gap interno de rows (profile-row, toggle-row) |
+| `14px` | Padding interno de cards compactas (info-pill, rgpd-block) |
+| `16px` | Padding interno de cards móviles, gap entre secciones de perfil |
+| `20px` | Margen entre secciones, gap de la grid de pistas |
+| `24px` | Padding horizontal de contenido mobile, margen de sección |
+| `28px` | Margen superior de elementos de formulario destacados |
+| `32px` | Padding de cabeceras de stage |
+| `40px` | Padding horizontal del layout desktop admin |
+| `48px` | Padding superior del hero de índice |
+| `60px` | Padding inferior de grids de contenido |
+
+---
+
+## Border radius
+
+| Token (clase o contexto) | Valor | Uso |
+|--------------------------|-------|-----|
+| Phone frame | `48px` | Marco exterior del teléfono |
+| Desktop frame | `12px` | Marco exterior del mockup desktop |
+| Cards grandes | `24px` | Cards de hero (checkout, pago confirmado) |
+| Cards estándar | `16px` | Cards de reserva, KPI, pista, tabla admin, checkout card |
+| Cards de partida | `16px` | `partida-card` |
+| Botones `p-btn` | `14px` | Botones primarios mobile |
+| Botones `admin-btn` | `8px` | Botones admin |
+| Info pills | `12px` | `info-pill`, `rgpd-block` |
+| OTP boxes | `12px` | Cajas de código OTP |
+| Badges inline | `6–8px` | Pills de estado (OK, Pago, Cancelada) |
+| Dots / indicadores | `50%` | Punto de marca, avatares circulares |
+
+---
+
+## Sombras
+
+| Contexto | Valor | Uso |
+|----------|-------|-----|
+| Phone frame | `0 32px 64px rgba(0,0,0,0.18)` | Elevación del frame de teléfono |
+| OTP box activo | `0 0 0 3px var(--olive)` | Foco visible en campo OTP activo |
+| Card hover (index) | `0 4px 16px rgba(0,0,0,0.06)` | Hover sutil en tarjetas del índice |
+| Desktop frame | `0 24px 48px rgba(0,0,0,0.12)` | Elevación del frame de desktop |
+
+---
+
+## Iconografía
+
+Los iconos se implementan como SVG inline con las siguientes propiedades base:
+
+| Propiedad | Valor |
+|-----------|-------|
+| Viewbox | `0 0 24 24` |
+| Fill | `none` |
+| Stroke | `currentColor` |
+| Stroke-width | `2` (nav, formularios) / `2.5` (botones back, OTP) |
+| Tamaño mobile | `18px` (lista), `16px` (nav admin) |
+| Tamaño desktop | `16px` (sidebar), `14px` (tabla) |
+
+**Excepción:** El icono de Telegram usa `fill="currentColor"` en lugar de stroke, ya que es una forma sólida.
+
+---
+
+## Tokens de z-index
+
+| Capa | Valor | Uso |
+|------|-------|-----|
+| Chrome (barra de navegación del mockup) | `100` | Siempre encima del contenido |
+| Tab bar mobile | `10` | Sobre el scroll de contenido |
+| Sticky footer (resdet-footer) | Auto | Pegado al fondo del frame del teléfono |

--- a/docs/ux/flujos.md
+++ b/docs/ux/flujos.md
@@ -1,0 +1,199 @@
+# PadelPro · Flujos de usuario
+
+Seis diagramas Mermaid que cubren los flujos principales de la aplicación.
+Las pantallas se referencian por su nombre de fichero (sin extensión).
+
+---
+
+## Flujo 1 · Onboarding y autenticación
+
+```mermaid
+flowchart TD
+    classDef screen fill:#e8f5a3,stroke:#8a9a2a,color:#1a1a17
+    classDef decision fill:#fff3d6,stroke:#c8922a,color:#1a1a17
+    classDef endpoint fill:#f0f0ec,stroke:#c0c0b8,color:#666
+
+    SPLASH[07-splash]:::screen
+    LOGIN[01-login]:::screen
+    REGISTER[08-crear-cuenta]:::screen
+    FORGOT[09-recuperar-password]:::screen
+    RESET[10-nueva-password]:::screen
+    HOME[02-home-jugador]:::screen
+
+    HAS_ACCOUNT{¿Tiene cuenta?}:::decision
+    CREDS_OK{¿Credenciales OK?}:::decision
+    LINK_SENT{Email enviado}:::decision
+
+    SPLASH --> HAS_ACCOUNT
+    HAS_ACCOUNT -- Sí --> LOGIN
+    HAS_ACCOUNT -- No --> REGISTER
+    REGISTER -->|POST /auth/register 201| HOME
+    LOGIN --> CREDS_OK
+    CREDS_OK -- OK --> HOME
+    CREDS_OK -- Error 401 --> LOGIN
+    CREDS_OK -- Olvidé --> FORGOT
+    FORGOT -->|POST /auth/forgot-password 200| LINK_SENT
+    LINK_SENT -->|Token en email| RESET
+    RESET -->|POST /auth/reset-password 200| LOGIN
+```
+
+---
+
+## Flujo 2 · Buscar y reservar pista
+
+```mermaid
+flowchart TD
+    classDef screen fill:#e8f5a3,stroke:#8a9a2a,color:#1a1a17
+    classDef decision fill:#fff3d6,stroke:#c8922a,color:#1a1a17
+    classDef endpoint fill:#f0f0ec,stroke:#c0c0b8,color:#666
+
+    HOME[02-home-jugador]:::screen
+    BUSCAR[03-buscar-disponibilidad]:::screen
+    CONFIRMAR[04-confirmar-reserva]:::screen
+    CHECKOUT[11-checkout-redsys]:::screen
+    SUCCESS[12-pago-confirmado]:::screen
+    MIS[05-mis-reservas]:::screen
+    DETALLE[13-detalle-reserva]:::screen
+
+    SLOT_OK{¿Slot disponible?}:::decision
+    PAGO_OK{¿Pago autorizado?}:::decision
+
+    HOME -->|Buscar pista| BUSCAR
+    BUSCAR -->|GET /pistas/disponibilidad| SLOT_OK
+    SLOT_OK -- Disponible --> CONFIRMAR
+    SLOT_OK -- Sin hueco --> BUSCAR
+    CONFIRMAR -->|POST /reservas 201| CHECKOUT
+    CHECKOUT --> PAGO_OK
+    PAGO_OK -- Redsys OK --> SUCCESS
+    PAGO_OK -- Error pago --> CHECKOUT
+    SUCCESS -->|Ver reserva| DETALLE
+    HOME -->|Mis reservas| MIS
+    MIS -->|Tap reserva| DETALLE
+```
+
+---
+
+## Flujo 3 · Pago Redsys
+
+```mermaid
+flowchart LR
+    classDef screen fill:#e8f5a3,stroke:#8a9a2a,color:#1a1a17
+    classDef external fill:#e0e8fa,stroke:#4a6fa5,color:#1a1a17
+    classDef decision fill:#fff3d6,stroke:#c8922a,color:#1a1a17
+
+    CONFIRMAR[04-confirmar-reserva]:::screen
+    CHECKOUT[11-checkout-redsys]:::screen
+    REDSYS[Redsys TPV]:::external
+    WEBHOOK[Webhook backend]:::external
+    SUCCESS[12-pago-confirmado]:::screen
+    DETALLE[13-detalle-reserva]:::screen
+
+    AUTH_OK{¿3DS OK?}:::decision
+    WEBHOOK_OK{¿Webhook 200?}:::decision
+
+    CONFIRMAR -->|POST /pagos/iniciar| CHECKOUT
+    CHECKOUT -->|Datos tarjeta| REDSYS
+    REDSYS --> AUTH_OK
+    AUTH_OK -- Autorizado --> WEBHOOK
+    AUTH_OK -- Denegado --> CHECKOUT
+    WEBHOOK --> WEBHOOK_OK
+    WEBHOOK_OK -- OK --> SUCCESS
+    WEBHOOK_OK -- Fallo --> DETALLE
+    SUCCESS -->|Ver reserva| DETALLE
+```
+
+---
+
+## Flujo 4 · Vinculación Telegram y OTP
+
+```mermaid
+flowchart TD
+    classDef screen fill:#e8f5a3,stroke:#8a9a2a,color:#1a1a17
+    classDef external fill:#e0e8fa,stroke:#4a6fa5,color:#1a1a17
+    classDef decision fill:#fff3d6,stroke:#c8922a,color:#1a1a17
+
+    PERFIL[14-mi-perfil]:::screen
+    VINCULAR[15-vincular-telegram]:::screen
+    BOT[Bot @PadelPro_bot]:::external
+    OTP[16-otp-telegram]:::screen
+
+    VINCULADO{¿Vinculado?}:::decision
+    OTP_OK{¿Código correcto?}:::decision
+    CADUCADO{¿Expirado?}:::decision
+
+    PERFIL --> VINCULADO
+    VINCULADO -- No --> VINCULAR
+    VINCULADO -- Sí --> PERFIL
+    VINCULAR -->|POST /telegram/link/initiate| BOT
+    BOT -->|Código 6 dígitos| OTP
+    OTP --> OTP_OK
+    OTP_OK -- OK -->|POST /telegram/link/verify 200| PERFIL
+    OTP_OK -- Error --> CADUCADO
+    CADUCADO -- Expirado --> VINCULAR
+    CADUCADO -- Incorrecto --> OTP
+```
+
+---
+
+## Flujo 5 · Partidas: crear y unirse
+
+```mermaid
+flowchart TD
+    classDef screen fill:#e8f5a3,stroke:#8a9a2a,color:#1a1a17
+    classDef decision fill:#fff3d6,stroke:#c8922a,color:#1a1a17
+
+    HOME[02-home-jugador]:::screen
+    ABIERTAS[21-partidas-abiertas]:::screen
+    CREAR[20-crear-partida]:::screen
+    DETALLE_R[13-detalle-reserva]:::screen
+    UNION[22-confirmar-union]:::screen
+    SUCCESS[12-pago-confirmado]:::screen
+
+    COMPLETA{¿Partida completa?}:::decision
+    PAGO_OK{¿Pago OK?}:::decision
+    NIVEL_OK{¿Nivel compatible?}:::decision
+
+    HOME -->|Buscar partidas| ABIERTAS
+    HOME -->|Nueva partida| DETALLE_R
+    DETALLE_R -->|Crear partida pública| CREAR
+    CREAR -->|POST /partidas 201| ABIERTAS
+    ABIERTAS -->|Tap partida| UNION
+    UNION --> NIVEL_OK
+    NIVEL_OK -- Compatible --> PAGO_OK
+    NIVEL_OK -- Incompatible --> ABIERTAS
+    PAGO_OK -- Pago OK -->|POST /partidas/{id}/unirse 200| SUCCESS
+    PAGO_OK -- Error pago --> UNION
+    SUCCESS --> COMPLETA
+    COMPLETA -- Sí --> SUCCESS
+    COMPLETA -- No (1h antes) --> ABIERTAS
+```
+
+---
+
+## Flujo 6 · RGPD: exportar datos y eliminar cuenta
+
+```mermaid
+flowchart TD
+    classDef screen fill:#e8f5a3,stroke:#8a9a2a,color:#1a1a17
+    classDef danger fill:#fbe8e0,stroke:#c0392b,color:#1a1a17
+    classDef decision fill:#fff3d6,stroke:#c8922a,color:#1a1a17
+    classDef external fill:#f0f0ec,stroke:#c0c0b8,color:#666
+
+    PERFIL[14-mi-perfil]:::screen
+    DATOS[23-mis-datos]:::screen
+    ELIMINAR[24-eliminar-cuenta]:::danger
+    EMAIL[Email con JSON]:::external
+    LOGIN[01-login]:::screen
+
+    CONFIRM_OK{¿"ELIMINAR [nombre]"?}:::decision
+    EXPORT_OK{¿Export enviado?}:::decision
+
+    PERFIL -->|RGPD| DATOS
+    DATOS -->|Solicitar exportación| EXPORT_OK
+    EXPORT_OK -- OK -->|POST /users/me/export 202| EMAIL
+    EXPORT_OK -- Error --> DATOS
+    DATOS -->|Eliminar cuenta| ELIMINAR
+    ELIMINAR --> CONFIRM_OK
+    CONFIRM_OK -- Correcto -->|DELETE /users/me 204| LOGIN
+    CONFIRM_OK -- Incorrecto --> ELIMINAR
+```

--- a/docs/ux/mockups/01-login.html
+++ b/docs/ux/mockups/01-login.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PadelPro · 01 · Iniciar sesión</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,500;12..96,600;12..96,700;12..96,800&family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="./_shared/styles.css">
+<style>
+.login { height: 100%; display: flex; flex-direction: column; padding: 36px 28px 32px; background: linear-gradient(180deg, var(--bg-cream) 0%, var(--bg-warm) 100%); }
+.login-hero { flex: 1; display: flex; flex-direction: column; justify-content: flex-end; padding-bottom: 8px; position: relative; }
+.login-hero .glyph { position: absolute; top: 20px; right: -10px; font-family: 'Bricolage Grotesque', sans-serif; font-size: 200px; font-weight: 800; line-height: 0.85; color: var(--lime); letter-spacing: -0.08em; opacity: 0.95; transform: rotate(-4deg); }
+.login-hero h1 { font-family: 'Bricolage Grotesque', sans-serif; font-size: 52px; font-weight: 700; line-height: 0.9; letter-spacing: -0.05em; position: relative; z-index: 2; }
+.login-hero h1 em { font-style: italic; font-weight: 500; color: var(--olive); }
+.login-hero .sub { margin-top: 16px; color: var(--muted); font-size: 14px; line-height: 1.5; max-width: 280px; position: relative; z-index: 2; }
+.login-form { display: flex; flex-direction: column; gap: 20px; margin-top: 28px; }
+.login-form .row { display: flex; flex-direction: column; gap: 4px; }
+.login-footer { margin-top: 18px; display: flex; justify-content: space-between; align-items: center; font-size: 13px; }
+.p-link { color: var(--ink); text-decoration: none; border-bottom: 1px solid var(--ink); font-weight: 500; }
+</style>
+</head>
+<body>
+<div class="chrome">
+  <div class="chrome-brand"><span class="dot"></span> PadelPro · Mockups</div>
+  <div style="font-family:'Geist Mono',monospace;font-size:11px;color:var(--muted-light)">01 · Iniciar sesión → <a href="./index.html" style="color:var(--lime)">índice</a></div>
+</div>
+
+<div class="stage active" style="display:flex;">
+  <div class="stage-header">
+    <div class="stage-title">
+      <span class="num">01 · ONBOARDING · MOBILE</span>
+      Iniciar sesión
+    </div>
+    <div class="stage-meta">
+      Capability: <span>auth-local</span><br>
+      Endpoint: <span>POST /api/v1/auth/login</span><br>
+      Permisos: <span>público</span>
+    </div>
+  </div>
+  <div class="stage-body">
+    <div class="phone">
+      <div class="phone-notch"></div>
+      <div class="phone-screen">
+        <div class="phone-status">
+          <span>9:41</span>
+          <span>● ● ●</span>
+        </div>
+        <div class="phone-content">
+          <div class="login">
+            <div class="login-hero">
+              <div class="glyph">PP</div>
+              <div class="p-logo" style="margin-bottom: auto;"><span class="dot"></span> PadelPro</div>
+              <h1>Reserva, <em>juega</em>, vuelve.</h1>
+              <p class="sub">Tu club, tus pistas y tus partidas en una sola app.</p>
+            </div>
+            <div class="login-form">
+              <div class="row">
+                <span class="p-input-label">Email</span>
+                <input class="p-input" type="email" value="laura.casado@padelpro.com">
+              </div>
+              <div class="row">
+                <span class="p-input-label">Contraseña</span>
+                <input class="p-input" type="password" value="••••••••••">
+              </div>
+              <button class="p-btn lime" style="margin-top: 8px;">
+                Entrar <span class="arrow">→</span>
+              </button>
+              <div class="login-footer">
+                <a href="#" class="p-link" style="font-size: 12px;">¿Olvidaste la contraseña?</a>
+                <a href="#" class="p-link" style="font-size: 12px;">Crear cuenta</a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <aside class="stage-notes">
+      <h3>Notas de diseño</h3>
+      <ul>
+        <li><b>Glifo "PP"</b> sobredimensionado en lima como marca distintiva; rota -4° para dinamismo deportivo.</li>
+        <li><b>Tipografía mixta</b>: Bricolage Grotesque para hero ("Reserva, juega, vuelve.") con itálica en verbo central.</li>
+        <li><b>Inputs sin caja</b>, solo línea inferior. Reduce ruido visual y se alinea con la estética editorial.</li>
+        <li><b>CTA primario en lima</b> + flecha →: claridad de acción sin saturar.</li>
+        <li>Cubre <span class="cap">auth-local</span> Req 1, scenarios "login válido" e "input inválido".</li>
+      </ul>
+    </aside>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/ux/mockups/02-home-jugador.html
+++ b/docs/ux/mockups/02-home-jugador.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PadelPro · 02 · Home del jugador</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,500;12..96,600;12..96,700;12..96,800&family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="./_shared/styles.css">
+<style>
+.home { padding-bottom: 110px; }
+.home-top { display: flex; justify-content: space-between; align-items: center; margin-bottom: 26px; }
+.home-avatar { width: 40px; height: 40px; background: var(--olive); color: var(--lime); border-radius: 50%; display: flex; align-items: center; justify-content: center; font-family: 'Bricolage Grotesque', sans-serif; font-weight: 700; font-size: 15px; }
+.home-greet { margin-bottom: 24px; }
+.home-greet .p-eyebrow { margin-bottom: 8px; }
+.home-greet h1 { font-family: 'Bricolage Grotesque', sans-serif; font-size: 38px; font-weight: 700; line-height: 0.95; letter-spacing: -0.04em; }
+.home-greet h1 em { font-style: italic; font-weight: 500; color: var(--olive); }
+.home-actions { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-bottom: 28px; }
+.home-action { background: white; border: 1px solid var(--line); border-radius: 18px; padding: 18px 16px; cursor: pointer; transition: all 0.15s; }
+.home-action.primary { background: var(--lime); border-color: var(--lime); }
+.home-action .ico { width: 32px; height: 32px; display: flex; align-items: center; justify-content: center; margin-bottom: 18px; }
+.home-action .label { font-family: 'Bricolage Grotesque', sans-serif; font-size: 17px; font-weight: 700; line-height: 1.1; letter-spacing: -0.02em; }
+.home-action .sub { font-size: 11px; color: var(--muted); margin-top: 3px; }
+.home-action.primary .sub { color: var(--olive-dark); }
+.home-section-title { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 14px; }
+.home-section-title h2 { font-family: 'Bricolage Grotesque', sans-serif; font-size: 18px; font-weight: 700; letter-spacing: -0.02em; }
+.home-section-title a { font-family: 'Geist Mono', monospace; font-size: 10px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--muted); text-decoration: none; }
+.home-stat-row { display: flex; gap: 12px; }
+.home-stat { flex: 1; background: var(--bg-warm); border-radius: 16px; padding: 16px; }
+.home-stat .num { font-family: 'Bricolage Grotesque', sans-serif; font-size: 32px; font-weight: 700; letter-spacing: -0.03em; line-height: 1; }
+.home-stat .lab { font-family: 'Geist Mono', monospace; font-size: 10px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); margin-top: 6px; }
+</style>
+</head>
+<body>
+<div class="chrome">
+  <div class="chrome-brand"><span class="dot"></span> PadelPro · Mockups</div>
+  <div style="font-family:'Geist Mono',monospace;font-size:11px;color:var(--muted-light)">02 · Home del jugador → <a href="./index.html" style="color:var(--lime)">índice</a></div>
+</div>
+
+<div class="stage active" style="display:flex;">
+  <div class="stage-header">
+    <div class="stage-title">
+      <span class="num">02 · RESERVAS · MOBILE</span>
+      Home del jugador
+    </div>
+    <div class="stage-meta">
+      Capability: <span>reservas, disponibilidad-pistas</span><br>
+      Endpoints: <span>GET /reservas/mias, GET /pistas/disponibles</span><br>
+      Permisos: <span>JUGADOR autenticado</span>
+    </div>
+  </div>
+  <div class="stage-body">
+    <div class="phone">
+      <div class="phone-notch"></div>
+      <div class="phone-screen">
+        <div class="phone-status">
+          <span>9:41</span>
+          <span>● ● ●</span>
+        </div>
+        <div class="phone-content">
+          <div class="p-screen home">
+            <div class="home-top">
+              <div class="p-logo"><span class="dot"></span> PadelPro</div>
+              <div class="home-avatar">LC</div>
+            </div>
+            <div class="home-greet">
+              <span class="p-eyebrow">Buenas tardes</span>
+              <h1>Hola,<br><em>Laura.</em></h1>
+            </div>
+
+            <div class="home-next">
+              <div class="tag"><span class="live"></span> Próxima reserva · en 3 horas</div>
+              <div class="time">18:00 — 19:30</div>
+              <div class="court">Pista 3 · Cristal · Outdoor</div>
+              <div class="meta">
+                <div>Hoy<br><b>Jueves 22 May</b></div>
+                <div>Pago<br><b>Confirmado · 16€</b></div>
+                <div>Compañeros<br><b>3 · faltan 0</b></div>
+              </div>
+            </div>
+
+            <div class="home-actions">
+              <div class="home-action primary">
+                <div class="ico">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <rect x="3" y="4" width="18" height="18" rx="2"/>
+                    <line x1="16" y1="2" x2="16" y2="6"/>
+                    <line x1="8" y1="2" x2="8" y2="6"/>
+                    <line x1="3" y1="10" x2="21" y2="10"/>
+                  </svg>
+                </div>
+                <div class="label">Reservar pista</div>
+                <div class="sub">Encuentra una franja libre</div>
+              </div>
+              <div class="home-action">
+                <div class="ico">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <circle cx="12" cy="12" r="9"/>
+                    <path d="M3 12h18M12 3a14 14 0 010 18M12 3a14 14 0 000 18"/>
+                  </svg>
+                </div>
+                <div class="label">Partidas abiertas</div>
+                <div class="sub">12 buscan jugador</div>
+              </div>
+            </div>
+
+            <div class="home-section-title">
+              <h2>Tu mes</h2>
+              <a href="#">Ver más →</a>
+            </div>
+            <div class="home-stat-row">
+              <div class="home-stat">
+                <div class="num">14</div>
+                <div class="lab">Partidos jugados</div>
+              </div>
+              <div class="home-stat">
+                <div class="num">21h</div>
+                <div class="lab">En pista</div>
+              </div>
+            </div>
+          </div>
+
+          <div class="p-tabbar">
+            <div class="p-tab active">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 12L12 3l9 9v9a2 2 0 01-2 2h-4v-7H9v7H5a2 2 0 01-2-2v-9z"/></svg>
+              Inicio
+            </div>
+            <div class="p-tab">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.5" y2="16.5"/></svg>
+              Buscar
+            </div>
+            <div class="p-tab">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+              Reservas
+            </div>
+            <div class="p-tab">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="8" r="4"/><path d="M4 21v-1a7 7 0 0114 0v1"/></svg>
+              Perfil
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <aside class="stage-notes">
+      <h3>Notas de diseño</h3>
+      <ul>
+        <li><b>Hero "Próxima reserva"</b> en negro con burbuja lima como punto focal; refuerza qué es lo siguiente que va a hacer el usuario.</li>
+        <li><b>Live dot</b> pulsante: detalle de microinteracción que comunica "esto está sucediendo ahora".</li>
+        <li><b>Acción primaria en lima</b> ("Reservar pista") vs secundaria neutra: jerarquía clara sin caer en colores múltiples.</li>
+        <li>Datos "Tu mes" usan números grandes Bricolage: estética de revista deportiva.</li>
+        <li>Cubre <span class="cap">reservas</span> Req 1 (ver propias) y <span class="cap">disponibilidad-pistas</span>.</li>
+      </ul>
+    </aside>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/ux/mockups/03-buscar-disponibilidad.html
+++ b/docs/ux/mockups/03-buscar-disponibilidad.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PadelPro · 03 · Buscar disponibilidad</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,500;12..96,600;12..96,700;12..96,800&family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="./_shared/styles.css">
+<style>
+.search { padding-bottom: 110px; }
+.search-top { display: flex; align-items: center; gap: 12px; margin-bottom: 28px; }
+.search-back { width: 40px; height: 40px; border: 1px solid var(--line); border-radius: 50%; background: white; display: flex; align-items: center; justify-content: center; cursor: pointer; }
+.search-top h1 { font-family: 'Bricolage Grotesque', sans-serif; font-size: 22px; font-weight: 700; letter-spacing: -0.02em; }
+.search-section { margin-bottom: 24px; }
+.search-section .p-eyebrow { margin-bottom: 12px; }
+.date-strip { display: flex; gap: 8px; overflow-x: auto; padding-bottom: 4px; margin: 0 -22px; padding-left: 22px; padding-right: 22px; }
+.date-strip::-webkit-scrollbar { display: none; }
+.date-cell { flex-shrink: 0; width: 64px; background: white; border: 1px solid var(--line); border-radius: 14px; padding: 12px 8px; text-align: center; cursor: pointer; }
+.date-cell.active { background: var(--ink); border-color: var(--ink); }
+.date-cell .dow { font-family: 'Geist Mono', monospace; font-size: 10px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--muted); }
+.date-cell.active .dow { color: var(--muted-light); }
+.date-cell .num { font-family: 'Bricolage Grotesque', sans-serif; font-size: 24px; font-weight: 700; letter-spacing: -0.02em; margin-top: 4px; color: var(--ink); }
+.date-cell.active .num { color: var(--lime); }
+.court-list { display: flex; flex-direction: column; gap: 12px; margin-top: 8px; }
+.court-item { background: white; border: 1px solid var(--line); border-radius: 18px; padding: 18px; }
+.court-item .head { display: flex; justify-content: space-between; align-items: start; margin-bottom: 14px; }
+.court-item .name { font-family: 'Bricolage Grotesque', sans-serif; font-size: 18px; font-weight: 700; letter-spacing: -0.02em; }
+.court-item .type { font-family: 'Geist Mono', monospace; font-size: 10px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); margin-top: 4px; }
+.court-item .price { font-family: 'Bricolage Grotesque', sans-serif; font-size: 22px; font-weight: 700; letter-spacing: -0.03em; }
+.court-item .price small { font-family: 'Geist Mono', monospace; font-size: 10px; color: var(--muted); font-weight: 400; display: block; margin-top: 2px; letter-spacing: 0.08em; text-transform: uppercase; }
+</style>
+</head>
+<body>
+<div class="chrome">
+  <div class="chrome-brand"><span class="dot"></span> PadelPro · Mockups</div>
+  <div style="font-family:'Geist Mono',monospace;font-size:11px;color:var(--muted-light)">03 · Buscar disponibilidad → <a href="./index.html" style="color:var(--lime)">índice</a></div>
+</div>
+
+<div class="stage active" style="display:flex;">
+  <div class="stage-header">
+    <div class="stage-title">
+      <span class="num">03 · RESERVAS · MOBILE</span>
+      Buscar disponibilidad
+    </div>
+    <div class="stage-meta">
+      Capability: <span>disponibilidad-pistas</span><br>
+      Endpoint: <span>GET /api/v1/pistas/disponibilidad</span><br>
+      Permisos: <span>JUGADOR · INVITADO</span>
+    </div>
+  </div>
+  <div class="stage-body">
+    <div class="phone">
+      <div class="phone-notch"></div>
+      <div class="phone-screen">
+        <div class="phone-status">
+          <span>9:41</span>
+          <span>● ● ●</span>
+        </div>
+        <div class="phone-content">
+          <div class="p-screen search">
+            <div class="search-top">
+              <div class="search-back">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="15 18 9 12 15 6"/></svg>
+              </div>
+              <h1>Buscar pista</h1>
+            </div>
+
+            <div class="search-section">
+              <span class="p-eyebrow">Fecha</span>
+              <div class="date-strip">
+                <div class="date-cell"><div class="dow">Mié</div><div class="num">21</div></div>
+                <div class="date-cell active"><div class="dow">Jue</div><div class="num">22</div></div>
+                <div class="date-cell"><div class="dow">Vie</div><div class="num">23</div></div>
+                <div class="date-cell"><div class="dow">Sáb</div><div class="num">24</div></div>
+                <div class="date-cell"><div class="dow">Dom</div><div class="num">25</div></div>
+                <div class="date-cell"><div class="dow">Lun</div><div class="num">26</div></div>
+                <div class="date-cell"><div class="dow">Mar</div><div class="num">27</div></div>
+              </div>
+            </div>
+
+            <div class="search-section">
+              <span class="p-eyebrow">Franja</span>
+              <div class="chip-row">
+                <div class="chip">Mañana</div>
+                <div class="chip">Mediodía</div>
+                <div class="chip active">Tarde</div>
+                <div class="chip">Noche</div>
+              </div>
+            </div>
+
+            <div class="search-section">
+              <span class="p-eyebrow">Tipo · 3 pistas disponibles</span>
+              <div class="court-list">
+                <div class="court-item">
+                  <div class="head">
+                    <div>
+                      <div class="name">Pista Central</div>
+                      <div class="type">Cristal · Indoor · 4 jug.</div>
+                    </div>
+                    <div class="price">18€<small>/90min</small></div>
+                  </div>
+                  <div class="court-slots">
+                    <div class="slot taken">17:00</div>
+                    <div class="slot taken">18:30</div>
+                    <div class="slot hot">20:00</div>
+                    <div class="slot">21:30</div>
+                  </div>
+                </div>
+
+                <div class="court-item">
+                  <div class="head">
+                    <div>
+                      <div class="name">Pista 3</div>
+                      <div class="type">Cristal · Outdoor · 4 jug.</div>
+                    </div>
+                    <div class="price">16€<small>/90min</small></div>
+                  </div>
+                  <div class="court-slots">
+                    <div class="slot">17:00</div>
+                    <div class="slot hot">18:30</div>
+                    <div class="slot">20:00</div>
+                    <div class="slot taken">21:30</div>
+                  </div>
+                </div>
+
+                <div class="court-item">
+                  <div class="head">
+                    <div>
+                      <div class="name">Pista 5</div>
+                      <div class="type">Muro · Outdoor · 4 jug.</div>
+                    </div>
+                    <div class="price">14€<small>/90min</small></div>
+                  </div>
+                  <div class="court-slots">
+                    <div class="slot">17:00</div>
+                    <div class="slot">18:30</div>
+                    <div class="slot">20:00</div>
+                    <div class="slot">21:30</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="p-tabbar">
+            <div class="p-tab">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 12L12 3l9 9v9a2 2 0 01-2 2h-4v-7H9v7H5a2 2 0 01-2-2v-9z"/></svg>
+              Inicio
+            </div>
+            <div class="p-tab active">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.5" y2="16.5"/></svg>
+              Buscar
+            </div>
+            <div class="p-tab">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+              Reservas
+            </div>
+            <div class="p-tab">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="8" r="4"/><path d="M4 21v-1a7 7 0 0114 0v1"/></svg>
+              Perfil
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <aside class="stage-notes">
+      <h3>Notas de diseño</h3>
+      <ul>
+        <li><b>Date strip</b> con scroll horizontal; día activo invertido a negro+lima para destacar.</li>
+        <li><b>Slot "hot"</b> en lima señala franjas recomendadas (por ej. mismo horario que la última reserva).</li>
+        <li><b>Slots taken</b> con tachado y opacidad: el usuario ve qué NO puede en lugar de ocultarlo.</li>
+        <li><b>Precio prominente</b> en cada pista con tipografía display: decisión clave para reservar.</li>
+        <li>Cubre <span class="cap">disponibilidad-pistas</span> Req 1-3 y <span class="cap">pistas</span>.</li>
+      </ul>
+    </aside>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/ux/mockups/04-confirmar-reserva.html
+++ b/docs/ux/mockups/04-confirmar-reserva.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PadelPro · 04 · Confirmar reserva</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,500;12..96,600;12..96,700;12..96,800&family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="./_shared/styles.css">
+</head>
+<body>
+<div class="chrome">
+  <div class="chrome-brand"><span class="dot"></span> PadelPro · Mockups</div>
+  <div style="font-family:'Geist Mono',monospace;font-size:11px;color:var(--muted-light)">04 · Confirmar reserva → <a href="./index.html" style="color:var(--lime)">índice</a></div>
+</div>
+
+<div class="stage active" style="display:flex;">
+  <div class="stage-header">
+    <div class="stage-title">
+      <span class="num">04 · RESERVAS · MOBILE</span>
+      Confirmar reserva
+    </div>
+    <div class="stage-meta">
+      Capability: <span>reservas, pagos-redsys</span><br>
+      Endpoint: <span>POST /api/v1/reservas</span><br>
+      Permisos: <span>JUGADOR autenticado</span>
+    </div>
+  </div>
+  <div class="stage-body">
+    <div class="phone">
+      <div class="phone-notch"></div>
+      <div class="phone-screen">
+        <div class="phone-status">
+          <span>9:41</span>
+          <span style="color:white;">● ● ●</span>
+        </div>
+        <div class="phone-content">
+          <div class="detail">
+            <div class="detail-hero">
+              <div class="detail-back">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="15 18 9 12 15 6"/></svg>
+              </div>
+              <span style="font-family:'Geist Mono',monospace;font-size:10px;text-transform:uppercase;letter-spacing:0.12em;color:var(--lime);">Jueves 22 Mayo · 18:30</span>
+              <div class="court-name" style="margin-top: 14px;">Pista 3</div>
+              <div style="font-size:14px;color:var(--muted-light);">Club Pádel Madrid Este</div>
+              <div class="tags">
+                <div class="tag">Cristal</div>
+                <div class="tag">Outdoor</div>
+                <div class="tag">4 jugadores</div>
+              </div>
+            </div>
+            <div class="detail-body">
+              <div class="detail-row">
+                <span class="lab">Horario</span>
+                <span class="val lg">18:30 — 20:00</span>
+              </div>
+              <div class="detail-row">
+                <span class="lab">Duración</span>
+                <span class="val">90 minutos</span>
+              </div>
+              <div class="detail-row">
+                <span class="lab">Pago</span>
+                <span class="val">Redsys · tarjeta</span>
+              </div>
+              <div class="detail-row">
+                <span class="lab">Compañeros (3)</span>
+                <span class="val">Tú · 3 invitados</span>
+              </div>
+
+              <div class="detail-policy">
+                <b>Política de cancelación</b>
+                Cancelación gratuita hasta 24h antes (100% reembolso).
+                Cancelaciones con menos de 24h no reembolsables. <span style="color:var(--olive);font-weight:600;">RN-04</span>
+              </div>
+            </div>
+            <div class="detail-footer">
+              <div class="total">
+                <div class="lab">Total · iva incl.</div>
+                <div class="price">16,00 €</div>
+              </div>
+              <button class="p-btn lime">Reservar →</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <aside class="stage-notes">
+      <h3>Notas de diseño</h3>
+      <ul>
+        <li><b>Hero en olive oscuro</b> con burbuja lima difusa: invierte la jerarquía y eleva la "pista elegida" como protagonista.</li>
+        <li><b>Política de cancelación</b> referencia explícita a RN-04: el spec lo exige y la UI lo materializa.</li>
+        <li><b>Footer sticky</b> con total grande + CTA: patrón de checkout móvil estándar pero refinado.</li>
+        <li><b>Eyebrow día/hora</b> en lima sobre el hero: ancla temporal antes de mostrar el qué.</li>
+        <li>Cubre <span class="cap">reservas</span> Req 1 (crear) y enlaza a <span class="cap">pagos-redsys</span>.</li>
+      </ul>
+    </aside>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/ux/mockups/05-mis-reservas.html
+++ b/docs/ux/mockups/05-mis-reservas.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PadelPro · 05 · Mis reservas</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,500;12..96,600;12..96,700;12..96,800&family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="./_shared/styles.css">
+</head>
+<body>
+<div class="chrome">
+  <div class="chrome-brand"><span class="dot"></span> PadelPro · Mockups</div>
+  <div style="font-family:'Geist Mono',monospace;font-size:11px;color:var(--muted-light)">05 · Mis reservas → <a href="./index.html" style="color:var(--lime)">índice</a></div>
+</div>
+
+<div class="stage active" style="display:flex;">
+  <div class="stage-header">
+    <div class="stage-title">
+      <span class="num">05 · RESERVAS · MOBILE</span>
+      Mis reservas
+    </div>
+    <div class="stage-meta">
+      Capability: <span>reservas</span><br>
+      Endpoint: <span>GET /api/v1/reservas/mias</span><br>
+      Permisos: <span>JUGADOR autenticado</span>
+    </div>
+  </div>
+  <div class="stage-body">
+    <div class="phone">
+      <div class="phone-notch"></div>
+      <div class="phone-screen">
+        <div class="phone-status">
+          <span>9:41</span>
+          <span>● ● ●</span>
+        </div>
+        <div class="phone-content">
+          <div class="p-screen reservas">
+            <h1>Tus<br><em style="font-style:italic;font-weight:500;color:var(--olive);">reservas</em></h1>
+            <div class="sub">14 partidos en lo que va de mes</div>
+
+            <div class="reservas-tabs">
+              <div class="reservas-tab active">Próximas · 3</div>
+              <div class="reservas-tab">Pasadas</div>
+              <div class="reservas-tab">Canceladas</div>
+            </div>
+
+            <div class="reservas-list">
+              <div class="reserva-card">
+                <span class="status confirmada">Confirmada</span>
+                <div class="date-band">
+                  <span>Hoy · <b>Jue 22 May</b></span>
+                  <span>R-2026-0512</span>
+                </div>
+                <div class="body">
+                  <div class="time-block">
+                    <div class="h">18:00</div>
+                    <div class="dur">90min</div>
+                  </div>
+                  <div class="info">
+                    <div class="court-n">Pista 3</div>
+                    <div class="court-m">Cristal · Outdoor · 16€</div>
+                  </div>
+                </div>
+              </div>
+
+              <div class="reserva-card">
+                <span class="status pendiente">Pendiente pago</span>
+                <div class="date-band">
+                  <span>Mañana · <b>Vie 23 May</b></span>
+                  <span>R-2026-0517</span>
+                </div>
+                <div class="body">
+                  <div class="time-block">
+                    <div class="h">20:00</div>
+                    <div class="dur">90min</div>
+                  </div>
+                  <div class="info">
+                    <div class="court-n">Pista Central</div>
+                    <div class="court-m">Cristal · Indoor · 18€</div>
+                  </div>
+                </div>
+              </div>
+
+              <div class="reserva-card">
+                <span class="status confirmada">Confirmada</span>
+                <div class="date-band">
+                  <span>Sáb 24 May</span>
+                  <span>R-2026-0521</span>
+                </div>
+                <div class="body">
+                  <div class="time-block">
+                    <div class="h">10:30</div>
+                    <div class="dur">90min</div>
+                  </div>
+                  <div class="info">
+                    <div class="court-n">Pista 5</div>
+                    <div class="court-m">Muro · Outdoor · 14€</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="p-tabbar">
+            <div class="p-tab">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 12L12 3l9 9v9a2 2 0 01-2 2h-4v-7H9v7H5a2 2 0 01-2-2v-9z"/></svg>
+              Inicio
+            </div>
+            <div class="p-tab">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.5" y2="16.5"/></svg>
+              Buscar
+            </div>
+            <div class="p-tab active">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+              Reservas
+            </div>
+            <div class="p-tab">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="8" r="4"/><path d="M4 21v-1a7 7 0 0114 0v1"/></svg>
+              Perfil
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <aside class="stage-notes">
+      <h3>Notas de diseño</h3>
+      <ul>
+        <li><b>H1 con itálica color olive</b>: misma fórmula visual que en Home, mantiene coherencia.</li>
+        <li><b>Tabs con contador</b> ("Próximas · 3") en lugar de números separados: ahorra clic mental.</li>
+        <li><b>Pill de estado</b> superpuesta a la card: lima=confirmada, ámbar=pendiente. Sin verde-rojo-amarillo cliché.</li>
+        <li><b>Time block</b> separado con border vertical: ancla la hora como dato más importante.</li>
+        <li><b>Código reserva</b> en mono pequeño: profesional, fácil de citar en soporte.</li>
+        <li>Cubre <span class="cap">reservas</span> Req "listar propias" con todos los estados.</li>
+      </ul>
+    </aside>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/ux/mockups/06-dashboard-club.html
+++ b/docs/ux/mockups/06-dashboard-club.html
@@ -1,0 +1,234 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PadelPro · 06 · Dashboard del club</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,500;12..96,600;12..96,700;12..96,800&family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="./_shared/styles.css">
+</head>
+<body>
+<div class="chrome">
+  <div class="chrome-brand"><span class="dot"></span> PadelPro · Mockups</div>
+  <div style="font-family:'Geist Mono',monospace;font-size:11px;color:var(--muted-light)">06 · Dashboard del club → <a href="./index.html" style="color:var(--lime)">índice</a></div>
+</div>
+
+<div class="stage active" style="display:flex;">
+  <div class="stage-header">
+    <div class="stage-title">
+      <span class="num">06 · ADMIN CLUB · DESKTOP</span>
+      Dashboard del club
+    </div>
+    <div class="stage-meta">
+      Capability: <span>administracion-club</span><br>
+      Endpoints: <span>GET /admin/kpis, GET /admin/ocupacion</span><br>
+      Permisos: <span>MANAGER_CLUB · ADMIN</span>
+    </div>
+  </div>
+  <div class="stage-body" style="gap: 40px;">
+    <div class="desktop">
+      <div class="desktop-bar">
+        <div class="traffic"><span></span><span></span><span></span></div>
+        <div class="url">padelpro.app/admin/dashboard</div>
+      </div>
+      <div class="desktop-content">
+        <div class="admin">
+          <div class="admin-sidebar">
+            <div class="admin-brand"><span class="dot"></span> PadelPro</div>
+            <div class="admin-club-pill">
+              <div class="lab">Gestionando</div>
+              <div class="name">Club Madrid Este</div>
+            </div>
+            <div class="admin-nav-section">Operación</div>
+            <div class="admin-nav">
+              <div class="admin-nav-item active">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>
+                Dashboard
+              </div>
+              <div class="admin-nav-item">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+                Calendario
+              </div>
+              <div class="admin-nav-item">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 17 9 11 13 15 21 7"/><polyline points="14 7 21 7 21 14"/></svg>
+                Reservas
+              </div>
+              <div class="admin-nav-item">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="6" width="20" height="14" rx="2"/><line x1="2" y1="10" x2="22" y2="10"/></svg>
+                Pagos
+              </div>
+            </div>
+            <div class="admin-nav-section">Configuración</div>
+            <div class="admin-nav">
+              <div class="admin-nav-item">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="9" y1="9" x2="9" y2="21"/></svg>
+                Pistas
+              </div>
+              <div class="admin-nav-item">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="8" r="4"/><path d="M4 21v-1a7 7 0 0114 0v1"/></svg>
+                Usuarios
+              </div>
+              <div class="admin-nav-item">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 01-2.83 2.83l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09a1.65 1.65 0 00-1-1.51 1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06a1.65 1.65 0 00.33-1.82 1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09a1.65 1.65 0 001.51-1 1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06a1.65 1.65 0 001.82.33H9a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06a1.65 1.65 0 00-.33 1.82V9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z"/></svg>
+                Política
+              </div>
+            </div>
+          </div>
+
+          <div class="admin-main">
+            <div class="admin-topbar">
+              <div>
+                <h1>Buenos días, Marcos.</h1>
+                <div class="date">Jueves · 22 mayo 2026 · semana 21</div>
+              </div>
+              <div class="admin-topbar-actions">
+                <button class="admin-btn">Exportar</button>
+                <button class="admin-btn dark">+ Nueva pista</button>
+              </div>
+            </div>
+
+            <div class="admin-content">
+              <div class="admin-kpis">
+                <div class="kpi hero">
+                  <div class="lab">Ocupación hoy</div>
+                  <div class="num">87%</div>
+                  <div class="delta">↑ 12% vs ayer</div>
+                </div>
+                <div class="kpi">
+                  <div class="lab">Reservas hoy</div>
+                  <div class="num">42</div>
+                  <div class="delta">↑ 6 vs media</div>
+                </div>
+                <div class="kpi">
+                  <div class="lab">Ingresos día</div>
+                  <div class="num">714€</div>
+                  <div class="delta">↑ 9%</div>
+                </div>
+                <div class="kpi">
+                  <div class="lab">Cancelaciones</div>
+                  <div class="num">3</div>
+                  <div class="delta neg">↑ 1 vs media</div>
+                </div>
+              </div>
+
+              <div class="admin-grid">
+                <div class="admin-panel">
+                  <div class="admin-panel-head">
+                    <h3>Ocupación hoy · por pista</h3>
+                    <span class="filter">15:00 — 23:00 ▾</span>
+                  </div>
+                  <div class="timeline">
+                    <div class="timeline-hours">
+                      <div></div>
+                      <div class="scale">
+                        <span>15</span><span>16</span><span>17</span><span>18</span><span>19</span><span>20</span><span>21</span><span>22</span><span>23</span><span></span><span></span><span></span>
+                      </div>
+                    </div>
+                    <div class="timeline-row">
+                      <div class="timeline-court">P. Central<span class="t">Cristal · IN</span></div>
+                      <div class="timeline-bar">
+                        <div class="timeline-slot" style="left:8%;width:18%;background:var(--olive);">Sergio M.</div>
+                        <div class="timeline-slot" style="left:30%;width:18%;background:var(--olive-dark);">Laura C.</div>
+                        <div class="timeline-slot" style="left:52%;width:18%;background:var(--olive);">Iván R.</div>
+                        <div class="timeline-slot" style="left:74%;width:14%;background:var(--lime);color:var(--ink);">Libre</div>
+                      </div>
+                    </div>
+                    <div class="timeline-row">
+                      <div class="timeline-court">Pista 3<span class="t">Cristal · OUT</span></div>
+                      <div class="timeline-bar">
+                        <div class="timeline-slot" style="left:0%;width:14%;background:var(--olive);">M. Sanz</div>
+                        <div class="timeline-slot" style="left:16%;width:18%;background:var(--lime);color:var(--ink);">Libre</div>
+                        <div class="timeline-slot" style="left:36%;width:18%;background:var(--olive-dark);">Equipo Aldi</div>
+                        <div class="timeline-slot" style="left:58%;width:18%;background:var(--olive);">Carla L.</div>
+                        <div class="timeline-slot" style="left:80%;width:18%;background:var(--olive-dark);">P. Vega</div>
+                      </div>
+                    </div>
+                    <div class="timeline-row">
+                      <div class="timeline-court">Pista 5<span class="t">Muro · OUT</span></div>
+                      <div class="timeline-bar">
+                        <div class="timeline-slot" style="left:0%;width:36%;background:var(--olive);">Liga municipal</div>
+                        <div class="timeline-slot" style="left:38%;width:14%;background:var(--olive-dark);">D. Ríos</div>
+                        <div class="timeline-slot" style="left:54%;width:14%;background:var(--lime);color:var(--ink);">Libre</div>
+                        <div class="timeline-slot" style="left:70%;width:14%;background:var(--olive);">J. Pérez</div>
+                        <div class="timeline-slot" style="left:86%;width:12%;background:var(--olive-dark);">Trío Sur</div>
+                      </div>
+                    </div>
+                    <div class="timeline-row">
+                      <div class="timeline-court">Pista 6<span class="t">Cristal · IN</span></div>
+                      <div class="timeline-bar">
+                        <div class="timeline-slot" style="left:0%;width:14%;background:var(--olive);">Sara F.</div>
+                        <div class="timeline-slot" style="left:16%;width:14%;background:var(--olive-dark);">N. Castro</div>
+                        <div class="timeline-slot" style="left:32%;width:18%;background:var(--olive);">A. Rivas</div>
+                        <div class="timeline-slot" style="left:52%;width:18%;background:var(--olive-dark);">Cuarteto J.</div>
+                        <div class="timeline-slot" style="left:72%;width:14%;background:var(--danger);">Mantenim.</div>
+                        <div class="timeline-slot" style="left:88%;width:10%;background:var(--lime);color:var(--ink);">Libre</div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="admin-side">
+                  <div class="admin-panel">
+                    <div class="admin-panel-head">
+                      <h3>Últimos pagos</h3>
+                      <span class="filter">Hoy ▾</span>
+                    </div>
+                    <div class="admin-list">
+                      <div class="admin-list-item">
+                        <div class="av">LC</div>
+                        <div class="info">
+                          <div class="name">Laura Casado</div>
+                          <div class="meta">P3 · 18:00 · Redsys</div>
+                        </div>
+                        <div class="amount">+16€</div>
+                      </div>
+                      <div class="admin-list-item">
+                        <div class="av">SM</div>
+                        <div class="info">
+                          <div class="name">Sergio Martín</div>
+                          <div class="meta">PC · 17:00 · Redsys</div>
+                        </div>
+                        <div class="amount">+18€</div>
+                      </div>
+                      <div class="admin-list-item">
+                        <div class="av">IR</div>
+                        <div class="info">
+                          <div class="name">Iván Reyes</div>
+                          <div class="meta">PC · 19:00 · Redsys</div>
+                        </div>
+                        <div class="amount">+18€</div>
+                      </div>
+                      <div class="admin-list-item">
+                        <div class="av">MS</div>
+                        <div class="info">
+                          <div class="name">María Sanz</div>
+                          <div class="meta">P3 · 15:00 · Redsys</div>
+                        </div>
+                        <div class="amount">+16€</div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <aside class="stage-notes" style="width: 280px;">
+      <h3>Notas de diseño</h3>
+      <ul>
+        <li><b>Sidebar negro</b> con club activo en pill: contexto siempre visible, evita errores entre clubes en multi-tenant.</li>
+        <li><b>KPI hero "Ocupación"</b> en negro con burbuja lima: misma fórmula que mobile, sistema consistente.</li>
+        <li><b>Timeline con tonos de olive</b> para reservas y lima para huecos libres: el manager ve "donde puedo meter más" en segundos.</li>
+        <li><b>Mantenimiento en rojo</b>: única excepción cromática reservada para estados problemáticos.</li>
+        <li><b>Lateral de pagos en vivo</b>: refuerza la sensación de "negocio funcionando".</li>
+        <li>Cubre <span class="cap">administracion-club</span> Req 1-2.</li>
+      </ul>
+    </aside>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/ux/mockups/07-splash.html
+++ b/docs/ux/mockups/07-splash.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PadelPro · 07 · Splash / Bienvenida</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,500;12..96,600;12..96,700;12..96,800&family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="./_shared/styles.css">
+</head>
+<body>
+<div class="chrome">
+  <div class="chrome-brand"><span class="dot"></span> PadelPro · Mockups</div>
+  <div style="font-family:'Geist Mono',monospace;font-size:11px;color:var(--muted-light)">07 · Splash / Bienvenida → <a href="./index.html" style="color:var(--lime)">índice</a></div>
+</div>
+
+<div class="stage active" style="display:flex;">
+  <div class="stage-header">
+    <div class="stage-title">
+      <span class="num">07 · ONBOARDING · MOBILE</span>
+      Splash / Bienvenida
+    </div>
+    <div class="stage-meta">
+      Capability: <span>auth-local</span><br>
+      Endpoint: <span>—</span><br>
+      Permisos: <span>público</span>
+    </div>
+  </div>
+  <div class="stage-body">
+    <div class="phone">
+      <div class="phone-notch"></div>
+      <div class="phone-screen">
+        <div class="phone-status dark"><span>9:41</span><span>● ● ●</span></div>
+        <div class="phone-content">
+          <div class="splash">
+            <div class="logo"><span class="dot"></span> PadelPro</div>
+            <div class="glyph">PP</div>
+            <div class="footer">
+              <div class="tagline">Reserva, <em>juega</em>,<br>vuelve.</div>
+              <div class="actions">
+                <button class="p-btn">Crear cuenta</button>
+                <button class="p-btn outline">Ya tengo cuenta</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <aside class="stage-notes">
+      <h3>Notas de diseño</h3>
+      <ul>
+        <li><b>Versión inversa</b> de la pantalla de login: fondo negro, glifo crema, esfera lima como masa visual dominante.</li>
+        <li>Solo dos acciones: crear cuenta (primario) o entrar (secundario). Cero ruido cognitivo.</li>
+        <li>Refuerza identidad de marca antes de pedir nada al usuario.</li>
+        <li>Cubre <span class="cap">auth-local</span> punto de entrada.</li>
+      </ul>
+    </aside>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/ux/mockups/08-crear-cuenta.html
+++ b/docs/ux/mockups/08-crear-cuenta.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PadelPro · 08 · Crear cuenta</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,500;12..96,600;12..96,700;12..96,800&family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="./_shared/styles.css">
+</head>
+<body>
+<div class="chrome">
+  <div class="chrome-brand"><span class="dot"></span> PadelPro · Mockups</div>
+  <div style="font-family:'Geist Mono',monospace;font-size:11px;color:var(--muted-light)">08 · Crear cuenta → <a href="./index.html" style="color:var(--lime)">índice</a></div>
+</div>
+
+<div class="stage active" style="display:flex;">
+  <div class="stage-header">
+    <div class="stage-title">
+      <span class="num">08 · ONBOARDING · MOBILE</span>
+      Crear cuenta
+    </div>
+    <div class="stage-meta">
+      Capability: <span>auth-local, usuarios</span><br>
+      Endpoint: <span>POST /api/v1/auth/register</span><br>
+      Permisos: <span>público</span>
+    </div>
+  </div>
+  <div class="stage-body">
+    <div class="phone">
+      <div class="phone-notch"></div>
+      <div class="phone-screen">
+        <div class="phone-status"><span>9:41</span><span>● ● ●</span></div>
+        <div class="phone-content">
+          <div class="reg">
+            <div class="p-back" style="margin-bottom: 24px;">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="15 18 9 12 15 6"/></svg>
+            </div>
+            <div class="reg-hero">
+              <div class="step">Paso 1 de 1</div>
+              <h1>Crea tu<br><em>cuenta.</em></h1>
+            </div>
+            <div class="reg-form">
+              <div class="row">
+                <span class="p-input-label">Nombre completo</span>
+                <input class="p-input" type="text" value="Laura Casado">
+              </div>
+              <div class="row">
+                <span class="p-input-label">Email</span>
+                <input class="p-input" type="email" value="laura.casado@email.com">
+              </div>
+              <div class="row">
+                <span class="p-input-label">Teléfono</span>
+                <input class="p-input" type="tel" value="+34 612 345 678">
+              </div>
+              <div class="row">
+                <span class="p-input-label">Contraseña</span>
+                <input class="p-input" type="password" value="••••••••••">
+              </div>
+              <div class="check">
+                <input type="checkbox" checked>
+                <span>Acepto los <a href="#">términos</a> y la <a href="#">política de privacidad</a>. He leído cómo se tratan mis datos según el RGPD.</span>
+              </div>
+              <button class="p-btn lime" style="margin-top: auto;">
+                Crear cuenta <span class="arrow">→</span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <aside class="stage-notes">
+      <h3>Notas de diseño</h3>
+      <ul>
+        <li><b>Un solo paso</b>: minimizamos fricción frente al wizard multi-pantalla típico.</li>
+        <li><b>Itálica en "cuenta"</b>: refuerza identidad editorial.</li>
+        <li><b>Check RGPD explícito</b>: requisito legal y cumple <span class="rn">RN-rgpd-01</span>.</li>
+        <li>El "Paso 1 de 1" parece innecesario pero comunica al usuario "no hay más".</li>
+        <li>Cubre <span class="cap">auth-local</span> Req registro y <span class="cap">usuarios</span> creación.</li>
+      </ul>
+    </aside>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/ux/mockups/09-recuperar-password.html
+++ b/docs/ux/mockups/09-recuperar-password.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PadelPro · 09 · Recuperar contraseña</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,500;12..96,600;12..96,700;12..96,800&family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="./_shared/styles.css">
+</head>
+<body>
+<div class="chrome">
+  <div class="chrome-brand"><span class="dot"></span> PadelPro · Mockups</div>
+  <div style="font-family:'Geist Mono',monospace;font-size:11px;color:var(--muted-light)">09 · Recuperar contraseña → <a href="./index.html" style="color:var(--lime)">índice</a></div>
+</div>
+
+<div class="stage active" style="display:flex;">
+  <div class="stage-header">
+    <div class="stage-title">
+      <span class="num">09 · ONBOARDING · MOBILE</span>
+      Recuperar contraseña
+    </div>
+    <div class="stage-meta">
+      Capability: <span>auth-local</span><br>
+      Endpoint: <span>POST /api/v1/auth/forgot-password</span><br>
+      Permisos: <span>público</span>
+    </div>
+  </div>
+  <div class="stage-body">
+    <div class="phone">
+      <div class="phone-notch"></div>
+      <div class="phone-screen">
+        <div class="phone-status"><span>9:41</span><span>● ● ●</span></div>
+        <div class="phone-content">
+          <div class="forgot">
+            <div class="p-back" style="margin-bottom: 28px;">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="15 18 9 12 15 6"/></svg>
+            </div>
+            <div class="forgot-hero">
+              <h1>¿Olvidaste la<br>contraseña?</h1>
+              <p>Tranquilo, te enviamos un enlace al email para que puedas crear una nueva.</p>
+            </div>
+            <div class="reg-form">
+              <div class="row">
+                <span class="p-input-label">Email registrado</span>
+                <input class="p-input" type="email" value="laura.casado@email.com">
+              </div>
+              <button class="p-btn lime" style="margin-top: 8px;">
+                Enviar enlace <span class="arrow">→</span>
+              </button>
+              <div style="text-align: center; margin-top: 24px; font-size: 13px; color: var(--muted);">
+                ¿Recuerdas tu contraseña? <a href="#" style="color: var(--ink); border-bottom: 1px solid var(--ink); text-decoration: none; font-weight: 500;">Inicia sesión</a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <aside class="stage-notes">
+      <h3>Notas de diseño</h3>
+      <ul>
+        <li><b>Mensaje tranquilizador</b> antes del campo: reduce ansiedad del usuario que ya está en mal momento.</li>
+        <li><b>Sin scroll</b>: una sola pantalla, una sola acción.</li>
+        <li>Por seguridad, la pantalla siguiente <b>no debe revelar</b> si el email existe (responde 200 siempre).</li>
+        <li>Cubre <span class="cap">auth-local</span> Req "recuperar contraseña".</li>
+      </ul>
+    </aside>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/ux/mockups/10-nueva-password.html
+++ b/docs/ux/mockups/10-nueva-password.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PadelPro · 10 · Nueva contraseña</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,500;12..96,600;12..96,700;12..96,800&family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="./_shared/styles.css">
+</head>
+<body>
+<div class="chrome">
+  <div class="chrome-brand"><span class="dot"></span> PadelPro · Mockups</div>
+  <div style="font-family:'Geist Mono',monospace;font-size:11px;color:var(--muted-light)">10 · Nueva contraseña → <a href="./index.html" style="color:var(--lime)">índice</a></div>
+</div>
+
+<div class="stage active" style="display:flex;">
+  <div class="stage-header">
+    <div class="stage-title">
+      <span class="num">10 · ONBOARDING · MOBILE</span>
+      Nueva contraseña
+    </div>
+    <div class="stage-meta">
+      Capability: <span>auth-local</span><br>
+      Endpoint: <span>POST /api/v1/auth/reset-password</span><br>
+      Permisos: <span>token reset válido</span>
+    </div>
+  </div>
+  <div class="stage-body">
+    <div class="phone">
+      <div class="phone-notch"></div>
+      <div class="phone-screen">
+        <div class="phone-status"><span>9:41</span><span>● ● ●</span></div>
+        <div class="phone-content">
+          <div class="forgot">
+            <div class="forgot-hero">
+              <div style="font-family: 'Geist Mono', monospace; font-size: 10px; text-transform: uppercase; letter-spacing: 0.12em; color: var(--muted); margin-bottom: 12px;">
+                Hola Laura
+              </div>
+              <h1>Crea una<br><em style="font-style:italic;font-weight:500;color:var(--olive);">nueva</em> contraseña</h1>
+              <p style="margin-top: 14px;">Debe tener al menos 8 caracteres, una mayúscula, un número y un símbolo.</p>
+            </div>
+            <div class="reg-form">
+              <div class="row">
+                <span class="p-input-label">Nueva contraseña</span>
+                <input class="p-input" type="password" value="••••••••••••">
+                <div class="reset-strength">
+                  <span class="fill1"></span>
+                  <span class="fill2"></span>
+                  <span class="fill3"></span>
+                  <span></span>
+                </div>
+                <div class="reset-strength-label">Fuerte</div>
+                <div class="reset-rules">
+                  <div class="ok">8 caracteres o más</div>
+                  <div class="ok">1 mayúscula</div>
+                  <div class="ok">1 número</div>
+                  <div class="ko" style="color:var(--muted);">1 símbolo (!@#$%)</div>
+                </div>
+              </div>
+              <div class="row" style="margin-top: 14px;">
+                <span class="p-input-label">Confirmar contraseña</span>
+                <input class="p-input" type="password" value="••••••••••••">
+              </div>
+              <button class="p-btn lime" style="margin-top: 14px;">
+                Guardar contraseña <span class="arrow">→</span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <aside class="stage-notes">
+      <h3>Notas de diseño</h3>
+      <ul>
+        <li><b>Barra de fuerza</b> con 4 segmentos: comunicación instantánea de calidad.</li>
+        <li><b>Reglas con check en tiempo real</b>: el usuario sabe qué le falta sin enviar el form.</li>
+        <li><b>"Hola Laura"</b> personaliza desde el token de reset; sin filtrar email si lo abre el dueño del enlace o terceros.</li>
+        <li>Cubre <span class="cap">auth-local</span> Req "reset con token" y <span class="rn">RN-auth-04</span> política de contraseñas.</li>
+      </ul>
+    </aside>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/ux/mockups/11-checkout-redsys.html
+++ b/docs/ux/mockups/11-checkout-redsys.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PadelPro · 11 · Checkout Redsys</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,500;12..96,600;12..96,700;12..96,800&family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="./_shared/styles.css">
+</head>
+<body>
+<div class="chrome">
+  <div class="chrome-brand"><span class="dot"></span> PadelPro · Mockups</div>
+  <div style="font-family:'Geist Mono',monospace;font-size:11px;color:var(--muted-light)">11 · Checkout Redsys → <a href="./index.html" style="color:var(--lime)">índice</a></div>
+</div>
+
+<div class="stage active" style="display:flex;">
+  <div class="stage-header">
+    <div class="stage-title">
+      <span class="num">11 · PAGO · MOBILE</span>
+      Checkout Redsys
+    </div>
+    <div class="stage-meta">
+      Capability: <span>pagos-redsys</span><br>
+      Endpoint: <span>POST /api/v1/pagos/iniciar → redirect Redsys</span><br>
+      Permisos: <span>JUGADOR autenticado</span>
+    </div>
+  </div>
+  <div class="stage-body">
+    <div class="phone">
+      <div class="phone-notch"></div>
+      <div class="phone-screen">
+        <div class="phone-status"><span>9:41</span><span>● ● ●</span></div>
+        <div class="phone-content">
+          <div class="checkout">
+            <div class="checkout-header">
+              <div class="p-back">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="15 18 9 12 15 6"/></svg>
+              </div>
+              <h1>Pagar con tarjeta</h1>
+            </div>
+            <div class="checkout-merch">
+              <div class="logo">PP</div>
+              <div class="info">
+                <div class="name">PadelPro · Club Madrid Este</div>
+                <div class="url">checkout.redsys.es/sis</div>
+              </div>
+              <div class="secure">
+                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0110 0v4"/></svg>
+                3DSv2
+              </div>
+            </div>
+            <div class="checkout-amount">
+              <div class="lab">Importe</div>
+              <div class="price">16,00€</div>
+              <div class="desc">Pista 3 · Jue 22 May · 18:30</div>
+            </div>
+
+            <div class="card-preview">
+              <div class="chip"></div>
+              <div class="num">4539 •••• •••• 7421</div>
+              <div class="row">
+                <div>Titular<b>Laura Casado</b></div>
+                <div>Caducidad<b>09 / 28</b></div>
+              </div>
+            </div>
+
+            <div class="form-row">
+              <span class="lab">Número de tarjeta</span>
+              <input class="form-input" type="text" value="4539 ••••  ••••  7421">
+            </div>
+            <div class="form-grid">
+              <div class="form-row" style="margin-bottom:0;">
+                <span class="lab">Caducidad</span>
+                <input class="form-input" type="text" value="09 / 28">
+              </div>
+              <div class="form-row" style="margin-bottom:0;">
+                <span class="lab">CVV</span>
+                <input class="form-input" type="text" value="•••">
+              </div>
+            </div>
+
+            <button class="p-btn lime">
+              Pagar 16,00€ <span class="arrow">→</span>
+            </button>
+
+            <div style="text-align: center; margin-top: 16px; font-family: 'Geist Mono', monospace; font-size: 10px; color: var(--muted); letter-spacing: 0.04em;">
+              Procesado por Redsys · HMAC SHA-256 · PCI-DSS L1
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <aside class="stage-notes">
+      <h3>Notas de diseño</h3>
+      <ul>
+        <li><b>Merchant header</b> con URL Redsys + 3DSv2: el usuario entiende que es checkout externo seguro.</li>
+        <li><b>Tarjeta visual</b> con bandas olive como simulación de Resy/Stripe: refuerza confianza.</li>
+        <li><b>Precio enorme</b> en hero del checkout: el usuario sabe exactamente qué paga.</li>
+        <li><b>Footer técnico discreto</b>: HMAC + PCI-DSS, sin asustar.</li>
+        <li>Cubre <span class="cap">pagos-redsys</span> Req "iniciar pago" + <span class="rn">RN-pago-01</span> firma HMAC SHA-256.</li>
+      </ul>
+    </aside>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/ux/mockups/12-pago-confirmado.html
+++ b/docs/ux/mockups/12-pago-confirmado.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PadelPro · 12 · Pago confirmado</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,500;12..96,600;12..96,700;12..96,800&family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="./_shared/styles.css">
+</head>
+<body>
+<div class="chrome">
+  <div class="chrome-brand"><span class="dot"></span> PadelPro · Mockups</div>
+  <div style="font-family:'Geist Mono',monospace;font-size:11px;color:var(--muted-light)">12 · Pago confirmado → <a href="./index.html" style="color:var(--lime)">índice</a></div>
+</div>
+
+<div class="stage active" style="display:flex;">
+  <div class="stage-header">
+    <div class="stage-title">
+      <span class="num">12 · PAGO · MOBILE</span>
+      Pago confirmado
+    </div>
+    <div class="stage-meta">
+      Capability: <span>pagos-redsys, reservas, notificaciones</span><br>
+      Endpoint: <span>Webhook Redsys → callback HMAC verificado</span><br>
+      Permisos: <span>JUGADOR autenticado</span>
+    </div>
+  </div>
+  <div class="stage-body">
+    <div class="phone">
+      <div class="phone-notch"></div>
+      <div class="phone-screen">
+        <div class="phone-status dark"><span>9:41</span><span>● ● ●</span></div>
+        <div class="phone-content">
+          <div class="success">
+            <div class="success-ico">
+              <svg viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="20 6 9 17 4 12"/>
+              </svg>
+            </div>
+            <h1>¡Pista <em>reservada!</em></h1>
+            <div class="sub">Te esperamos en pista el jueves a las 18:30</div>
+
+            <div class="success-card">
+              <div class="row">
+                <span class="lab">Reserva</span>
+                <span class="val">R-2026-0512</span>
+              </div>
+              <div class="row">
+                <span class="lab">Pista</span>
+                <span class="val">Pista 3 · Cristal</span>
+              </div>
+              <div class="row">
+                <span class="lab">Cuándo</span>
+                <span class="val">Jue 22 May · 18:30</span>
+              </div>
+              <div class="row">
+                <span class="lab">Importe</span>
+                <span class="val">16,00€</span>
+              </div>
+              <div class="row">
+                <span class="lab">Pago</span>
+                <span class="val" style="color:var(--lime);">✓ Confirmado</span>
+              </div>
+            </div>
+
+            <div style="text-align:center;font-family:'Geist Mono',monospace;font-size:10px;color:var(--muted-light);letter-spacing:0.08em;margin-bottom:8px;">
+              Recibo enviado a laura.casado@email.com
+            </div>
+
+            <div class="actions">
+              <button class="p-btn">Añadir al calendario</button>
+              <button class="p-btn outline">Ver reserva →</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <aside class="stage-notes">
+      <h3>Notas de diseño</h3>
+      <ul>
+        <li><b>Verde lima sobre negro</b>: éxito sin caer en el cliché del checkmark verde.</li>
+        <li><b>Glow radial detrás del ícono</b>: refuerza el momento de celebración.</li>
+        <li><b>Resumen escaneable</b> con check explícito en "Pago confirmado".</li>
+        <li><b>Recibo por email</b> mencionado: cierre del flujo + confianza.</li>
+        <li>Cubre <span class="cap">pagos-redsys</span> Req "callback OK", <span class="cap">notificaciones</span> "AFTER_COMMIT" <span class="rn">RN-notif-01</span>.</li>
+      </ul>
+    </aside>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/ux/mockups/13-detalle-reserva.html
+++ b/docs/ux/mockups/13-detalle-reserva.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PadelPro · 13 · Detalle de mi reserva</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,500;12..96,600;12..96,700;12..96,800&family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="./_shared/styles.css">
+</head>
+<body>
+<div class="chrome">
+  <div class="chrome-brand"><span class="dot"></span> PadelPro · Mockups</div>
+  <div style="font-family:'Geist Mono',monospace;font-size:11px;color:var(--muted-light)">13 · Detalle de mi reserva → <a href="./index.html" style="color:var(--lime)">índice</a></div>
+</div>
+
+<div class="stage active" style="display:flex;">
+  <div class="stage-header">
+    <div class="stage-title">
+      <span class="num">13 · RESERVAS · MOBILE</span>
+      Detalle de mi reserva
+    </div>
+    <div class="stage-meta">
+      Capability: <span>reservas</span><br>
+      Endpoint: <span>GET /api/v1/reservas/{id} · DELETE /api/v1/reservas/{id}</span><br>
+      Permisos: <span>JUGADOR (propias)</span>
+    </div>
+  </div>
+  <div class="stage-body">
+    <div class="phone">
+      <div class="phone-notch"></div>
+      <div class="phone-screen">
+        <div class="phone-status dark"><span>9:41</span><span>● ● ●</span></div>
+        <div class="phone-content">
+          <div class="resdet">
+            <div class="resdet-hero">
+              <div class="resdet-back">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="15 18 9 12 15 6"/></svg>
+              </div>
+              <div class="resdet-status">
+                <span class="dot"></span> Confirmada · empieza en 3h
+              </div>
+              <h1>Pista 3</h1>
+              <div class="meta">Cristal · Outdoor · Club Madrid Este</div>
+              <div class="code">R-2026-0512</div>
+            </div>
+            <div class="resdet-body">
+              <div class="resdet-section">
+                <h3>Horario</h3>
+                <div class="resdet-info-grid">
+                  <div class="info-pill">
+                    <div class="lab">Día</div>
+                    <div class="val">Jue 22 May</div>
+                  </div>
+                  <div class="info-pill">
+                    <div class="lab">Hora</div>
+                    <div class="val">18:30 — 20:00</div>
+                  </div>
+                </div>
+              </div>
+
+              <div class="resdet-section">
+                <h3>Jugadores · 3 de 4</h3>
+                <div class="players-row">
+                  <div class="player-chip">
+                    <div class="av">LC</div>
+                    Laura · Tú
+                  </div>
+                  <div class="player-chip">
+                    <div class="av">MR</div>
+                    Marcos R.
+                  </div>
+                  <div class="player-chip">
+                    <div class="av">PG</div>
+                    Pablo G.
+                  </div>
+                  <div class="player-chip empty">
+                    <div class="av">+</div>
+                    Invitar
+                  </div>
+                </div>
+              </div>
+
+              <div class="resdet-section">
+                <h3>Pago</h3>
+                <div class="resdet-info-grid">
+                  <div class="info-pill">
+                    <div class="lab">Importe</div>
+                    <div class="val">16,00 €</div>
+                  </div>
+                  <div class="info-pill">
+                    <div class="lab">Método</div>
+                    <div class="val">VISA •7421</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="resdet-footer">
+              <button class="p-btn outline" style="flex: 1;">Modificar</button>
+              <button class="p-btn danger" style="flex: 1.4;">Cancelar reserva</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <aside class="stage-notes">
+      <h3>Notas de diseño</h3>
+      <ul>
+        <li><b>Hero olive con código de reserva en lima</b>: jerarquía clara, código fácil de leer/citar.</li>
+        <li><b>Player chips con avatar</b>: ver al equipo de un vistazo + invitar a cuarto miembro.</li>
+        <li><b>Cancelar en rojo</b> como acción peligrosa, modificar neutro. Jerarquía de riesgo visible.</li>
+        <li><b>Sin overlay confuso</b>: el cancelar abre un modal con la política <span class="rn">RN-04</span> aplicada al caso.</li>
+        <li>Cubre <span class="cap">reservas</span> Req "ver detalle" + "cancelar".</li>
+      </ul>
+    </aside>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/ux/mockups/14-mi-perfil.html
+++ b/docs/ux/mockups/14-mi-perfil.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PadelPro · 14 · Mi perfil</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,500;12..96,600;12..96,700;12..96,800&family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="./_shared/styles.css">
+</head>
+<body>
+<div class="chrome">
+  <div class="chrome-brand"><span class="dot"></span> PadelPro · Mockups</div>
+  <div style="font-family:'Geist Mono',monospace;font-size:11px;color:var(--muted-light)">14 · Mi perfil → <a href="./index.html" style="color:var(--lime)">índice</a></div>
+</div>
+
+<div class="stage active" style="display:flex;">
+  <div class="stage-header">
+    <div class="stage-title">
+      <span class="num">14 · PERFIL · MOBILE</span>
+      Mi perfil
+    </div>
+    <div class="stage-meta">
+      Capability: <span>usuarios, auth-otp-telegram</span><br>
+      Endpoint: <span>GET /api/v1/users/me</span><br>
+      Permisos: <span>JUGADOR autenticado</span>
+    </div>
+  </div>
+  <div class="stage-body">
+    <div class="phone">
+      <div class="phone-notch"></div>
+      <div class="phone-screen">
+        <div class="phone-status"><span>9:41</span><span>● ● ●</span></div>
+        <div class="phone-content">
+          <div class="profile">
+            <div class="profile-head">
+              <div class="profile-avatar">LC</div>
+              <div class="info">
+                <h1>Laura Casado</h1>
+                <div class="email">laura.casado@email.com</div>
+              </div>
+            </div>
+
+            <div class="profile-section">
+              <h2>Cuenta</h2>
+              <div class="profile-row">
+                <div class="ico">
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="8" r="4"/><path d="M4 21v-1a7 7 0 0114 0v1"/></svg>
+                </div>
+                <div class="text">
+                  <div class="name">Datos personales</div>
+                  <div class="sub">Nombre, email, teléfono</div>
+                </div>
+                <span class="chev">→</span>
+              </div>
+              <div class="profile-row">
+                <div class="ico">
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0110 0v4"/></svg>
+                </div>
+                <div class="text">
+                  <div class="name">Seguridad</div>
+                  <div class="sub">Cambiar contraseña</div>
+                </div>
+                <span class="chev">→</span>
+              </div>
+            </div>
+
+            <div class="profile-section">
+              <h2>Conexiones</h2>
+              <div class="profile-row">
+                <div class="ico" style="background:#E8F0FA;color:var(--info);">
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M21.5 4.5l-3 15s-.5 1-1.5 1c-.5 0-2-1-2-1l-7-5-3-1s-1-.5-1-1.5 1-1.5 1-1.5l16-5s.5-.5 1-.5c.5 0 .5.5.5.5z"/></svg>
+                </div>
+                <div class="text">
+                  <div class="name">Telegram</div>
+                  <div class="sub">Recibe avisos y usa OTP</div>
+                </div>
+                <span class="status linked">Vinculado</span>
+              </div>
+              <div class="profile-row">
+                <div class="ico">
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="6" width="20" height="14" rx="2"/><line x1="2" y1="10" x2="22" y2="10"/></svg>
+                </div>
+                <div class="text">
+                  <div class="name">Métodos de pago</div>
+                  <div class="sub">VISA •7421</div>
+                </div>
+                <span class="chev">→</span>
+              </div>
+            </div>
+
+            <div class="profile-section">
+              <h2>Privacidad</h2>
+              <div class="profile-row">
+                <div class="ico">
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+                </div>
+                <div class="text">
+                  <div class="name">Mis datos · RGPD</div>
+                  <div class="sub">Exportar o eliminar</div>
+                </div>
+                <span class="chev">→</span>
+              </div>
+            </div>
+          </div>
+
+          <div class="p-tabbar">
+            <div class="p-tab">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 12L12 3l9 9v9a2 2 0 01-2 2h-4v-7H9v7H5a2 2 0 01-2-2v-9z"/></svg>
+              Inicio
+            </div>
+            <div class="p-tab">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.5" y2="16.5"/></svg>
+              Buscar
+            </div>
+            <div class="p-tab">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+              Reservas
+            </div>
+            <div class="p-tab active">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="8" r="4"/><path d="M4 21v-1a7 7 0 0114 0v1"/></svg>
+              Perfil
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <aside class="stage-notes">
+      <h3>Notas de diseño</h3>
+      <ul>
+        <li><b>3 secciones claras</b>: Cuenta, Conexiones, Privacidad. RGPD destacado como sección propia.</li>
+        <li><b>Pill "Vinculado" en lima</b> para Telegram: estado visible sin entrar al detalle.</li>
+        <li><b>Iconografía única</b> para Telegram (azul) entre los iconos olive: lo distingue como integración externa.</li>
+        <li>Cubre <span class="cap">usuarios</span> + entrada a <span class="cap">auth-otp-telegram</span> + <span class="cap">exportaciones-rgpd</span>.</li>
+      </ul>
+    </aside>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/ux/mockups/15-vincular-telegram.html
+++ b/docs/ux/mockups/15-vincular-telegram.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PadelPro · 15 · Vincular Telegram</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,500;12..96,600;12..96,700;12..96,800&family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="./_shared/styles.css">
+</head>
+<body>
+<div class="chrome">
+  <div class="chrome-brand"><span class="dot"></span> PadelPro · Mockups</div>
+  <div style="font-family:'Geist Mono',monospace;font-size:11px;color:var(--muted-light)">15 · Vincular Telegram → <a href="./index.html" style="color:var(--lime)">índice</a></div>
+</div>
+
+<div class="stage active" style="display:flex;">
+  <div class="stage-header">
+    <div class="stage-title">
+      <span class="num">15 · TELEGRAM · MOBILE</span>
+      Vincular Telegram
+    </div>
+    <div class="stage-meta">
+      Capability: <span>auth-otp-telegram</span><br>
+      Endpoint: <span>POST /api/v1/telegram/link/initiate</span><br>
+      Permisos: <span>JUGADOR autenticado</span>
+    </div>
+  </div>
+  <div class="stage-body">
+    <div class="phone">
+      <div class="phone-notch"></div>
+      <div class="phone-screen">
+        <div class="phone-status"><span>9:41</span><span>● ● ●</span></div>
+        <div class="phone-content">
+          <div class="tg">
+            <div style="display:flex;align-items:center;gap:12px;margin-bottom:16px;">
+              <div class="p-back">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="15 18 9 12 15 6"/></svg>
+              </div>
+            </div>
+            <div class="tg-hero">
+              <div class="tg-icon">
+                <svg viewBox="0 0 24 24" fill="white"><path d="M21.5 4.5l-3 15s-.5 1-1.5 1c-.5 0-2-1-2-1l-7-5-3-1s-1-.5-1-1.5 1-1.5 1-1.5l16-5s.5-.5 1-.5c.5 0 .5.5.5.5z"/></svg>
+              </div>
+              <h1>Activa <em>Telegram</em> en tu cuenta</h1>
+              <p>Recibe avisos de tu próxima reserva y usa el bot como segundo factor de autenticación.</p>
+            </div>
+
+            <div class="tg-steps">
+              <div class="tg-step">
+                <div class="num">1</div>
+                <div class="text">
+                  <div class="title">Abre el bot en Telegram</div>
+                  <div class="desc">Pulsa el botón de abajo o búscalo en Telegram.</div>
+                  <span class="botname">@PadelPro_bot</span>
+                </div>
+              </div>
+              <div class="tg-step">
+                <div class="num">2</div>
+                <div class="text">
+                  <div class="title">Envía /vincular en el chat</div>
+                  <div class="desc">El bot te pedirá un código que verás en la siguiente pantalla.</div>
+                </div>
+              </div>
+              <div class="tg-step">
+                <div class="num">3</div>
+                <div class="text">
+                  <div class="title">Introduce el código de 6 dígitos</div>
+                  <div class="desc">Solo válido durante 5 minutos. Si caduca, vuelve a empezar.</div>
+                </div>
+              </div>
+            </div>
+
+            <button class="p-btn lime" style="margin-top: auto;">
+              Abrir Telegram <span class="arrow">→</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <aside class="stage-notes">
+      <h3>Notas de diseño</h3>
+      <ul>
+        <li><b>Color azul Telegram</b> respetado en el icono e ilustración: confianza inmediata con la marca.</li>
+        <li><b>3 pasos numerados</b>: el flujo cross-app es confuso, lo desglosamos para evitar abandono.</li>
+        <li><b>Username del bot en mono</b>: el usuario sabe que es un identificador técnico exacto.</li>
+        <li><b>Mención de 5 minutos</b>: gestiona expectativas sobre <span class="rn">RN-otp-01</span> caducidad.</li>
+        <li>Cubre <span class="cap">auth-otp-telegram</span> Req "iniciar vinculación".</li>
+      </ul>
+    </aside>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/ux/mockups/16-otp-telegram.html
+++ b/docs/ux/mockups/16-otp-telegram.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PadelPro · 16 · Introducir OTP</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,500;12..96,600;12..96,700;12..96,800&family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="./_shared/styles.css">
+</head>
+<body>
+<div class="chrome">
+  <div class="chrome-brand"><span class="dot"></span> PadelPro · Mockups</div>
+  <div style="font-family:'Geist Mono',monospace;font-size:11px;color:var(--muted-light)">16 · Introducir OTP → <a href="./index.html" style="color:var(--lime)">índice</a></div>
+</div>
+
+<div class="stage active" style="display:flex;">
+  <div class="stage-header">
+    <div class="stage-title">
+      <span class="num">16 · TELEGRAM · MOBILE</span>
+      Introducir OTP
+    </div>
+    <div class="stage-meta">
+      Capability: <span>auth-otp-telegram</span><br>
+      Endpoint: <span>POST /api/v1/telegram/link/verify</span><br>
+      Permisos: <span>JUGADOR autenticado</span>
+    </div>
+  </div>
+  <div class="stage-body">
+    <div class="phone">
+      <div class="phone-notch"></div>
+      <div class="phone-screen">
+        <div class="phone-status"><span>9:41</span><span>● ● ●</span></div>
+        <div class="phone-content">
+          <div class="otp">
+            <div class="p-back" style="margin-bottom: 28px;">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="15 18 9 12 15 6"/></svg>
+            </div>
+            <div class="otp-hero">
+              <h1>Introduce el código</h1>
+              <p>Te hemos enviado un código de 6 dígitos a tu chat de Telegram <b>@laucasado</b>. Cópialo aquí abajo.</p>
+            </div>
+
+            <div class="otp-boxes">
+              <div class="otp-box filled">4</div>
+              <div class="otp-box filled">9</div>
+              <div class="otp-box filled">2</div>
+              <div class="otp-box filled">7</div>
+              <div class="otp-box active"><div class="cursor"></div></div>
+              <div class="otp-box"></div>
+            </div>
+
+            <div class="otp-timer">
+              Expira en <span class="num">4:12</span>
+            </div>
+
+            <button class="p-btn lime">
+              Verificar <span class="arrow">→</span>
+            </button>
+
+            <div class="otp-resend">
+              ¿No te llegó? <a href="#">Reenviar código</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <aside class="stage-notes">
+      <h3>Notas de diseño</h3>
+      <ul>
+        <li><b>6 cajas independientes</b>: feedback inmediato de cuántos dígitos faltan.</li>
+        <li><b>Active state con shadow olive</b>: el usuario sabe dónde escribir aunque tape el cursor con el teclado.</li>
+        <li><b>Timer en mono</b> con el segundero contando: presión sutil pero clara, conecta con <span class="rn">RN-otp-01</span>.</li>
+        <li><b>Username Telegram</b> visible: confirma que va al chat correcto antes de pegar.</li>
+        <li>Cubre <span class="cap">auth-otp-telegram</span> Req "verificar OTP".</li>
+      </ul>
+    </aside>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/ux/mockups/17-gestion-pistas.html
+++ b/docs/ux/mockups/17-gestion-pistas.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PadelPro · 17 · Gestión de pistas</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,500;12..96,600;12..96,700;12..96,800&family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="./_shared/styles.css">
+</head>
+<body>
+<div class="chrome">
+  <div class="chrome-brand"><span class="dot"></span> PadelPro · Mockups</div>
+  <div style="font-family:'Geist Mono',monospace;font-size:11px;color:var(--muted-light)">17 · Gestión de pistas → <a href="./index.html" style="color:var(--lime)">índice</a></div>
+</div>
+
+<div class="stage active" style="display:flex;">
+  <div class="stage-header">
+    <div class="stage-title">
+      <span class="num">17 · ADMIN CLUB · DESKTOP</span>
+      Gestión de pistas
+    </div>
+    <div class="stage-meta">
+      Capability: <span>pistas</span><br>
+      Endpoint: <span>GET /api/v1/admin/pistas</span><br>
+      Permisos: <span>MANAGER_CLUB · ADMIN</span>
+    </div>
+  </div>
+  <div class="stage-body" style="gap: 40px;">
+    <div class="desktop">
+      <div class="desktop-bar">
+        <div class="traffic"><span></span><span></span><span></span></div>
+        <div class="url">padelpro.app/admin/pistas</div>
+      </div>
+      <div class="desktop-content">
+        <div class="admin">
+          <div class="admin-sidebar">
+            <div class="admin-brand"><span class="dot"></span> PadelPro</div>
+            <div class="admin-club-pill">
+              <div class="lab">Gestionando</div>
+              <div class="name">Club Madrid Este</div>
+            </div>
+            <div class="admin-nav-section">Operación</div>
+            <div class="admin-nav">
+              <div class="admin-nav-item"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>Dashboard</div>
+              <div class="admin-nav-item"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>Calendario</div>
+              <div class="admin-nav-item"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 17 9 11 13 15 21 7"/><polyline points="14 7 21 7 21 14"/></svg>Reservas</div>
+              <div class="admin-nav-item"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="6" width="20" height="14" rx="2"/><line x1="2" y1="10" x2="22" y2="10"/></svg>Pagos</div>
+            </div>
+            <div class="admin-nav-section">Configuración</div>
+            <div class="admin-nav">
+              <div class="admin-nav-item active"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="9" y1="9" x2="9" y2="21"/></svg>Pistas</div>
+              <div class="admin-nav-item"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="8" r="4"/><path d="M4 21v-1a7 7 0 0114 0v1"/></svg>Usuarios</div>
+              <div class="admin-nav-item"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 01-2.83 2.83l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09a1.65 1.65 0 00-1-1.51 1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06a1.65 1.65 0 00.33-1.82 1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09a1.65 1.65 0 001.51-1 1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06a1.65 1.65 0 001.82.33H9a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06a1.65 1.65 0 00-.33 1.82V9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z"/></svg>Política</div>
+            </div>
+          </div>
+
+          <div class="admin-main">
+            <div class="admin-topbar">
+              <div>
+                <h1>Pistas del club</h1>
+                <div class="date">6 pistas activas · 1 en mantenimiento</div>
+              </div>
+              <div class="admin-topbar-actions">
+                <button class="admin-btn">Importar</button>
+                <button class="admin-btn dark">+ Nueva pista</button>
+              </div>
+            </div>
+
+            <div class="admin-content">
+              <div class="courts-grid">
+                <div class="court-card">
+                  <span class="badge active">Activa</span>
+                  <div class="ico-court"></div>
+                  <div class="name">Pista Central</div>
+                  <div class="meta">Cristal · Indoor</div>
+                  <div class="stats">
+                    <div class="stat">
+                      <div class="lab">Ocupación</div>
+                      <div class="val">91%</div>
+                    </div>
+                    <div class="stat">
+                      <div class="lab">Tarifa hora</div>
+                      <div class="val">18€</div>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="court-card">
+                  <span class="badge active">Activa</span>
+                  <div class="ico-court"></div>
+                  <div class="name">Pista 3</div>
+                  <div class="meta">Cristal · Outdoor</div>
+                  <div class="stats">
+                    <div class="stat">
+                      <div class="lab">Ocupación</div>
+                      <div class="val">84%</div>
+                    </div>
+                    <div class="stat">
+                      <div class="lab">Tarifa hora</div>
+                      <div class="val">16€</div>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="court-card">
+                  <span class="badge active">Activa</span>
+                  <div class="ico-court"></div>
+                  <div class="name">Pista 5</div>
+                  <div class="meta">Muro · Outdoor</div>
+                  <div class="stats">
+                    <div class="stat">
+                      <div class="lab">Ocupación</div>
+                      <div class="val">72%</div>
+                    </div>
+                    <div class="stat">
+                      <div class="lab">Tarifa hora</div>
+                      <div class="val">14€</div>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="court-card">
+                  <span class="badge active">Activa</span>
+                  <div class="ico-court"></div>
+                  <div class="name">Pista 6</div>
+                  <div class="meta">Cristal · Indoor</div>
+                  <div class="stats">
+                    <div class="stat">
+                      <div class="lab">Ocupación</div>
+                      <div class="val">88%</div>
+                    </div>
+                    <div class="stat">
+                      <div class="lab">Tarifa hora</div>
+                      <div class="val">18€</div>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="court-card">
+                  <span class="badge maint">Mantenimiento</span>
+                  <div class="ico-court" style="opacity:0.4;"></div>
+                  <div class="name">Pista 7</div>
+                  <div class="meta">Cristal · Outdoor</div>
+                  <div class="stats">
+                    <div class="stat">
+                      <div class="lab">Reapertura</div>
+                      <div class="val" style="font-size:14px;">28 May</div>
+                    </div>
+                    <div class="stat">
+                      <div class="lab">Tarifa hora</div>
+                      <div class="val">16€</div>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="court-card add">
+                  <div class="plus">+</div>
+                  <div class="lab">Añadir pista</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <aside class="stage-notes" style="width: 280px;">
+      <h3>Notas de diseño</h3>
+      <ul>
+        <li><b>Icono visual de pista</b> con líneas tipo cancha de pádel: hace memorable y reconocible.</li>
+        <li><b>Mantenimiento con icono opaco</b>: comunica "fuera de servicio" sin tener que leer.</li>
+        <li><b>KPIs por pista</b>: el manager evalúa ROI individual.</li>
+        <li><b>Card de "añadir"</b> visualmente distinto, dashed: acción de bajo riesgo y no compite con cards reales.</li>
+        <li>Cubre <span class="cap">pistas</span> Req CRUD.</li>
+      </ul>
+    </aside>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/ux/mockups/18-calendario-semanal.html
+++ b/docs/ux/mockups/18-calendario-semanal.html
@@ -1,0 +1,193 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PadelPro · 18 · Calendario semanal</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,500;12..96,600;12..96,700;12..96,800&family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="./_shared/styles.css">
+</head>
+<body>
+<div class="chrome">
+  <div class="chrome-brand"><span class="dot"></span> PadelPro · Mockups</div>
+  <div style="font-family:'Geist Mono',monospace;font-size:11px;color:var(--muted-light)">18 · Calendario semanal → <a href="./index.html" style="color:var(--lime)">índice</a></div>
+</div>
+
+<div class="stage active" style="display:flex;">
+  <div class="stage-header">
+    <div class="stage-title">
+      <span class="num">18 · ADMIN CLUB · DESKTOP</span>
+      Calendario semanal
+    </div>
+    <div class="stage-meta">
+      Capability: <span>reservas, disponibilidad-pistas</span><br>
+      Endpoint: <span>GET /api/v1/admin/reservas?semana=21</span><br>
+      Permisos: <span>MANAGER_CLUB · ADMIN</span>
+    </div>
+  </div>
+  <div class="stage-body" style="gap: 40px;">
+    <div class="desktop">
+      <div class="desktop-bar">
+        <div class="traffic"><span></span><span></span><span></span></div>
+        <div class="url">padelpro.app/admin/calendario</div>
+      </div>
+      <div class="desktop-content">
+        <div class="admin">
+          <div class="admin-sidebar">
+            <div class="admin-brand"><span class="dot"></span> PadelPro</div>
+            <div class="admin-club-pill">
+              <div class="lab">Gestionando</div>
+              <div class="name">Club Madrid Este</div>
+            </div>
+            <div class="admin-nav-section">Operación</div>
+            <div class="admin-nav">
+              <div class="admin-nav-item"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>Dashboard</div>
+              <div class="admin-nav-item active"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>Calendario</div>
+              <div class="admin-nav-item"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 17 9 11 13 15 21 7"/><polyline points="14 7 21 7 21 14"/></svg>Reservas</div>
+              <div class="admin-nav-item"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="6" width="20" height="14" rx="2"/><line x1="2" y1="10" x2="22" y2="10"/></svg>Pagos</div>
+            </div>
+            <div class="admin-nav-section">Configuración</div>
+            <div class="admin-nav">
+              <div class="admin-nav-item"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="9" y1="9" x2="9" y2="21"/></svg>Pistas</div>
+              <div class="admin-nav-item"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="8" r="4"/><path d="M4 21v-1a7 7 0 0114 0v1"/></svg>Usuarios</div>
+            </div>
+          </div>
+
+          <div class="admin-main">
+            <div class="admin-topbar">
+              <div>
+                <h1>Calendario · Pista 3</h1>
+                <div class="date">Vista semanal · ocupación por franja</div>
+              </div>
+              <div class="admin-topbar-actions">
+                <button class="admin-btn">Pista 3 · Cristal ▾</button>
+                <button class="admin-btn dark">+ Reserva manual</button>
+              </div>
+            </div>
+
+            <div class="admin-content">
+              <div class="cal-toolbar">
+                <div class="week">
+                  Semana 21 · 19 — 25 Mayo
+                  <span class="sub">2026</span>
+                </div>
+                <div class="cal-nav">
+                  <button>
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="15 18 9 12 15 6"/></svg>
+                  </button>
+                  <button class="today">Hoy</button>
+                  <button>
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="9 18 15 12 9 6"/></svg>
+                  </button>
+                </div>
+              </div>
+
+              <div class="cal-grid">
+                <div class="cal-head">
+                  <div></div>
+                  <div class="h"><div class="dow">Lun</div><div class="num">19</div></div>
+                  <div class="h"><div class="dow">Mar</div><div class="num">20</div></div>
+                  <div class="h"><div class="dow">Mié</div><div class="num">21</div></div>
+                  <div class="h today"><div class="dow">Jue</div><div class="num">22</div></div>
+                  <div class="h"><div class="dow">Vie</div><div class="num">23</div></div>
+                  <div class="h"><div class="dow">Sáb</div><div class="num">24</div></div>
+                  <div class="h"><div class="dow">Dom</div><div class="num">25</div></div>
+                </div>
+                <div class="cal-body">
+                  <div class="cal-hours">
+                    <div class="cal-hour">9:00</div>
+                    <div class="cal-hour">10:00</div>
+                    <div class="cal-hour">11:00</div>
+                    <div class="cal-hour">12:00</div>
+                    <div class="cal-hour">13:00</div>
+                    <div class="cal-hour">14:00</div>
+                    <div class="cal-hour">15:00</div>
+                    <div class="cal-hour">16:00</div>
+                    <div class="cal-hour">17:00</div>
+                    <div class="cal-hour">18:00</div>
+                  </div>
+
+                  <div class="cal-col">
+                    <div class="hline"></div><div class="hline"></div><div class="hline"></div><div class="hline"></div>
+                    <div class="hline"></div><div class="hline"></div><div class="hline"></div><div class="hline"></div>
+                    <div class="hline"></div><div class="hline"></div>
+                    <div class="cal-event" style="top:56px;height:84px;"><span class="t">10:00 — 11:30</span>Liga municipal</div>
+                    <div class="cal-event alt" style="top:280px;height:84px;"><span class="t">14:00 — 15:30</span>Sergio M.</div>
+                    <div class="cal-event" style="top:448px;height:84px;"><span class="t">17:00 — 18:30</span>P. Vega</div>
+                  </div>
+
+                  <div class="cal-col">
+                    <div class="hline"></div><div class="hline"></div><div class="hline"></div><div class="hline"></div>
+                    <div class="hline"></div><div class="hline"></div><div class="hline"></div><div class="hline"></div>
+                    <div class="hline"></div><div class="hline"></div>
+                    <div class="cal-event" style="top:112px;height:84px;"><span class="t">11:00 — 12:30</span>Carla L.</div>
+                    <div class="cal-event alt" style="top:336px;height:56px;"><span class="t">15:00</span>Iván R.</div>
+                  </div>
+
+                  <div class="cal-col">
+                    <div class="hline"></div><div class="hline"></div><div class="hline"></div><div class="hline"></div>
+                    <div class="hline"></div><div class="hline"></div><div class="hline"></div><div class="hline"></div>
+                    <div class="hline"></div><div class="hline"></div>
+                    <div class="cal-event maint" style="top:0;height:84px;"><span class="t">09:00 — 10:30</span>Mantenimiento</div>
+                    <div class="cal-event" style="top:224px;height:84px;"><span class="t">13:00 — 14:30</span>D. Ríos</div>
+                    <div class="cal-event alt" style="top:392px;height:56px;"><span class="t">16:00</span>J. Pérez</div>
+                  </div>
+
+                  <div class="cal-col">
+                    <div class="hline"></div><div class="hline"></div><div class="hline"></div><div class="hline"></div>
+                    <div class="hline"></div><div class="hline"></div><div class="hline"></div><div class="hline"></div>
+                    <div class="hline"></div><div class="hline"></div>
+                    <div class="cal-event" style="top:56px;height:84px;"><span class="t">10:00 — 11:30</span>María Sanz</div>
+                    <div class="cal-event alt" style="top:280px;height:84px;"><span class="t">14:00 — 15:30</span>N. Castro</div>
+                    <div class="cal-event lime" style="top:504px;height:84px;"><span class="t">18:30 — 20:00</span>Laura C.</div>
+                  </div>
+
+                  <div class="cal-col">
+                    <div class="hline"></div><div class="hline"></div><div class="hline"></div><div class="hline"></div>
+                    <div class="hline"></div><div class="hline"></div><div class="hline"></div><div class="hline"></div>
+                    <div class="hline"></div><div class="hline"></div>
+                    <div class="cal-event" style="top:168px;height:56px;"><span class="t">12:00</span>A. Rivas</div>
+                    <div class="cal-event alt" style="top:336px;height:84px;"><span class="t">15:00 — 16:30</span>Cuarteto J.</div>
+                    <div class="cal-event" style="top:448px;height:84px;"><span class="t">17:00 — 18:30</span>P. Vega</div>
+                  </div>
+
+                  <div class="cal-col">
+                    <div class="hline"></div><div class="hline"></div><div class="hline"></div><div class="hline"></div>
+                    <div class="hline"></div><div class="hline"></div><div class="hline"></div><div class="hline"></div>
+                    <div class="hline"></div><div class="hline"></div>
+                    <div class="cal-event" style="top:0;height:84px;"><span class="t">09:00 — 10:30</span>Liga municipal</div>
+                    <div class="cal-event alt" style="top:112px;height:56px;"><span class="t">11:00</span>Sara F.</div>
+                    <div class="cal-event" style="top:224px;height:84px;"><span class="t">13:00 — 14:30</span>M. Sanz</div>
+                    <div class="cal-event alt" style="top:336px;height:56px;"><span class="t">15:00</span>Sergio M.</div>
+                  </div>
+
+                  <div class="cal-col">
+                    <div class="hline"></div><div class="hline"></div><div class="hline"></div><div class="hline"></div>
+                    <div class="hline"></div><div class="hline"></div><div class="hline"></div><div class="hline"></div>
+                    <div class="hline"></div><div class="hline"></div>
+                    <div class="cal-event" style="top:56px;height:84px;"><span class="t">10:00 — 11:30</span>Carla L.</div>
+                    <div class="cal-event alt" style="top:280px;height:84px;"><span class="t">14:00 — 15:30</span>Pablo G.</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <aside class="stage-notes" style="width: 280px;">
+      <h3>Notas de diseño</h3>
+      <ul>
+        <li><b>Día actual con header negro</b>: ancla visual fuerte sin colores estridentes.</li>
+        <li><b>Reservas en tonos de olive</b> según turno; mantenimiento rojo; reserva resaltada en lima.</li>
+        <li><b>Pista seleccionable</b> en topbar: filtro principal sin ocupar mucho espacio.</li>
+        <li><b>Reserva manual</b> como acción primaria: caso típico de soporte telefónico.</li>
+        <li>Cubre <span class="cap">reservas</span> + <span class="cap">disponibilidad-pistas</span> vista admin.</li>
+      </ul>
+    </aside>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/ux/mockups/19-reservas-club.html
+++ b/docs/ux/mockups/19-reservas-club.html
@@ -1,0 +1,185 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PadelPro · 19 · Reservas del club</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,500;12..96,600;12..96,700;12..96,800&family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="./_shared/styles.css">
+</head>
+<body>
+<div class="chrome">
+  <div class="chrome-brand"><span class="dot"></span> PadelPro · Mockups</div>
+  <div style="font-family:'Geist Mono',monospace;font-size:11px;color:var(--muted-light)">19 · Reservas del club → <a href="./index.html" style="color:var(--lime)">índice</a></div>
+</div>
+
+<div class="stage active" style="display:flex;">
+  <div class="stage-header">
+    <div class="stage-title">
+      <span class="num">19 · ADMIN CLUB · DESKTOP</span>
+      Reservas del club
+    </div>
+    <div class="stage-meta">
+      Capability: <span>reservas, pagos-redsys</span><br>
+      Endpoint: <span>GET /api/v1/admin/reservas</span><br>
+      Permisos: <span>MANAGER_CLUB · ADMIN</span>
+    </div>
+  </div>
+  <div class="stage-body" style="gap: 40px;">
+    <div class="desktop">
+      <div class="desktop-bar">
+        <div class="traffic"><span></span><span></span><span></span></div>
+        <div class="url">padelpro.app/admin/reservas</div>
+      </div>
+      <div class="desktop-content">
+        <div class="admin">
+          <div class="admin-sidebar">
+            <div class="admin-brand"><span class="dot"></span> PadelPro</div>
+            <div class="admin-club-pill">
+              <div class="lab">Gestionando</div>
+              <div class="name">Club Madrid Este</div>
+            </div>
+            <div class="admin-nav-section">Operación</div>
+            <div class="admin-nav">
+              <div class="admin-nav-item"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>Dashboard</div>
+              <div class="admin-nav-item"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>Calendario</div>
+              <div class="admin-nav-item active"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 17 9 11 13 15 21 7"/><polyline points="14 7 21 7 21 14"/></svg>Reservas</div>
+              <div class="admin-nav-item"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="6" width="20" height="14" rx="2"/><line x1="2" y1="10" x2="22" y2="10"/></svg>Pagos</div>
+            </div>
+          </div>
+
+          <div class="admin-main">
+            <div class="admin-topbar">
+              <div>
+                <h1>Reservas</h1>
+                <div class="date">Esta semana · 184 reservas · 2.890€</div>
+              </div>
+              <div class="admin-topbar-actions">
+                <button class="admin-btn">Exportar CSV</button>
+                <button class="admin-btn dark">+ Reserva manual</button>
+              </div>
+            </div>
+
+            <div class="admin-content">
+              <div class="filters-bar">
+                <div class="filter-chip active">Todas <span class="count">184</span></div>
+                <div class="filter-chip">Confirmadas <span class="count">162</span></div>
+                <div class="filter-chip">Pendientes <span class="count">8</span></div>
+                <div class="filter-chip">Canceladas <span class="count">14</span></div>
+                <div class="search-box">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.5" y2="16.5"/></svg>
+                  <input type="text" placeholder="Buscar por email, código o jugador…">
+                </div>
+              </div>
+
+              <div style="background:white;border:1px solid var(--line);border-radius:16px;overflow:hidden;">
+                <div class="table-head">
+                  <div class="col">Código</div>
+                  <div class="col">Jugador</div>
+                  <div class="col">Día / hora</div>
+                  <div class="col">Pista</div>
+                  <div class="col">Importe</div>
+                  <div class="col">Estado</div>
+                  <div></div>
+                </div>
+
+                <div class="table-row">
+                  <div class="code">R-2026-0512</div>
+                  <div class="player">
+                    <div class="av">LC</div>
+                    <div><div class="name">Laura Casado</div><div class="email">laura.casado@email.com</div></div>
+                  </div>
+                  <div class="when"><div class="d">Jue 22 May</div><div class="h">18:30 — 20:00</div></div>
+                  <div class="court-name">Pista 3<span class="sub">Cristal · OUT</span></div>
+                  <div class="amount">16,00€</div>
+                  <div class="pill ok">OK</div>
+                  <div style="color:var(--muted-light);">→</div>
+                </div>
+
+                <div class="table-row">
+                  <div class="code">R-2026-0517</div>
+                  <div class="player">
+                    <div class="av">SM</div>
+                    <div><div class="name">Sergio Martín</div><div class="email">s.martin@padelpro.com</div></div>
+                  </div>
+                  <div class="when"><div class="d">Vie 23 May</div><div class="h">20:00 — 21:30</div></div>
+                  <div class="court-name">P. Central<span class="sub">Cristal · IN</span></div>
+                  <div class="amount">18,00€</div>
+                  <div class="pill warn">Pago</div>
+                  <div style="color:var(--muted-light);">→</div>
+                </div>
+
+                <div class="table-row">
+                  <div class="code">R-2026-0521</div>
+                  <div class="player">
+                    <div class="av">IR</div>
+                    <div><div class="name">Iván Reyes</div><div class="email">ivan.reyes@email.com</div></div>
+                  </div>
+                  <div class="when"><div class="d">Sáb 24 May</div><div class="h">10:30 — 12:00</div></div>
+                  <div class="court-name">Pista 5<span class="sub">Muro · OUT</span></div>
+                  <div class="amount">14,00€</div>
+                  <div class="pill ok">OK</div>
+                  <div style="color:var(--muted-light);">→</div>
+                </div>
+
+                <div class="table-row">
+                  <div class="code">R-2026-0508</div>
+                  <div class="player">
+                    <div class="av">MS</div>
+                    <div><div class="name">María Sanz</div><div class="email">maria.sanz@email.com</div></div>
+                  </div>
+                  <div class="when"><div class="d">Jue 22 May</div><div class="h">15:00 — 16:30</div></div>
+                  <div class="court-name">Pista 3<span class="sub">Cristal · OUT</span></div>
+                  <div class="amount">16,00€</div>
+                  <div class="pill ok">OK</div>
+                  <div style="color:var(--muted-light);">→</div>
+                </div>
+
+                <div class="table-row">
+                  <div class="code">R-2026-0498</div>
+                  <div class="player">
+                    <div class="av">PG</div>
+                    <div><div class="name">Pablo García</div><div class="email">p.garcia@email.com</div></div>
+                  </div>
+                  <div class="when"><div class="d">Mié 21 May</div><div class="h">19:00 — 20:30</div></div>
+                  <div class="court-name">Pista 6<span class="sub">Cristal · IN</span></div>
+                  <div class="amount">−18,00€</div>
+                  <div class="pill bad">Cancelada</div>
+                  <div style="color:var(--muted-light);">→</div>
+                </div>
+
+                <div class="table-row">
+                  <div class="code">R-2026-0492</div>
+                  <div class="player">
+                    <div class="av">CL</div>
+                    <div><div class="name">Carla López</div><div class="email">carla.lopez@email.com</div></div>
+                  </div>
+                  <div class="when"><div class="d">Mié 21 May</div><div class="h">11:00 — 12:30</div></div>
+                  <div class="court-name">Pista 3<span class="sub">Cristal · OUT</span></div>
+                  <div class="amount">16,00€</div>
+                  <div class="pill ok">OK</div>
+                  <div style="color:var(--muted-light);">→</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <aside class="stage-notes" style="width: 280px;">
+      <h3>Notas de diseño</h3>
+      <ul>
+        <li><b>Filtros con contador</b>: el admin sabe cuántas hay sin filtrar primero.</li>
+        <li><b>Buscador por email/código</b>: caso típico de atención al cliente.</li>
+        <li><b>Importe negativo en cancelaciones</b>: reembolso visible sin tener que leer.</li>
+        <li><b>Pills minimalistas</b>: OK / Pago / Cancelada en 3 estados claros.</li>
+        <li><b>Exportar CSV</b> para conciliación contable.</li>
+        <li>Cubre <span class="cap">reservas</span> + <span class="cap">pagos-redsys</span> vista operativa.</li>
+      </ul>
+    </aside>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/ux/mockups/20-crear-partida.html
+++ b/docs/ux/mockups/20-crear-partida.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PadelPro · 20 · Crear partida pública</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,500;12..96,600;12..96,700;12..96,800&family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="./_shared/styles.css">
+</head>
+<body>
+<div class="chrome">
+  <div class="chrome-brand"><span class="dot"></span> PadelPro · Mockups</div>
+  <div style="font-family:'Geist Mono',monospace;font-size:11px;color:var(--muted-light)">20 · Crear partida pública → <a href="./index.html" style="color:var(--lime)">índice</a></div>
+</div>
+
+<div class="stage active" style="display:flex;">
+  <div class="stage-header">
+    <div class="stage-title">
+      <span class="num">14 · PARTIDAS · MOBILE</span>
+      Crear partida pública
+    </div>
+    <div class="stage-meta">
+      Capability: <span>partidas</span><br>
+      Endpoint: <span>POST /api/v1/partidas</span><br>
+      Permisos: <span>JUGADOR autenticado</span>
+    </div>
+  </div>
+  <div class="stage-body">
+    <div class="phone">
+      <div class="phone-notch"></div>
+      <div class="phone-screen">
+        <div class="phone-status"><span>9:41</span><span>● ● ●</span></div>
+        <div class="phone-content">
+          <div class="p-screen partidas">
+            <div class="p-top">
+              <div class="p-back">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="15 18 9 12 15 6"/></svg>
+              </div>
+              <h1>Nueva partida</h1>
+            </div>
+
+            <div class="crear-step">
+              <h3>Reserva base</h3>
+              <div style="background:var(--ink);color:var(--bg-cream);border-radius:16px;padding:16px;display:flex;align-items:center;gap:14px;">
+                <div style="text-align:center;padding-right:14px;border-right:1px solid #2a2a28;">
+                  <div style="font-family:'Bricolage Grotesque',sans-serif;font-size:24px;font-weight:700;letter-spacing:-0.02em;line-height:1;">18:30</div>
+                  <div style="font-family:'Geist Mono',monospace;font-size:9px;color:var(--muted-light);margin-top:4px;letter-spacing:0.08em;">90 MIN</div>
+                </div>
+                <div style="flex:1;">
+                  <div style="font-family:'Bricolage Grotesque',sans-serif;font-size:16px;font-weight:700;">Pista 3 · Jue 22</div>
+                  <div style="font-size:11px;color:var(--muted-light);margin-top:2px;">Cristal · Outdoor · 16€</div>
+                </div>
+              </div>
+            </div>
+
+            <div class="crear-step">
+              <h3>Tipo de partida</h3>
+              <div class="toggle-row">
+                <div>
+                  <div class="name">Partida pública</div>
+                  <div class="sub">Otros jugadores pueden unirse</div>
+                </div>
+                <div class="switch"></div>
+              </div>
+              <div class="toggle-row">
+                <div>
+                  <div class="name">Pago compartido</div>
+                  <div class="sub">El coste se divide entre 4</div>
+                </div>
+                <div class="switch"></div>
+              </div>
+            </div>
+
+            <div class="crear-step">
+              <h3>Nivel</h3>
+              <div class="level-pick">
+                <div class="opt">
+                  <div class="num">1-2</div>
+                  <div class="lab">Inicia</div>
+                </div>
+                <div class="opt active">
+                  <div class="num">3-4</div>
+                  <div class="lab">Medio</div>
+                </div>
+                <div class="opt">
+                  <div class="num">5-6</div>
+                  <div class="lab">Avanz.</div>
+                </div>
+                <div class="opt">
+                  <div class="num">7+</div>
+                  <div class="lab">Pro</div>
+                </div>
+              </div>
+            </div>
+
+            <button class="p-btn lime">
+              Crear partida <span class="arrow">→</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <aside class="stage-notes">
+      <h3>Notas de diseño</h3>
+      <ul>
+        <li><b>Reserva base como card destacada</b>: deja claro que la partida cuelga de una reserva existente.</li>
+        <li><b>Switches lima</b>: público + pago compartido como toggles intuitivos.</li>
+        <li><b>Nivel en 4 segmentos</b> compatible con Playtomic: facilita migración de usuarios habituales.</li>
+        <li><b>Sin scroll</b>: el flujo de creación cabe en una pantalla.</li>
+        <li>Cubre <span class="cap">partidas</span> Req "crear partida" (Fase 2).</li>
+      </ul>
+    </aside>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/ux/mockups/21-partidas-abiertas.html
+++ b/docs/ux/mockups/21-partidas-abiertas.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PadelPro · 21 · Partidas abiertas</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,500;12..96,600;12..96,700;12..96,800&family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="./_shared/styles.css">
+</head>
+<body>
+<div class="chrome">
+  <div class="chrome-brand"><span class="dot"></span> PadelPro · Mockups</div>
+  <div style="font-family:'Geist Mono',monospace;font-size:11px;color:var(--muted-light)">21 · Partidas abiertas → <a href="./index.html" style="color:var(--lime)">índice</a></div>
+</div>
+
+<div class="stage active" style="display:flex;">
+  <div class="stage-header">
+    <div class="stage-title">
+      <span class="num">15 · PARTIDAS · MOBILE</span>
+      Partidas abiertas
+    </div>
+    <div class="stage-meta">
+      Capability: <span>partidas</span><br>
+      Endpoint: <span>GET /api/v1/partidas/abiertas</span><br>
+      Permisos: <span>JUGADOR autenticado</span>
+    </div>
+  </div>
+  <div class="stage-body">
+    <div class="phone">
+      <div class="phone-notch"></div>
+      <div class="phone-screen">
+        <div class="phone-status"><span>9:41</span><span>● ● ●</span></div>
+        <div class="phone-content">
+          <div class="p-screen partidas">
+            <h1 class="p-h1" style="margin-bottom:6px;">Partidas<br><em style="font-style:italic;font-weight:500;color:var(--olive);">abiertas</em></h1>
+            <div style="color:var(--muted);font-size:13px;margin-bottom:24px;">12 buscan jugador en tu nivel</div>
+
+            <div class="partidas-tabs">
+              <div class="partidas-tab active">Hoy</div>
+              <div class="partidas-tab">Mañana</div>
+              <div class="partidas-tab">Semana</div>
+            </div>
+
+            <div class="partida-card">
+              <div class="head">
+                <div class="when-block">
+                  18:30
+                  <div class="d">Hoy · 90min</div>
+                </div>
+                <span class="level med">Nivel 3-4</span>
+              </div>
+              <div class="court-line">Pista Central · Cristal · Indoor</div>
+              <div class="players">
+                <div class="av">MR</div>
+                <div class="av">PG</div>
+                <div class="av">AS</div>
+                <div class="av empty">+1</div>
+                <span class="count"><b>3</b> · falta 1 jugador</span>
+              </div>
+              <div class="footer">
+                <div class="price">4,50€ <small>/jugador</small></div>
+                <button class="join-btn">Unirme →</button>
+              </div>
+            </div>
+
+            <div class="partida-card">
+              <div class="head">
+                <div class="when-block">
+                  20:00
+                  <div class="d">Hoy · 90min</div>
+                </div>
+                <span class="level med">Nivel 4</span>
+              </div>
+              <div class="court-line">Pista 5 · Muro · Outdoor</div>
+              <div class="players">
+                <div class="av">CL</div>
+                <div class="av">DM</div>
+                <div class="av empty">+1</div>
+                <div class="av empty">+1</div>
+                <span class="count"><b>2</b> · faltan 2 jugadores</span>
+              </div>
+              <div class="footer">
+                <div class="price">3,50€ <small>/jugador</small></div>
+                <button class="join-btn">Unirme →</button>
+              </div>
+            </div>
+
+            <div class="partida-card">
+              <div class="head">
+                <div class="when-block">
+                  21:30
+                  <div class="d">Hoy · 60min</div>
+                </div>
+                <span class="level adv">Nivel 5-6</span>
+              </div>
+              <div class="court-line">Pista 3 · Cristal · Outdoor</div>
+              <div class="players">
+                <div class="av">NC</div>
+                <div class="av">SF</div>
+                <div class="av">JP</div>
+                <div class="av empty">+1</div>
+                <span class="count"><b>3</b> · falta 1 jugador</span>
+              </div>
+              <div class="footer">
+                <div class="price">4,00€ <small>/jugador</small></div>
+                <button class="join-btn">Unirme →</button>
+              </div>
+            </div>
+          </div>
+
+          <div class="p-tabbar">
+            <div class="p-tab">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 12L12 3l9 9v9a2 2 0 01-2 2h-4v-7H9v7H5a2 2 0 01-2-2v-9z"/></svg>
+              Inicio
+            </div>
+            <div class="p-tab active">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.5" y2="16.5"/></svg>
+              Buscar
+            </div>
+            <div class="p-tab">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+              Reservas
+            </div>
+            <div class="p-tab">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="8" r="4"/><path d="M4 21v-1a7 7 0 0114 0v1"/></svg>
+              Perfil
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <aside class="stage-notes">
+      <h3>Notas de diseño</h3>
+      <ul>
+        <li><b>Avatares apilados</b> con huecos para faltantes: la falta es visible y tentadora.</li>
+        <li><b>Nivel destacado</b> con color (azul medio, rojo avanzado): match rápido visualmente.</li>
+        <li><b>Precio por jugador</b>: cálculo hecho, sin tener que dividir mentalmente.</li>
+        <li><b>"Unirme →" en lima</b>: acción dominante. Botón único, decisión clara.</li>
+        <li>Cubre <span class="cap">partidas</span> Req "listar abiertas" (Fase 2).</li>
+      </ul>
+    </aside>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/ux/mockups/22-confirmar-union.html
+++ b/docs/ux/mockups/22-confirmar-union.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PadelPro · 22 · Confirmar unión</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,500;12..96,600;12..96,700;12..96,800&family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="./_shared/styles.css">
+</head>
+<body>
+<div class="chrome">
+  <div class="chrome-brand"><span class="dot"></span> PadelPro · Mockups</div>
+  <div style="font-family:'Geist Mono',monospace;font-size:11px;color:var(--muted-light)">22 · Confirmar unión → <a href="./index.html" style="color:var(--lime)">índice</a></div>
+</div>
+
+<div class="stage active" style="display:flex;">
+  <div class="stage-header">
+    <div class="stage-title">
+      <span class="num">16 · PARTIDAS · MOBILE</span>
+      Confirmar unión
+    </div>
+    <div class="stage-meta">
+      Capability: <span>partidas, pagos-redsys</span><br>
+      Endpoint: <span>POST /api/v1/partidas/{id}/unirse</span><br>
+      Permisos: <span>JUGADOR autenticado</span>
+    </div>
+  </div>
+  <div class="stage-body">
+    <div class="phone">
+      <div class="phone-notch"></div>
+      <div class="phone-screen">
+        <div class="phone-status dark"><span>9:41</span><span>● ● ●</span></div>
+        <div class="phone-content">
+          <div class="resdet">
+            <div class="resdet-hero">
+              <div class="resdet-back">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="15 18 9 12 15 6"/></svg>
+              </div>
+              <div class="resdet-status">
+                <span class="dot"></span> Partida pública · Hoy 18:30
+              </div>
+              <h1>Falta<br>1 jugador</h1>
+              <div class="meta">Pista Central · Cristal · Indoor</div>
+              <div class="code">PARTIDA-2026-094</div>
+            </div>
+            <div class="resdet-body">
+              <div class="resdet-section">
+                <h3>Jugadores · 3 confirmados</h3>
+                <div class="players-row">
+                  <div class="player-chip">
+                    <div class="av">MR</div>
+                    Marcos R. · Anfitrión
+                  </div>
+                  <div class="player-chip">
+                    <div class="av">PG</div>
+                    Pablo G.
+                  </div>
+                  <div class="player-chip">
+                    <div class="av">AS</div>
+                    Andrea S.
+                  </div>
+                  <div class="player-chip empty">
+                    <div class="av">?</div>
+                    Tú
+                  </div>
+                </div>
+              </div>
+
+              <div class="resdet-section">
+                <h3>Detalles</h3>
+                <div class="resdet-info-grid">
+                  <div class="info-pill">
+                    <div class="lab">Horario</div>
+                    <div class="val">18:30 — 20:00</div>
+                  </div>
+                  <div class="info-pill">
+                    <div class="lab">Nivel</div>
+                    <div class="val">Medio · 3-4</div>
+                  </div>
+                  <div class="info-pill">
+                    <div class="lab">Tu parte</div>
+                    <div class="val">4,50€</div>
+                  </div>
+                  <div class="info-pill">
+                    <div class="lab">Total partida</div>
+                    <div class="val">18,00€</div>
+                  </div>
+                </div>
+              </div>
+
+              <div style="background:var(--bg-warm);border-radius:14px;padding:14px;font-size:12px;color:var(--muted);line-height:1.5;margin-top:14px;">
+                <b style="color:var(--ink);">¡Compatible con tu nivel!</b><br>
+                Tu nivel registrado es 3-4. Si la partida no se completa antes de 1h del inicio, se cancela y se reembolsa.
+              </div>
+            </div>
+            <div class="resdet-footer">
+              <button class="p-btn lime" style="flex:1;">Unirme · 4,50€ →</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <aside class="stage-notes">
+      <h3>Notas de diseño</h3>
+      <ul>
+        <li><b>Tú como hueco vacío</b> en la lista: posiciona al usuario en el equipo antes de unirse.</li>
+        <li><b>Anfitrión destacado</b>: si hay conflicto, hay un responsable.</li>
+        <li><b>Tu parte / Total</b> en pills separadas: claridad de precio en pago compartido.</li>
+        <li><b>Política de cancelación automática</b>: protege al usuario de pagar por partidas que no se completen.</li>
+        <li>Cubre <span class="cap">partidas</span> Req "unirse" + cobro <span class="cap">pagos-redsys</span>.</li>
+      </ul>
+    </aside>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/ux/mockups/23-mis-datos.html
+++ b/docs/ux/mockups/23-mis-datos.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PadelPro · 23 · Mis datos y privacidad</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,500;12..96,600;12..96,700;12..96,800&family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="./_shared/styles.css">
+</head>
+<body>
+<div class="chrome">
+  <div class="chrome-brand"><span class="dot"></span> PadelPro · Mockups</div>
+  <div style="font-family:'Geist Mono',monospace;font-size:11px;color:var(--muted-light)">23 · Mis datos y privacidad → <a href="./index.html" style="color:var(--lime)">índice</a></div>
+</div>
+
+<div class="stage active" style="display:flex;">
+  <div class="stage-header">
+    <div class="stage-title">
+      <span class="num">17 · RGPD · MOBILE</span>
+      Mis datos y privacidad
+    </div>
+    <div class="stage-meta">
+      Capability: <span>exportaciones-rgpd</span><br>
+      Endpoint: <span>POST /api/v1/users/me/export · DELETE /api/v1/users/me</span><br>
+      Permisos: <span>JUGADOR autenticado</span>
+    </div>
+  </div>
+  <div class="stage-body">
+    <div class="phone">
+      <div class="phone-notch"></div>
+      <div class="phone-screen">
+        <div class="phone-status"><span>9:41</span><span>● ● ●</span></div>
+        <div class="phone-content">
+          <div class="rgpd">
+            <div class="p-top" style="margin-bottom:18px;">
+              <div class="p-back">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="15 18 9 12 15 6"/></svg>
+              </div>
+            </div>
+            <h1>Tus<br><em>datos.</em></h1>
+            <div class="sub">Bajo el Reglamento General de Protección de Datos, tienes pleno control sobre tu información en PadelPro.</div>
+
+            <div class="rgpd-block">
+              <div class="head">
+                <div class="ico">
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                </div>
+                <div class="info">
+                  <div class="name">Descargar mis datos</div>
+                  <div class="law">Art. 15 RGPD · Derecho de acceso</div>
+                </div>
+              </div>
+              <div class="desc">Te enviamos un archivo JSON con todo lo que tenemos sobre ti: perfil, reservas, partidas y pagos.</div>
+              <button class="action-btn">Solicitar exportación</button>
+            </div>
+
+            <div class="rgpd-block">
+              <div class="head">
+                <div class="ico">
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7"/><polygon points="18.5 2.5 22 6 12 16 8 16 8 12 18.5 2.5"/></svg>
+                </div>
+                <div class="info">
+                  <div class="name">Editar mis datos</div>
+                  <div class="law">Art. 16 RGPD · Rectificación</div>
+                </div>
+              </div>
+              <div class="desc">Modifica tu nombre, email o teléfono. Los cambios quedan registrados en auditoría.</div>
+              <button class="action-btn">Editar perfil</button>
+            </div>
+
+            <div class="rgpd-block">
+              <div class="head">
+                <div class="ico" style="background:#FBE8E0;color:var(--danger);">
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-2 14a2 2 0 01-2 2H9a2 2 0 01-2-2L5 6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/></svg>
+                </div>
+                <div class="info">
+                  <div class="name">Eliminar mi cuenta</div>
+                  <div class="law">Art. 17 RGPD · Derecho al olvido</div>
+                </div>
+              </div>
+              <div class="desc">Tu cuenta queda anonimizada inmediatamente. Las reservas pasadas se conservan según ley fiscal (4 años).</div>
+              <button class="action-btn danger">Eliminar cuenta</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <aside class="stage-notes">
+      <h3>Notas de diseño</h3>
+      <ul>
+        <li><b>Referencia al artículo</b> RGPD en cada bloque: confianza legal y trazabilidad.</li>
+        <li><b>3 acciones diferenciadas</b>: descargar, editar, eliminar. Cada una con su semántica.</li>
+        <li><b>Eliminar en rojo</b> + icono distintivo: jerarquía de riesgo visible.</li>
+        <li><b>Mención a retención fiscal</b>: gestiona expectativa "qué significa eliminar".</li>
+        <li>Cubre <span class="cap">exportaciones-rgpd</span> Req "acceso, rectificación, olvido".</li>
+      </ul>
+    </aside>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/ux/mockups/24-eliminar-cuenta.html
+++ b/docs/ux/mockups/24-eliminar-cuenta.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PadelPro · 24 · Confirmar eliminación</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,500;12..96,600;12..96,700;12..96,800&family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="./_shared/styles.css">
+</head>
+<body>
+<div class="chrome">
+  <div class="chrome-brand"><span class="dot"></span> PadelPro · Mockups</div>
+  <div style="font-family:'Geist Mono',monospace;font-size:11px;color:var(--muted-light)">24 · Confirmar eliminación → <a href="./index.html" style="color:var(--lime)">índice</a></div>
+</div>
+
+<div class="stage active" style="display:flex;">
+  <div class="stage-header">
+    <div class="stage-title">
+      <span class="num">18 · RGPD · MOBILE</span>
+      Confirmar eliminación
+    </div>
+    <div class="stage-meta">
+      Capability: <span>exportaciones-rgpd, auditoria</span><br>
+      Endpoint: <span>DELETE /api/v1/users/me</span><br>
+      Permisos: <span>JUGADOR autenticado</span>
+    </div>
+  </div>
+  <div class="stage-body">
+    <div class="phone">
+      <div class="phone-notch"></div>
+      <div class="phone-screen">
+        <div class="phone-status"><span>9:41</span><span>● ● ●</span></div>
+        <div class="phone-content">
+          <div class="delete-screen">
+            <div class="p-back" style="margin-bottom:18px;">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="15 18 9 12 15 6"/></svg>
+            </div>
+            <div class="delete-warn">
+              <div class="ico">
+                <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.5"><path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+              </div>
+              <h1>Esta acción es definitiva</h1>
+              <p>Tu cuenta y tus datos personales se anonimizan inmediatamente. No se puede deshacer.</p>
+            </div>
+
+            <div class="delete-list">
+              <h3>Qué pasará con tus datos</h3>
+              <ul>
+                <li>Tu perfil (nombre, email, teléfono) será borrado.</li>
+                <li>Tus reservas pasadas quedan anonimizadas pero se conservan 4 años (ley fiscal).</li>
+                <li>Tu vinculación con Telegram se elimina.</li>
+                <li>Las partidas activas se cancelan y se reembolsan.</li>
+                <li>El movimiento queda registrado en auditoría sin tu identidad.</li>
+              </ul>
+            </div>
+
+            <div class="delete-confirm">
+              <div class="lab">Confirma escribiendo</div>
+              <input type="text" value="ELIMINAR LAURA" placeholder="ELIMINAR LAURA">
+              <div class="hint">Escribe exactamente <b>ELIMINAR LAURA</b> para continuar</div>
+            </div>
+
+            <button class="p-btn danger">
+              Eliminar cuenta para siempre
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <aside class="stage-notes">
+      <h3>Notas de diseño</h3>
+      <ul>
+        <li><b>Card "warning" en negro+rojo</b>: paleta única para esta acción crítica, sin colores festivos.</li>
+        <li><b>Lista explícita de consecuencias</b>: gestiona expectativas legales sin ambigüedad.</li>
+        <li><b>Confirmación tipo-tu-nombre</b>: patrón anti-clic accidental tipo GitHub delete repo.</li>
+        <li><b>Mención a auditoría sin identidad</b>: cumple <span class="rn">RN-rgpd-02</span> y <span class="rn">RN-aud-01</span>.</li>
+        <li>Cubre <span class="cap">exportaciones-rgpd</span> + <span class="cap">auditoria</span> Req "derecho al olvido".</li>
+      </ul>
+    </aside>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/ux/mockups/_shared/fonts.html
+++ b/docs/ux/mockups/_shared/fonts.html
@@ -1,0 +1,4 @@
+<!-- PadelPro fonts: Bricolage Grotesque + Geist + Geist Mono -->
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,500;12..96,600;12..96,700;12..96,800&family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">

--- a/docs/ux/mockups/_shared/styles.css
+++ b/docs/ux/mockups/_shared/styles.css
@@ -1,0 +1,728 @@
+/* PadelPro Design System — shared styles for all mockup screens */
+
+/* ─── Variables ─── */
+:root {
+  --bg-cream: #FAFAF5;
+  --bg-warm: #F4F2EA;
+  --ink: #0A0A0A;
+  --ink-soft: #2A2A28;
+  --muted: #6B6B66;
+  --muted-light: #A8A8A0;
+  --line: #E5E3D8;
+  --line-soft: #EFEDE3;
+  --olive: #3F4A2E;
+  --olive-dark: #2A3220;
+  --lime: #C8FF3D;
+  --lime-soft: #E8FFA0;
+  --danger: #C7472D;
+  --warn: #E8A33C;
+  --info: #4A6FA5;
+}
+
+/* ─── Reset ─── */
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html, body {
+  background: var(--bg-warm);
+  font-family: 'Geist', system-ui, sans-serif;
+  color: var(--ink);
+  min-height: 100vh;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* ─── Chrome (nav bar) ─── */
+.chrome {
+  position: fixed; top: 0; left: 0; right: 0;
+  background: var(--ink);
+  color: var(--bg-cream);
+  padding: 14px 24px;
+  z-index: 100;
+  display: flex; align-items: center; justify-content: space-between;
+  border-bottom: 1px solid #1a1a18;
+}
+.chrome-brand {
+  font-family: 'Bricolage Grotesque', sans-serif;
+  font-weight: 700;
+  font-size: 18px;
+  letter-spacing: -0.02em;
+  display: flex; align-items: center; gap: 10px;
+}
+.chrome-brand .dot {
+  width: 8px; height: 8px; background: var(--lime); border-radius: 50%;
+  display: inline-block;
+}
+.chrome-nav {
+  display: flex; gap: 4px; flex-wrap: wrap;
+  font-family: 'Geist Mono', monospace;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  max-width: 70%;
+}
+.chrome-nav button {
+  background: transparent;
+  color: var(--muted-light);
+  border: 1px solid #2a2a28;
+  padding: 5px 9px;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: inherit;
+  letter-spacing: inherit;
+  transition: all 0.15s;
+}
+.chrome-nav button:hover { color: var(--bg-cream); border-color: var(--muted); }
+.chrome-nav button.active {
+  background: var(--lime); color: var(--ink); border-color: var(--lime);
+}
+.chrome-counter {
+  font-family: 'Geist Mono', monospace;
+  font-size: 11px;
+  color: var(--muted-light);
+  letter-spacing: 0.08em;
+  white-space: nowrap;
+}
+.chrome-group-label {
+  color: var(--muted); font-size: 9px;
+  padding: 0 4px; align-self: center;
+  text-transform: uppercase; letter-spacing: 0.12em;
+}
+
+/* ─── Stage layout ─── */
+.stage {
+  padding-top: 88px;
+  min-height: 100vh;
+  display: none;
+  flex-direction: column;
+  align-items: center;
+}
+.stage.active { display: flex; }
+.stage-header {
+  width: 100%;
+  max-width: 1320px;
+  padding: 32px 40px 24px;
+  display: flex; justify-content: space-between; align-items: end;
+  border-bottom: 1px solid var(--line);
+}
+.stage-title {
+  font-family: 'Bricolage Grotesque', sans-serif;
+  font-weight: 700;
+  font-size: 42px;
+  line-height: 1;
+  letter-spacing: -0.03em;
+}
+.stage-title .num {
+  font-family: 'Geist Mono', monospace;
+  font-size: 13px;
+  color: var(--muted);
+  display: block;
+  margin-bottom: 8px;
+  letter-spacing: 0.1em;
+  font-weight: 400;
+}
+.stage-meta {
+  font-family: 'Geist Mono', monospace;
+  font-size: 11px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  text-align: right;
+  line-height: 1.7;
+}
+.stage-meta span { color: var(--ink); }
+.stage-body {
+  width: 100%;
+  max-width: 1320px;
+  padding: 48px 40px 80px;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 80px;
+}
+.stage-notes {
+  width: 320px;
+  flex-shrink: 0;
+  padding-top: 8px;
+}
+.stage-notes h3 {
+  font-family: 'Bricolage Grotesque', sans-serif;
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--muted);
+  margin-bottom: 16px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--line);
+}
+.stage-notes ul {
+  list-style: none;
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--ink-soft);
+}
+.stage-notes li {
+  padding: 10px 0;
+  border-bottom: 1px solid var(--line-soft);
+  display: flex; gap: 10px;
+}
+.stage-notes li::before {
+  content: "→";
+  color: var(--olive);
+  flex-shrink: 0;
+  font-weight: 600;
+}
+.stage-notes li b { color: var(--ink); font-weight: 600; }
+.stage-notes .cap {
+  font-family: 'Geist Mono', monospace;
+  font-size: 10px;
+  background: var(--ink);
+  color: var(--lime);
+  padding: 2px 6px;
+  border-radius: 3px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.stage-notes .rn {
+  font-family: 'Geist Mono', monospace;
+  font-size: 10px;
+  background: var(--lime);
+  color: var(--ink);
+  padding: 2px 6px;
+  border-radius: 3px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+}
+
+/* ─── Phone frame ─── */
+.phone {
+  width: 390px;
+  height: 844px;
+  background: var(--ink);
+  border-radius: 48px;
+  padding: 12px;
+  box-shadow: 0 30px 80px -20px rgba(10,10,10,0.35), 0 1px 0 rgba(255,255,255,0.04) inset;
+  flex-shrink: 0;
+  position: relative;
+}
+.phone-screen {
+  width: 100%; height: 100%;
+  background: var(--bg-cream);
+  border-radius: 38px;
+  overflow: hidden;
+  position: relative;
+}
+.phone-notch {
+  position: absolute;
+  top: 12px; left: 50%; transform: translateX(-50%);
+  width: 120px; height: 32px;
+  background: var(--ink);
+  border-radius: 20px;
+  z-index: 20;
+}
+.phone-status {
+  position: absolute; top: 0; left: 0; right: 0;
+  padding: 16px 32px 0;
+  display: flex; justify-content: space-between;
+  font-family: 'Geist', sans-serif;
+  font-size: 14px; font-weight: 600;
+  color: var(--ink);
+  z-index: 15;
+}
+.phone-status.dark { color: white; }
+.phone-content {
+  position: absolute; top: 56px; left: 0; right: 0; bottom: 0;
+  overflow: hidden;
+}
+
+/* ─── Desktop frame ─── */
+.desktop {
+  width: 1100px;
+  background: var(--bg-cream);
+  border-radius: 16px;
+  border: 1px solid var(--line);
+  box-shadow: 0 30px 80px -20px rgba(10,10,10,0.25);
+  overflow: hidden;
+}
+.desktop-bar {
+  background: var(--bg-warm);
+  padding: 12px 18px;
+  border-bottom: 1px solid var(--line);
+  display: flex; align-items: center; gap: 8px;
+}
+.desktop-bar .traffic { display: flex; gap: 6px; }
+.desktop-bar .traffic span {
+  width: 11px; height: 11px; border-radius: 50%;
+  background: var(--muted-light);
+}
+.desktop-bar .url {
+  flex: 1;
+  background: var(--bg-cream);
+  border: 1px solid var(--line);
+  padding: 5px 12px;
+  border-radius: 6px;
+  font-family: 'Geist Mono', monospace;
+  font-size: 11px;
+  color: var(--muted);
+  margin-left: 12px;
+}
+.desktop-content { min-height: 720px; }
+
+/* ─── Components (alphabetical) ─── */
+
+/* admin-brand */
+.admin-brand {
+  font-family: 'Bricolage Grotesque', sans-serif;
+  font-weight: 800; font-size: 22px; letter-spacing: -0.04em;
+  display: flex; align-items: center; gap: 8px;
+  margin-bottom: 32px; padding-bottom: 24px;
+  border-bottom: 1px solid #2a2a28;
+}
+.admin-brand .dot { width: 8px; height: 8px; background: var(--lime); border-radius: 50%; }
+
+/* admin-btn */
+.admin-btn {
+  padding: 9px 16px; border: 1px solid var(--line);
+  background: white; border-radius: 100px;
+  font-family: 'Geist', sans-serif; font-size: 12px; font-weight: 500;
+  cursor: pointer; display: flex; align-items: center; gap: 6px;
+}
+.admin-btn.dark { background: var(--ink); color: var(--bg-cream); border-color: var(--ink); }
+
+/* admin-club-pill */
+.admin-club-pill {
+  background: #1a1a18; border: 1px solid #2a2a28;
+  border-radius: 12px; padding: 12px; margin-bottom: 26px;
+}
+.admin-club-pill .lab {
+  font-family: 'Geist Mono', monospace; font-size: 9px;
+  text-transform: uppercase; letter-spacing: 0.1em; color: var(--muted-light);
+}
+.admin-club-pill .name {
+  font-family: 'Bricolage Grotesque', sans-serif;
+  font-weight: 600; font-size: 14px; margin-top: 4px;
+}
+
+/* admin layout */
+.admin { display: flex; height: 720px; background: var(--bg-cream); }
+.admin-sidebar {
+  width: 240px; background: var(--ink); color: var(--bg-cream);
+  padding: 24px 18px; flex-shrink: 0;
+}
+.admin-nav { display: flex; flex-direction: column; gap: 2px; }
+.admin-nav-item {
+  padding: 11px 14px; border-radius: 10px;
+  display: flex; align-items: center; gap: 12px;
+  color: var(--muted-light); font-size: 13px; font-weight: 500;
+  cursor: pointer; transition: all 0.15s;
+}
+.admin-nav-item:hover { background: #1a1a18; color: white; }
+.admin-nav-item.active { background: var(--lime); color: var(--ink); }
+.admin-nav-section {
+  font-family: 'Geist Mono', monospace; font-size: 9px;
+  text-transform: uppercase; letter-spacing: 0.12em;
+  color: var(--muted); padding: 18px 14px 8px; font-weight: 500;
+}
+.admin-main { flex: 1; overflow-y: auto; }
+.admin-topbar {
+  padding: 22px 36px; border-bottom: 1px solid var(--line);
+  display: flex; justify-content: space-between; align-items: center;
+  background: var(--bg-cream);
+}
+.admin-topbar h1 {
+  font-family: 'Bricolage Grotesque', sans-serif;
+  font-size: 28px; font-weight: 700; letter-spacing: -0.03em; line-height: 1;
+}
+.admin-topbar .date {
+  font-family: 'Geist Mono', monospace; font-size: 11px;
+  text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted);
+  margin-top: 4px;
+}
+.admin-topbar-actions { display: flex; gap: 10px; align-items: center; }
+.admin-content { padding: 28px 36px; }
+
+/* admin-kpis */
+.admin-kpis {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr 1fr 1fr;
+  gap: 14px;
+  margin-bottom: 24px;
+}
+
+/* admin-grid */
+.admin-grid { display: grid; grid-template-columns: 2fr 1fr; gap: 18px; }
+.admin-panel { background: white; border: 1px solid var(--line); border-radius: 20px; overflow: hidden; }
+.admin-panel-head {
+  padding: 18px 22px; border-bottom: 1px solid var(--line);
+  display: flex; justify-content: space-between; align-items: center;
+}
+.admin-panel-head h3 {
+  font-family: 'Bricolage Grotesque', sans-serif;
+  font-size: 16px; font-weight: 700; letter-spacing: -0.02em;
+}
+.admin-panel-head .filter {
+  font-family: 'Geist Mono', monospace; font-size: 10px;
+  text-transform: uppercase; letter-spacing: 0.08em;
+  color: var(--muted); cursor: pointer;
+}
+.admin-list { padding: 8px 0; }
+.admin-list-item {
+  display: flex; align-items: center; gap: 12px;
+  padding: 12px 22px; border-bottom: 1px solid var(--line-soft);
+}
+.admin-list-item:last-child { border-bottom: none; }
+.admin-list-item .av {
+  width: 32px; height: 32px; background: var(--bg-warm);
+  border-radius: 50%; display: flex; align-items: center; justify-content: center;
+  font-family: 'Bricolage Grotesque', sans-serif; font-weight: 700; font-size: 12px;
+  color: var(--olive); flex-shrink: 0;
+}
+.admin-list-item .info { flex: 1; min-width: 0; }
+.admin-list-item .name { font-size: 13px; font-weight: 500; color: var(--ink); }
+.admin-list-item .meta {
+  font-family: 'Geist Mono', monospace; font-size: 10px;
+  color: var(--muted); margin-top: 2px; letter-spacing: 0.04em;
+}
+.admin-list-item .amount {
+  font-family: 'Geist Mono', monospace; font-size: 12px; font-weight: 600; color: var(--ink);
+}
+.admin-side { display: flex; flex-direction: column; gap: 18px; }
+
+/* cal-event */
+.cal-event {
+  position: absolute; left: 4px; right: 4px;
+  background: var(--olive); color: var(--bg-cream);
+  border-radius: 6px; padding: 6px 8px;
+  font-size: 11px; font-weight: 500; overflow: hidden;
+}
+.cal-event.alt { background: var(--olive-dark); }
+.cal-event.lime { background: var(--lime); color: var(--ink); }
+.cal-event.maint { background: var(--danger); }
+.cal-event .t {
+  font-family: 'Geist Mono', monospace; font-size: 9px;
+  opacity: 0.8; display: block; margin-bottom: 2px;
+}
+
+/* cal-grid */
+.cal-toolbar {
+  display: flex; justify-content: space-between; align-items: center; margin-bottom: 18px;
+}
+.cal-toolbar .week {
+  font-family: 'Bricolage Grotesque', sans-serif;
+  font-size: 22px; font-weight: 700; letter-spacing: -0.02em;
+}
+.cal-toolbar .week .sub {
+  font-family: 'Geist Mono', monospace; font-size: 11px;
+  color: var(--muted); font-weight: 400; margin-left: 10px;
+  letter-spacing: 0.06em; text-transform: uppercase;
+}
+.cal-nav { display: flex; gap: 6px; align-items: center; }
+.cal-nav button {
+  width: 34px; height: 34px; border: 1px solid var(--line);
+  background: white; border-radius: 50%; cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+}
+.cal-nav .today { width: auto; padding: 0 14px; border-radius: 100px; font-family: 'Geist', sans-serif; font-size: 12px; font-weight: 500; }
+.cal-grid { background: white; border: 1px solid var(--line); border-radius: 16px; overflow: hidden; }
+.cal-head { display: grid; grid-template-columns: 60px repeat(7, 1fr); border-bottom: 1px solid var(--line); }
+.cal-head .h { padding: 12px 8px; text-align: center; border-right: 1px solid var(--line-soft); }
+.cal-head .h:last-child { border-right: none; }
+.cal-head .h .dow {
+  font-family: 'Geist Mono', monospace; font-size: 10px;
+  text-transform: uppercase; letter-spacing: 0.1em; color: var(--muted);
+}
+.cal-head .h .num {
+  font-family: 'Bricolage Grotesque', sans-serif;
+  font-size: 18px; font-weight: 700; letter-spacing: -0.02em; margin-top: 2px;
+}
+.cal-head .h.today .num { color: var(--lime); }
+.cal-head .h.today { background: var(--ink); }
+.cal-head .h.today .dow { color: var(--muted-light); }
+.cal-body { display: grid; grid-template-columns: 60px repeat(7, 1fr); max-height: 480px; overflow-y: auto; position: relative; }
+.cal-body::-webkit-scrollbar { display: none; }
+.cal-hours { background: var(--bg-warm); border-right: 1px solid var(--line); }
+.cal-hour {
+  height: 56px; padding: 6px 8px; text-align: right;
+  font-family: 'Geist Mono', monospace; font-size: 10px;
+  color: var(--muted); border-bottom: 1px solid var(--line-soft);
+}
+.cal-col { border-right: 1px solid var(--line-soft); position: relative; min-height: 560px; }
+.cal-col:last-child { border-right: none; }
+.cal-col .hline { height: 56px; border-bottom: 1px solid var(--line-soft); }
+
+/* card-preview */
+.card-preview {
+  background: linear-gradient(135deg, var(--olive) 0%, var(--olive-dark) 100%);
+  color: var(--bg-cream); border-radius: 16px;
+  padding: 18px; margin-bottom: 22px; position: relative; overflow: hidden;
+}
+.card-preview::after {
+  content: ''; position: absolute;
+  top: -40px; right: -40px; width: 120px; height: 120px;
+  background: var(--lime); border-radius: 50%; opacity: 0.16;
+}
+.card-preview .chip { width: 32px; height: 24px; background: var(--lime); border-radius: 4px; margin-bottom: 28px; opacity: 0.8; }
+.card-preview .num { font-family: 'Geist Mono', monospace; font-size: 17px; letter-spacing: 0.12em; margin-bottom: 14px; }
+.card-preview .row {
+  display: flex; justify-content: space-between;
+  font-family: 'Geist Mono', monospace; font-size: 11px;
+  color: var(--muted-light); text-transform: uppercase;
+}
+.card-preview .row b { color: white; display: block; font-size: 13px; margin-top: 2px; font-weight: 500; }
+
+/* chip */
+.chip {
+  padding: 9px 16px; border: 1px solid var(--line);
+  border-radius: 100px; background: white;
+  font-size: 13px; font-weight: 500; cursor: pointer;
+}
+.chip.active { background: var(--ink); color: var(--bg-cream); border-color: var(--ink); }
+.chip.lime { background: var(--lime); color: var(--ink); border-color: var(--lime); }
+.chip-row { display: flex; gap: 8px; flex-wrap: wrap; }
+
+/* courts-grid */
+.courts-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+.court-card { background: white; border: 1px solid var(--line); border-radius: 18px; padding: 20px; position: relative; }
+.court-card .ico-court { width: 56px; height: 80px; background: var(--olive); border-radius: 6px; position: relative; margin-bottom: 16px; overflow: hidden; }
+.court-card .ico-court::before { content: ''; position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%); width: 80%; height: 1.5px; background: var(--lime); opacity: 0.7; }
+.court-card .ico-court::after { content: ''; position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%); width: 1.5px; height: 90%; background: var(--lime); opacity: 0.4; }
+.court-card .name { font-family: 'Bricolage Grotesque', sans-serif; font-size: 20px; font-weight: 700; letter-spacing: -0.02em; }
+.court-card .meta { font-family: 'Geist Mono', monospace; font-size: 10px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); margin-top: 4px; margin-bottom: 16px; }
+.court-card .stats { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; padding-top: 14px; border-top: 1px solid var(--line); }
+.court-card .stat .lab { font-family: 'Geist Mono', monospace; font-size: 9px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); }
+.court-card .stat .val { font-family: 'Bricolage Grotesque', sans-serif; font-size: 18px; font-weight: 700; letter-spacing: -0.02em; margin-top: 2px; }
+.court-card .badge { position: absolute; top: 16px; right: 16px; font-family: 'Geist Mono', monospace; font-size: 9px; padding: 3px 8px; border-radius: 100px; text-transform: uppercase; letter-spacing: 0.1em; font-weight: 600; }
+.court-card .badge.active { background: var(--lime); color: var(--ink); }
+.court-card .badge.maint { background: var(--warn); color: white; }
+.court-card.add { border: 2px dashed var(--line); display: flex; flex-direction: column; align-items: center; justify-content: center; cursor: pointer; min-height: 240px; color: var(--muted); }
+.court-card.add:hover { border-color: var(--olive); color: var(--olive); }
+.court-card.add .plus { width: 48px; height: 48px; border: 1.5px solid currentColor; border-radius: 50%; display: flex; align-items: center; justify-content: center; margin-bottom: 14px; font-size: 22px; }
+.court-card.add .lab { font-family: 'Bricolage Grotesque', sans-serif; font-size: 14px; font-weight: 600; }
+
+/* delete-warn */
+.delete-warn {
+  background: linear-gradient(135deg, #1a1108 0%, #2a1810 100%);
+  color: var(--bg-cream); border-radius: 20px;
+  padding: 24px; margin-bottom: 22px; text-align: center;
+  border: 1px solid #3a2418;
+}
+.delete-warn .ico { width: 64px; height: 64px; background: var(--danger); border-radius: 50%; display: flex; align-items: center; justify-content: center; margin: 0 auto 18px; }
+.delete-warn h1 { font-family: 'Bricolage Grotesque', sans-serif; font-size: 26px; font-weight: 700; letter-spacing: -0.03em; line-height: 1.1; margin-bottom: 10px; }
+.delete-warn p { color: rgba(255,255,255,0.7); font-size: 13px; line-height: 1.5; }
+.delete-list { background: white; border: 1px solid var(--line); border-radius: 16px; padding: 18px; margin-bottom: 18px; }
+.delete-list h3 { font-family: 'Geist Mono', monospace; font-size: 10px; text-transform: uppercase; letter-spacing: 0.12em; color: var(--muted); margin-bottom: 14px; }
+.delete-list ul { list-style: none; }
+.delete-list li { padding: 8px 0; font-size: 13px; color: var(--ink-soft); display: flex; gap: 10px; border-bottom: 1px solid var(--line-soft); }
+.delete-list li:last-child { border-bottom: none; }
+.delete-list li::before { content: "○"; color: var(--danger); font-weight: 700; font-size: 14px; }
+.delete-confirm { background: var(--bg-warm); border-radius: 14px; padding: 16px; margin-bottom: 18px; }
+.delete-confirm .lab { font-family: 'Geist Mono', monospace; font-size: 10px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--muted); margin-bottom: 8px; }
+.delete-confirm input { width: 100%; background: white; border: 1px solid var(--line); border-radius: 10px; padding: 12px 14px; font-family: 'Geist Mono', monospace; font-size: 14px; color: var(--ink); outline: none; }
+.delete-confirm .hint { font-size: 11px; color: var(--muted); margin-top: 8px; }
+.delete-confirm .hint b { font-family: 'Geist Mono', monospace; color: var(--ink); font-weight: 600; }
+
+/* filters */
+.filters-bar { display: flex; gap: 10px; margin-bottom: 20px; align-items: center; }
+.filter-chip { padding: 9px 16px; background: white; border: 1px solid var(--line); border-radius: 100px; font-size: 12px; font-weight: 500; display: flex; align-items: center; gap: 8px; cursor: pointer; }
+.filter-chip.active { background: var(--ink); color: var(--bg-cream); border-color: var(--ink); }
+.filter-chip .count { background: var(--lime); color: var(--ink); padding: 1px 7px; border-radius: 100px; font-family: 'Geist Mono', monospace; font-size: 10px; font-weight: 700; }
+.search-box { flex: 1; max-width: 320px; background: white; border: 1px solid var(--line); border-radius: 100px; padding: 9px 16px; display: flex; align-items: center; gap: 10px; }
+.search-box input { border: none; outline: none; flex: 1; background: transparent; font-family: 'Geist', sans-serif; font-size: 13px; color: var(--ink); }
+.search-box svg { color: var(--muted); }
+
+/* home-next */
+.home-next {
+  background: var(--ink); color: var(--bg-cream);
+  border-radius: 24px; padding: 24px 22px; margin-bottom: 24px;
+  position: relative; overflow: hidden;
+}
+.home-next::before {
+  content: ''; position: absolute; top: -40px; right: -40px;
+  width: 160px; height: 160px; background: var(--lime);
+  border-radius: 50%; opacity: 0.18;
+}
+.home-next .tag { font-family: 'Geist Mono', monospace; font-size: 10px; text-transform: uppercase; letter-spacing: 0.12em; color: var(--lime); margin-bottom: 18px; display: flex; align-items: center; gap: 8px; }
+.home-next .tag .live { width: 6px; height: 6px; background: var(--lime); border-radius: 50%; animation: pulse 1.6s infinite; }
+@keyframes pulse { 0%, 100% { opacity: 1; transform: scale(1); } 50% { opacity: 0.4; transform: scale(0.7); } }
+.home-next .time { font-family: 'Bricolage Grotesque', sans-serif; font-size: 44px; font-weight: 700; letter-spacing: -0.04em; line-height: 1; margin-bottom: 4px; }
+.home-next .court { font-size: 14px; color: var(--muted-light); margin-bottom: 18px; }
+.home-next .meta { display: flex; gap: 16px; padding-top: 16px; border-top: 1px solid #2a2a28; font-size: 12px; color: var(--muted-light); }
+.home-next .meta b { color: white; font-weight: 600; display: block; margin-top: 2px; font-size: 13px; }
+
+/* info-pill */
+.info-pill { background: var(--bg-warm); border-radius: 14px; padding: 14px; }
+.info-pill .lab { font-family: 'Geist Mono', monospace; font-size: 9px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--muted); margin-bottom: 4px; }
+.info-pill .val { font-family: 'Bricolage Grotesque', sans-serif; font-size: 16px; font-weight: 600; letter-spacing: -0.02em; }
+
+/* kpi */
+.kpi { background: white; border: 1px solid var(--line); border-radius: 18px; padding: 20px; position: relative; }
+.kpi.hero { background: var(--ink); color: var(--bg-cream); border-color: var(--ink); overflow: hidden; }
+.kpi.hero::before { content: ''; position: absolute; top: -30px; right: -30px; width: 120px; height: 120px; border-radius: 50%; background: var(--lime); opacity: 0.18; }
+.kpi .lab { font-family: 'Geist Mono', monospace; font-size: 10px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--muted); }
+.kpi.hero .lab { color: var(--lime); }
+.kpi .num { font-family: 'Bricolage Grotesque', sans-serif; font-size: 36px; font-weight: 700; letter-spacing: -0.03em; line-height: 1; margin-top: 14px; }
+.kpi.hero .num { font-size: 44px; }
+.kpi .delta { margin-top: 8px; font-family: 'Geist Mono', monospace; font-size: 11px; color: var(--olive); font-weight: 500; }
+.kpi.hero .delta { color: var(--lime); }
+.kpi .delta.neg { color: var(--danger); }
+
+/* otp-box */
+.otp-box {
+  aspect-ratio: 1;
+  background: white; border: 1px solid var(--line); border-radius: 14px;
+  display: flex; align-items: center; justify-content: center;
+  font-family: 'Bricolage Grotesque', sans-serif;
+  font-weight: 700; font-size: 28px; letter-spacing: -0.02em;
+}
+.otp-box.filled { border-color: var(--ink); background: var(--bg-warm); }
+.otp-box.active { border-color: var(--olive); background: white; box-shadow: 0 0 0 3px rgba(63, 74, 46, 0.12); }
+.otp-box .cursor { width: 2px; height: 28px; background: var(--olive); animation: blink 1s infinite; }
+@keyframes blink { 50% { opacity: 0; } }
+.otp-boxes { display: grid; grid-template-columns: repeat(6, 1fr); gap: 10px; margin-bottom: 24px; }
+.otp-timer { text-align: center; font-family: 'Geist Mono', monospace; font-size: 12px; color: var(--muted); margin-bottom: 24px; letter-spacing: 0.04em; }
+.otp-timer .num { color: var(--olive); font-weight: 600; }
+.otp-resend { text-align: center; margin-top: 14px; font-size: 13px; color: var(--muted); }
+.otp-resend a { color: var(--ink); border-bottom: 1px solid var(--ink); text-decoration: none; font-weight: 500; }
+
+/* p-btn */
+.p-btn {
+  width: 100%; background: var(--ink); color: var(--bg-cream);
+  border: none; padding: 18px;
+  font-family: 'Geist', sans-serif; font-weight: 600; font-size: 15px;
+  border-radius: 100px; cursor: pointer;
+  display: flex; justify-content: center; align-items: center; gap: 8px;
+}
+.p-btn.lime { background: var(--lime); color: var(--ink); }
+.p-btn.outline { background: transparent; color: var(--ink); border: 1px solid var(--ink); }
+.p-btn.danger { background: var(--danger); color: white; }
+.p-btn .arrow { font-size: 18px; }
+
+/* p-card */
+.p-card { background: white; border: 1px solid var(--line); border-radius: 18px; padding: 18px; }
+
+/* p-eyebrow */
+.p-eyebrow {
+  font-family: 'Geist Mono', monospace; font-size: 10px;
+  text-transform: uppercase; letter-spacing: 0.12em; color: var(--muted);
+}
+
+/* p-h1, p-h2 */
+.p-h1 { font-family: 'Bricolage Grotesque', sans-serif; font-weight: 700; font-size: 36px; line-height: 0.95; letter-spacing: -0.04em; }
+.p-h2 { font-family: 'Bricolage Grotesque', sans-serif; font-weight: 700; font-size: 22px; letter-spacing: -0.03em; line-height: 1.1; }
+
+/* p-input */
+.p-input {
+  width: 100%; background: transparent; border: none;
+  border-bottom: 1px solid var(--line); padding: 14px 0;
+  font-family: 'Geist', sans-serif; font-size: 16px;
+  color: var(--ink); outline: none;
+}
+.p-input-label {
+  font-family: 'Geist Mono', monospace; font-size: 10px;
+  text-transform: uppercase; letter-spacing: 0.1em;
+  color: var(--muted); display: block; margin-bottom: 4px;
+}
+
+/* p-logo */
+.p-logo { font-family: 'Bricolage Grotesque', sans-serif; font-weight: 800; font-size: 22px; letter-spacing: -0.04em; display: flex; align-items: center; gap: 6px; }
+.p-logo .dot { width: 7px; height: 7px; background: var(--lime); border-radius: 50%; }
+
+/* p-back, p-top */
+.p-back { width: 40px; height: 40px; border: 1px solid var(--line); border-radius: 50%; background: white; display: flex; align-items: center; justify-content: center; cursor: pointer; }
+.p-back svg { width: 16px; height: 16px; }
+.p-top { display: flex; align-items: center; gap: 12px; margin-bottom: 28px; }
+.p-top h1 { font-family: 'Bricolage Grotesque', sans-serif; font-size: 22px; font-weight: 700; letter-spacing: -0.02em; }
+
+/* p-screen */
+.p-screen { width: 100%; height: 100%; padding: 24px 22px; overflow-y: auto; }
+.p-screen::-webkit-scrollbar { display: none; }
+
+/* p-tabbar */
+.p-tabbar {
+  position: absolute; bottom: 0; left: 0; right: 0;
+  background: var(--ink); padding: 18px 22px 32px;
+  border-radius: 24px 24px 38px 38px;
+  display: flex; justify-content: space-around; align-items: center;
+}
+.p-tab {
+  color: var(--muted-light); font-family: 'Geist Mono', monospace;
+  font-size: 10px; text-transform: uppercase; letter-spacing: 0.08em;
+  display: flex; flex-direction: column; align-items: center; gap: 6px; cursor: pointer;
+}
+.p-tab.active { color: var(--lime); }
+.p-tab svg { width: 22px; height: 22px; }
+
+/* partidas */
+.partidas { padding-bottom: 110px; }
+.partidas-tabs { display: flex; gap: 0; margin-bottom: 18px; border-bottom: 1px solid var(--line); }
+.partidas-tab { flex: 1; padding: 12px 0; text-align: center; font-family: 'Geist Mono', monospace; font-size: 11px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--muted); cursor: pointer; border-bottom: 2px solid transparent; margin-bottom: -1px; }
+.partidas-tab.active { color: var(--ink); border-bottom-color: var(--ink); font-weight: 600; }
+.partida-card { background: white; border: 1px solid var(--line); border-radius: 20px; padding: 18px; margin-bottom: 12px; }
+.partida-card .head { display: flex; justify-content: space-between; align-items: start; margin-bottom: 14px; }
+.partida-card .when-block { font-family: 'Bricolage Grotesque', sans-serif; font-size: 24px; font-weight: 700; letter-spacing: -0.03em; line-height: 1; }
+.partida-card .when-block .d { font-family: 'Geist Mono', monospace; font-size: 10px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.1em; font-weight: 400; margin-top: 6px; }
+.partida-card .level { padding: 4px 10px; background: var(--bg-warm); border-radius: 100px; font-family: 'Geist Mono', monospace; font-size: 10px; text-transform: uppercase; letter-spacing: 0.08em; font-weight: 600; }
+.partida-card .level.med { color: var(--info); }
+.partida-card .level.adv { color: var(--danger); }
+.partida-card .court-line { font-size: 13px; color: var(--muted); margin-bottom: 14px; }
+.partida-card .players { display: flex; gap: -6px; margin-bottom: 14px; align-items: center; }
+.partida-card .players .av { width: 36px; height: 36px; background: var(--olive); color: var(--lime); border-radius: 50%; display: flex; align-items: center; justify-content: center; font-family: 'Bricolage Grotesque', sans-serif; font-weight: 700; font-size: 11px; margin-right: -10px; border: 2px solid var(--bg-cream); }
+.partida-card .players .av.empty { background: transparent; border: 1.5px dashed var(--muted-light); color: var(--muted); }
+.partida-card .players .count { margin-left: 20px; font-size: 13px; color: var(--muted); }
+.partida-card .players .count b { color: var(--ink); font-weight: 600; }
+.partida-card .footer { display: flex; justify-content: space-between; align-items: center; padding-top: 14px; border-top: 1px solid var(--line-soft); }
+.partida-card .price { font-family: 'Bricolage Grotesque', sans-serif; font-size: 18px; font-weight: 700; letter-spacing: -0.02em; }
+.partida-card .price small { font-family: 'Geist Mono', monospace; font-size: 10px; color: var(--muted); font-weight: 400; }
+.partida-card .join-btn { padding: 9px 18px; background: var(--lime); color: var(--ink); border: none; border-radius: 100px; font-family: 'Geist', sans-serif; font-size: 13px; font-weight: 600; cursor: pointer; }
+.partida-card .join-btn.full { background: var(--bg-warm); color: var(--muted); }
+
+/* player-chip */
+.player-chip { display: flex; align-items: center; gap: 8px; padding: 6px 12px 6px 6px; background: var(--bg-warm); border-radius: 100px; font-size: 13px; font-weight: 500; }
+.player-chip .av { width: 26px; height: 26px; background: var(--olive); color: var(--lime); border-radius: 50%; display: flex; align-items: center; justify-content: center; font-family: 'Bricolage Grotesque', sans-serif; font-weight: 700; font-size: 10px; }
+.player-chip.empty { background: transparent; border: 1px dashed var(--line); color: var(--muted); }
+.player-chip.empty .av { background: transparent; border: 1px dashed var(--muted-light); color: var(--muted); }
+.players-row { display: flex; gap: 8px; flex-wrap: wrap; }
+
+/* slot */
+.slot { padding: 7px 11px; border: 1px solid var(--line); border-radius: 8px; font-family: 'Geist Mono', monospace; font-size: 11px; font-weight: 500; cursor: pointer; }
+.slot.taken { background: var(--bg-warm); color: var(--muted-light); text-decoration: line-through; cursor: not-allowed; }
+.slot.hot { background: var(--lime); border-color: var(--lime); color: var(--ink); }
+.court-slots { display: flex; flex-wrap: wrap; gap: 6px; }
+
+/* success-ico */
+.success-ico {
+  width: 120px; height: 120px;
+  background: var(--lime); border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  margin: 60px auto 28px; position: relative; z-index: 2;
+}
+.success-ico svg { width: 56px; height: 56px; }
+
+/* table-head / table-row */
+.table-head { display: grid; grid-template-columns: 100px 1fr 140px 120px 100px 80px 40px; gap: 16px; padding: 12px 22px; background: var(--bg-warm); }
+.table-head .col { font-family: 'Geist Mono', monospace; font-size: 10px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--muted); }
+.table-row { display: grid; grid-template-columns: 100px 1fr 140px 120px 100px 80px 40px; gap: 16px; padding: 16px 22px; align-items: center; border-bottom: 1px solid var(--line-soft); cursor: pointer; }
+.table-row:hover { background: var(--bg-cream); }
+.table-row .code { font-family: 'Geist Mono', monospace; font-size: 11px; color: var(--muted); letter-spacing: 0.04em; }
+.table-row .player { display: flex; align-items: center; gap: 10px; }
+.table-row .player .av { width: 30px; height: 30px; background: var(--olive); color: var(--lime); border-radius: 50%; display: flex; align-items: center; justify-content: center; font-family: 'Bricolage Grotesque', sans-serif; font-weight: 700; font-size: 10px; flex-shrink: 0; }
+.table-row .player .name { font-size: 13px; font-weight: 500; }
+.table-row .player .email { font-family: 'Geist Mono', monospace; font-size: 10px; color: var(--muted); letter-spacing: 0.02em; }
+.table-row .when { font-size: 13px; }
+.table-row .when .d { font-weight: 500; }
+.table-row .when .h { font-family: 'Geist Mono', monospace; font-size: 11px; color: var(--muted); }
+.table-row .court-name { font-size: 13px; font-weight: 500; }
+.table-row .court-name .sub { font-family: 'Geist Mono', monospace; font-size: 10px; color: var(--muted); display: block; }
+.table-row .amount { font-family: 'Geist Mono', monospace; font-size: 13px; font-weight: 600; }
+.table-row .pill { font-family: 'Geist Mono', monospace; font-size: 9px; padding: 4px 10px; border-radius: 100px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.1em; text-align: center; }
+.table-row .pill.ok { background: var(--lime); color: var(--ink); }
+.table-row .pill.warn { background: var(--warn); color: white; }
+.table-row .pill.bad { background: var(--bg-warm); color: var(--muted); }
+
+/* timeline */
+.timeline { padding: 22px; }
+.timeline-row { display: grid; grid-template-columns: 80px 1fr; gap: 14px; align-items: center; padding: 8px 0; }
+.timeline-court { font-family: 'Bricolage Grotesque', sans-serif; font-size: 13px; font-weight: 600; }
+.timeline-court .t { font-family: 'Geist Mono', monospace; font-size: 9px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.08em; font-weight: 400; margin-top: 2px; display: block; }
+.timeline-bar { position: relative; height: 32px; background: var(--bg-warm); border-radius: 6px; overflow: hidden; }
+.timeline-slot { position: absolute; top: 4px; bottom: 4px; border-radius: 4px; font-family: 'Geist Mono', monospace; font-size: 9px; color: white; display: flex; align-items: center; padding: 0 8px; overflow: hidden; white-space: nowrap; }
+.timeline-hours { display: grid; grid-template-columns: 80px 1fr; gap: 14px; margin-bottom: 8px; padding-bottom: 8px; border-bottom: 1px solid var(--line-soft); }
+.timeline-hours .scale { display: grid; grid-template-columns: repeat(12, 1fr); font-family: 'Geist Mono', monospace; font-size: 9px; color: var(--muted); }

--- a/docs/ux/mockups/index.html
+++ b/docs/ux/mockups/index.html
@@ -1,0 +1,297 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PadelPro · Mockups · Índice</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,500;12..96,600;12..96,700;12..96,800&family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="./_shared/styles.css">
+<style>
+  .index-hero {
+    padding: 48px 40px 32px;
+    border-bottom: 1px solid var(--line);
+    background: var(--bg-cream);
+  }
+  .index-hero h1 {
+    font-family: 'Bricolage Grotesque', sans-serif;
+    font-size: 36px;
+    font-weight: 800;
+    letter-spacing: -0.03em;
+    color: var(--ink);
+    margin: 0 0 6px;
+  }
+  .index-hero .sub {
+    font-size: 14px;
+    color: var(--muted);
+  }
+  .index-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 20px;
+    padding: 36px 40px 60px;
+    max-width: 1200px;
+    margin: 0 auto;
+  }
+  .idx-card {
+    background: white;
+    border: 1px solid var(--line);
+    border-radius: 16px;
+    padding: 20px;
+    text-decoration: none;
+    color: inherit;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    transition: border-color 0.15s, box-shadow 0.15s;
+  }
+  .idx-card:hover {
+    border-color: var(--olive);
+    box-shadow: 0 4px 16px rgba(0,0,0,0.06);
+  }
+  .idx-num {
+    font-family: 'Geist Mono', monospace;
+    font-size: 11px;
+    color: var(--muted-light);
+    letter-spacing: 0.06em;
+  }
+  .idx-name {
+    font-family: 'Bricolage Grotesque', sans-serif;
+    font-size: 17px;
+    font-weight: 700;
+    color: var(--ink);
+    letter-spacing: -0.01em;
+    line-height: 1.2;
+  }
+  .idx-cap {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    margin-top: 2px;
+  }
+  .idx-badge {
+    font-family: 'Geist Mono', monospace;
+    font-size: 9px;
+    letter-spacing: 0.04em;
+    padding: 3px 7px;
+    border-radius: 6px;
+    background: var(--ink);
+    color: var(--lime);
+    font-weight: 500;
+  }
+  .idx-device {
+    font-size: 11px;
+    color: var(--muted);
+    margin-top: auto;
+    padding-top: 8px;
+    border-top: 1px solid var(--line-soft);
+  }
+  .section-label {
+    grid-column: 1 / -1;
+    font-family: 'Geist Mono', monospace;
+    font-size: 10px;
+    letter-spacing: 0.1em;
+    color: var(--muted-light);
+    text-transform: uppercase;
+    padding-top: 8px;
+  }
+</style>
+</head>
+<body style="background:var(--bg-warm);min-height:100vh;">
+
+<div class="chrome">
+  <div class="chrome-brand"><span class="dot"></span> PadelPro · Mockups</div>
+  <div style="font-family:'Geist Mono',monospace;font-size:11px;color:var(--muted-light)">Índice · 24 pantallas</div>
+</div>
+
+<div class="index-hero">
+  <h1>PadelPro · Mockups</h1>
+  <div class="sub">24 pantallas · Sistema de diseño unificado · Entrega 1 + Entrega 2</div>
+</div>
+
+<div class="index-grid">
+
+  <div class="section-label">Auth &amp; Onboarding</div>
+
+  <a class="idx-card" href="./07-splash.html">
+    <div class="idx-num">01 · SPLASH · MOBILE</div>
+    <div class="idx-name">Splash &amp; bienvenida</div>
+    <div class="idx-cap"><span class="idx-badge">auth-local</span></div>
+    <div class="idx-device">Mobile · Público</div>
+  </a>
+
+  <a class="idx-card" href="./01-login.html">
+    <div class="idx-num">02 · AUTH · MOBILE</div>
+    <div class="idx-name">Login</div>
+    <div class="idx-cap"><span class="idx-badge">auth-local</span></div>
+    <div class="idx-device">Mobile · Público</div>
+  </a>
+
+  <a class="idx-card" href="./08-crear-cuenta.html">
+    <div class="idx-num">03 · AUTH · MOBILE</div>
+    <div class="idx-name">Crear cuenta</div>
+    <div class="idx-cap"><span class="idx-badge">auth-local</span><span class="idx-badge">usuarios</span></div>
+    <div class="idx-device">Mobile · Público</div>
+  </a>
+
+  <a class="idx-card" href="./09-recuperar-password.html">
+    <div class="idx-num">04 · AUTH · MOBILE</div>
+    <div class="idx-name">Recuperar contraseña</div>
+    <div class="idx-cap"><span class="idx-badge">auth-local</span></div>
+    <div class="idx-device">Mobile · Público</div>
+  </a>
+
+  <a class="idx-card" href="./10-nueva-password.html">
+    <div class="idx-num">05 · AUTH · MOBILE</div>
+    <div class="idx-name">Nueva contraseña</div>
+    <div class="idx-cap"><span class="idx-badge">auth-local</span></div>
+    <div class="idx-device">Mobile · Token reset</div>
+  </a>
+
+  <div class="section-label">Reservas · Jugador</div>
+
+  <a class="idx-card" href="./02-home-jugador.html">
+    <div class="idx-num">06 · HOME · MOBILE</div>
+    <div class="idx-name">Home jugador</div>
+    <div class="idx-cap"><span class="idx-badge">reservas</span><span class="idx-badge">disponibilidad-pistas</span></div>
+    <div class="idx-device">Mobile · JUGADOR</div>
+  </a>
+
+  <a class="idx-card" href="./03-buscar-disponibilidad.html">
+    <div class="idx-num">07 · RESERVAS · MOBILE</div>
+    <div class="idx-name">Buscar disponibilidad</div>
+    <div class="idx-cap"><span class="idx-badge">disponibilidad-pistas</span></div>
+    <div class="idx-device">Mobile · JUGADOR / INVITADO</div>
+  </a>
+
+  <a class="idx-card" href="./04-confirmar-reserva.html">
+    <div class="idx-num">08 · RESERVAS · MOBILE</div>
+    <div class="idx-name">Confirmar reserva</div>
+    <div class="idx-cap"><span class="idx-badge">reservas</span><span class="idx-badge">pagos-redsys</span></div>
+    <div class="idx-device">Mobile · JUGADOR</div>
+  </a>
+
+  <a class="idx-card" href="./11-checkout-redsys.html">
+    <div class="idx-num">09 · PAGOS · MOBILE</div>
+    <div class="idx-name">Checkout Redsys</div>
+    <div class="idx-cap"><span class="idx-badge">pagos-redsys</span></div>
+    <div class="idx-device">Mobile · JUGADOR</div>
+  </a>
+
+  <a class="idx-card" href="./12-pago-confirmado.html">
+    <div class="idx-num">10 · PAGOS · MOBILE</div>
+    <div class="idx-name">Pago confirmado</div>
+    <div class="idx-cap"><span class="idx-badge">pagos-redsys</span><span class="idx-badge">reservas</span></div>
+    <div class="idx-device">Mobile · JUGADOR</div>
+  </a>
+
+  <a class="idx-card" href="./05-mis-reservas.html">
+    <div class="idx-num">11 · RESERVAS · MOBILE</div>
+    <div class="idx-name">Mis reservas</div>
+    <div class="idx-cap"><span class="idx-badge">reservas</span></div>
+    <div class="idx-device">Mobile · JUGADOR</div>
+  </a>
+
+  <a class="idx-card" href="./13-detalle-reserva.html">
+    <div class="idx-num">12 · RESERVAS · MOBILE</div>
+    <div class="idx-name">Detalle de reserva</div>
+    <div class="idx-cap"><span class="idx-badge">reservas</span></div>
+    <div class="idx-device">Mobile · JUGADOR</div>
+  </a>
+
+  <div class="section-label">Perfil &amp; Telegram</div>
+
+  <a class="idx-card" href="./14-mi-perfil.html">
+    <div class="idx-num">13 · PERFIL · MOBILE</div>
+    <div class="idx-name">Mi perfil</div>
+    <div class="idx-cap"><span class="idx-badge">usuarios</span><span class="idx-badge">auth-otp-telegram</span></div>
+    <div class="idx-device">Mobile · JUGADOR</div>
+  </a>
+
+  <a class="idx-card" href="./15-vincular-telegram.html">
+    <div class="idx-num">14 · TELEGRAM · MOBILE</div>
+    <div class="idx-name">Vincular Telegram</div>
+    <div class="idx-cap"><span class="idx-badge">auth-otp-telegram</span></div>
+    <div class="idx-device">Mobile · JUGADOR</div>
+  </a>
+
+  <a class="idx-card" href="./16-otp-telegram.html">
+    <div class="idx-num">15 · TELEGRAM · MOBILE</div>
+    <div class="idx-name">Introducir OTP</div>
+    <div class="idx-cap"><span class="idx-badge">auth-otp-telegram</span></div>
+    <div class="idx-device">Mobile · JUGADOR</div>
+  </a>
+
+  <div class="section-label">Partidas (Fase 2)</div>
+
+  <a class="idx-card" href="./21-partidas-abiertas.html">
+    <div class="idx-num">16 · PARTIDAS · MOBILE</div>
+    <div class="idx-name">Partidas abiertas</div>
+    <div class="idx-cap"><span class="idx-badge">partidas</span></div>
+    <div class="idx-device">Mobile · JUGADOR</div>
+  </a>
+
+  <a class="idx-card" href="./20-crear-partida.html">
+    <div class="idx-num">17 · PARTIDAS · MOBILE</div>
+    <div class="idx-name">Crear partida pública</div>
+    <div class="idx-cap"><span class="idx-badge">partidas</span></div>
+    <div class="idx-device">Mobile · JUGADOR</div>
+  </a>
+
+  <a class="idx-card" href="./22-confirmar-union.html">
+    <div class="idx-num">18 · PARTIDAS · MOBILE</div>
+    <div class="idx-name">Confirmar unión</div>
+    <div class="idx-cap"><span class="idx-badge">partidas</span><span class="idx-badge">pagos-redsys</span></div>
+    <div class="idx-device">Mobile · JUGADOR</div>
+  </a>
+
+  <div class="section-label">RGPD &amp; Privacidad</div>
+
+  <a class="idx-card" href="./23-mis-datos.html">
+    <div class="idx-num">19 · RGPD · MOBILE</div>
+    <div class="idx-name">Mis datos y privacidad</div>
+    <div class="idx-cap"><span class="idx-badge">exportaciones-rgpd</span></div>
+    <div class="idx-device">Mobile · JUGADOR</div>
+  </a>
+
+  <a class="idx-card" href="./24-eliminar-cuenta.html">
+    <div class="idx-num">20 · RGPD · MOBILE</div>
+    <div class="idx-name">Confirmar eliminación</div>
+    <div class="idx-cap"><span class="idx-badge">exportaciones-rgpd</span><span class="idx-badge">auditoria</span></div>
+    <div class="idx-device">Mobile · JUGADOR</div>
+  </a>
+
+  <div class="section-label">Admin Club</div>
+
+  <a class="idx-card" href="./06-dashboard-club.html">
+    <div class="idx-num">21 · ADMIN · DESKTOP</div>
+    <div class="idx-name">Dashboard club</div>
+    <div class="idx-cap"><span class="idx-badge">administracion-club</span></div>
+    <div class="idx-device">Desktop · MANAGER_CLUB · ADMIN</div>
+  </a>
+
+  <a class="idx-card" href="./18-calendario-semanal.html">
+    <div class="idx-num">22 · ADMIN · DESKTOP</div>
+    <div class="idx-name">Calendario semanal</div>
+    <div class="idx-cap"><span class="idx-badge">reservas</span><span class="idx-badge">disponibilidad-pistas</span></div>
+    <div class="idx-device">Desktop · MANAGER_CLUB · ADMIN</div>
+  </a>
+
+  <a class="idx-card" href="./19-reservas-club.html">
+    <div class="idx-num">23 · ADMIN · DESKTOP</div>
+    <div class="idx-name">Reservas del club</div>
+    <div class="idx-cap"><span class="idx-badge">reservas</span><span class="idx-badge">pagos-redsys</span></div>
+    <div class="idx-device">Desktop · MANAGER_CLUB · ADMIN</div>
+  </a>
+
+  <a class="idx-card" href="./17-gestion-pistas.html">
+    <div class="idx-num">24 · ADMIN · DESKTOP</div>
+    <div class="idx-name">Gestión de pistas</div>
+    <div class="idx-cap"><span class="idx-badge">pistas</span></div>
+    <div class="idx-device">Desktop · MANAGER_CLUB · ADMIN</div>
+  </a>
+
+</div>
+</body>
+</html>

--- a/openspec/AGENTS.md
+++ b/openspec/AGENTS.md
@@ -1,0 +1,130 @@
+# AGENTS.md — Guía para agentes LLM en PadelPro OpenSpec
+
+> Este documento es la referencia obligatoria para cualquier agente que trabaje con el OpenSpec de PadelPro.
+> Léelo completo antes de crear, modificar o consultar cualquier artefacto del directorio `openspec/`.
+
+---
+
+## 1. Orden de lectura obligatorio
+
+Antes de escribir cualquier código, spec o artefacto, lee los documentos en este orden. Los de mayor numeración tienen mayor precedencia en caso de conflicto:
+
+| Orden | Documento | Qué extraer |
+|---|---|---|
+| 1 | `docs/PROJECT.md` | Variables operativas: `REPO_ROOT`, `BASE_BRANCH`, `GITHUB_ORG`, `GITHUB_REPO`, `GITHUB_PROJECT_NUMBER`, stack técnico, rutas de documentos. |
+| 2 | `docs/openapi.yaml` | Contrato REST canónico: rutas exactas (base `/api`), esquemas de request/response, códigos de estado, operationIds. |
+| 3 | `docs/security-design.md` | Reglas de seguridad autoritativas: RBAC, JWT (HS256), CORS, rate limiting, aislamiento de datos. |
+| 4 | `docs/data-model.md` | Entidades, tablas, campos, tipos, índices y constraints de la BD. |
+| 5 | `openspec/config.yaml` | Configuración del proyecto OpenSpec: stack, roles, fases, reglas por artefacto. |
+| 6 | `openspec/project.md` | Contexto de dominio: glosario, capabilities, fases del producto, flujos críticos, reglas de negocio. |
+| 7 | `openspec/changes/<slug>/proposal.md` | Propuesta del change activo: por qué, qué cambia, impacto. |
+| 8 | `openspec/changes/<slug>/design.md` | Decisiones de diseño del change activo. |
+| 9 | `openspec/changes/<slug>/specs/<capability>/spec.md` | Requisitos detallados y scenarios BDD del change activo. |
+| 10 | `openspec/changes/<slug>/tasks.md` | Checklist de tareas del change activo. |
+
+> **`README.md`** es contexto general de producto. Léelo para entender el dominio. En caso de conflicto con `docs/`, los documentos en `docs/` siempre tienen precedencia.
+
+---
+
+## 2. Qué es una capability
+
+Una **capability** es una agrupación funcional cohesiva del sistema que puede implementarse, probarse y documentarse de forma independiente. Corresponde a un módulo de negocio o un servicio transversal.
+
+Cada capability tiene:
+- Un **ID único** en `openspec/config.yaml` (ej. `auth-local`, `reservas`, `pagos-redsys`).
+- Un **spec base** en `openspec/specs/<capability>/spec.md` que describe los requisitos permanentes.
+- Cero o más **specs de change** en `openspec/changes/<slug>/specs/<capability>/spec.md` que añaden, modifican o eliminan requisitos para un change concreto.
+
+Las capabilities no mapean 1:1 con módulos Java. Por ejemplo, la capability `auth-otp-telegram` afecta a los módulos `usuarios`, `otp` y `mensajeria` del backend.
+
+---
+
+## 3. Qué es un change
+
+Un **change** es una unidad de trabajo planificada que modifica uno o más capabilities. Cada change tiene su propio directorio en `openspec/changes/<slug>/` con cuatro artefactos obligatorios:
+
+```
+openspec/changes/<slug>/
+├── proposal.md    ← Por qué (motivación, objetivos, impacto, fuera de alcance)
+├── design.md      ← Cómo (decisiones de diseño, riesgos, plan de migración)
+├── tasks.md       ← Checklist de tareas por capa (Backend / Frontend / Testing / Infra)
+└── specs/
+    └── <capability>/
+        └── spec.md  ← Requisitos AÑADIDOS/MODIFICADOS/ELIMINADOS por este change
+```
+
+Los specs de change son **deltas sobre los specs base**. Solo describen lo que cambia. Al archivar el change (`/opsx:archive`), los deltas se fusionan con los specs base.
+
+---
+
+## 4. Reglas para agentes
+
+1. **Nunca modifiques un spec sin un change activo.** Toda modificación de comportamiento del sistema debe tener un `openspec/changes/<slug>/` con sus cuatro artefactos. Si no existe, créalo con `/opsx:propose <slug>` antes de implementar.
+
+2. **Referencia siempre las reglas de negocio por su código exacto.** Usa `RN-AUTH-06`, `RN-PAY-01`, etc. — nunca parafrasees la regla sin citar el código. Los códigos están en `openspec/project.md §8` y en `docs/security-design.md`.
+
+3. **Usa solo los roles de v1.0 en las matrices RBAC.** Los roles válidos son `ADMIN` y `USER`. Nunca escribas `MANAGER_CLUB`, `JUGADOR` o `INVITADO` en specs, matrices de permisos o scenarios de la Fase 1.
+
+4. **Los paths de la API provienen exclusivamente de `docs/openapi.yaml`.** No inventes rutas. El base path es `/api` (no `/api/v1`). Si necesitas un endpoint nuevo, primero propón el cambio en `docs/openapi.yaml` como parte del change.
+
+5. **Los scenarios BDD usan el formato Given/When/Then estricto.** No uses prosa narrativa. Cada step comienza con `GIVEN`, `WHEN`, `THEN` o `AND`. El sistema es el sujeto del `THEN`, no el usuario.
+
+6. **No incluyas código, DDL ni detalles de implementación en los specs.** Los specs describen comportamiento observable desde la API o el dominio. El cómo se implementa va en `design.md` o en el código fuente.
+
+7. **Registra los conflictos como comentarios antes de proceder.** Si encuentras una contradicción entre dos fuentes (ej. `README.md` dice algo diferente a `docs/openapi.yaml`), documenta el conflicto como comentario HTML en el artefacto afectado y notifica al orquestador antes de continuar.
+
+8. **Los specs de change son deltas, no copias.** En `openspec/changes/<slug>/specs/<capability>/spec.md` solo escribas los requisitos nuevos o modificados. Marca cada requisito con `[AÑADIDO]`, `[MODIFICADO]` o `[ELIMINADO]` respecto al spec base.
+
+---
+
+## 5. Mapeo con GitHub Projects
+
+Cada change en OpenSpec corresponde a uno o más Issues en GitHub Projects v2 (`lcasadov/PadelPro`, Project #1):
+
+| Elemento OpenSpec | GitHub equivalente |
+|---|---|
+| Change `<slug>` | Issue con label `type:user-story` o `type:task` |
+| Tarea en `tasks.md` | Sub-issue o checkbox en el body del Issue padre |
+| Capability afectada | Label `area:<capability>` en el Issue |
+| Fase del change | Milestone `EP-NN <nombre>` del Issue |
+
+**Convención de nombre de rama:** `feature/<issue-number>-<slug>` (ej. `feature/42-auth-local`).
+**Referencia en commit:** `feat(auth-local): implementar login (#42)`.
+**Auto-cierre:** `Closes #42` en el cuerpo de la PR cierra el Issue al mergear.
+
+El agente `gh-projects-sync` es el responsable de mantener sincronizados los Issues de GitHub con el estado de los changes en OpenSpec.
+
+---
+
+## 6. Coherencia con docs/
+
+| Pregunta | Fuente autoritativa |
+|---|---|
+| ¿Qué endpoints existen y con qué paths? | `docs/openapi.yaml` |
+| ¿Qué rol puede hacer qué? | `docs/security-design.md §3` |
+| ¿Cómo se almacena el dato X? | `docs/data-model.md` |
+| ¿Qué algoritmo de firma usa el JWT? | `docs/security-design.md §2.2` (HS256, no RS256) |
+| ¿Cuánto dura el access token? | `docs/security-design.md §2.3` (15 min, no 8h como indica el README) |
+| ¿Cuál es el base path de la API? | `docs/openapi.yaml servers` (`/api`, no `/api/v1`) |
+| ¿Cuántas pistas tiene la instalación? | `README.md §3.2` + `openspec/project.md` (una sola pista en v1.0) |
+| ¿Qué datos personales son RGPD? | `docs/security-design.md §11.1` |
+
+> **Conflicto conocido documentado:** `README.md §3.7` indica 8h para el access token. `docs/security-design.md §2.3` lo corrige a 15 min. La fuente autoritativa es `security-design.md`.
+
+---
+
+## 7. Cuando detectes una inconsistencia
+
+Si al leer los documentos encuentras una contradicción entre dos fuentes:
+
+1. **Identifica la precedencia**: `docs/openapi.yaml` > `docs/security-design.md` > `docs/data-model.md` > `README.md` > cualquier otro documento.
+2. **No asumas**: no implementes la versión que te parece correcta sin documentar la inconsistencia.
+3. **Documenta el conflicto** en el artefacto más cercano al problema:
+   ```html
+   <!-- CONFLICTO: README.md §3.7 indica 8h para access token.
+        docs/security-design.md §2.3 indica 15 min.
+        Fuente autoritativa: security-design.md (15 min).
+        Notificado al orquestador: 2026-05-22. -->
+   ```
+4. **Notifica al orquestador** en tu mensaje de retorno con: ficheros en conflicto, valores contradictorios, fuente autoritativa elegida y razón.
+5. **Continúa con la fuente de mayor precedencia** si el orquestador no responde en el mismo turno y el conflicto no bloquea la tarea.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,113 @@
+schema: spec-driven
+
+project:
+  name: PadelPro
+  description: Sistema de gestión de reservas de pádel para instalaciones pequeñas (On-Premise, v1.0)
+  owner: lcasadov
+  language: es
+  version: "1.0"
+
+stack:
+  backend: "Spring Boot 3.2 (Java 21, arquitectura hexagonal Maven multi-módulo)"
+  frontend: "React 18 + Vite + TypeScript"
+  database: "PostgreSQL 15"
+  migrations: Flyway
+  orm: "Spring Data JPA + Hibernate"
+  infra_local: Docker Compose
+  ci: GitHub Actions
+  payment_gateway: "Redsys (HMAC SHA-256)"
+  bot: "Telegram Bot API"
+
+conventions:
+  api_base_path: /api  # verificado contra docs/openapi.yaml — usa /api, NO /api/v1
+  api_spec: docs/openapi.yaml
+  data_model: docs/data-model.md
+  security_design: docs/security-design.md
+  testing_strategy: docs/TESTING-STRATEGY.md
+  project_vars: docs/PROJECT.md
+  openspec_root: openspec/
+  language: es
+
+github:
+  org: lcasadov
+  repo: PadelPro
+  project_owner: lcasadov
+  project_manager: orquestadoria
+  project_number: 1
+  base_branch: develop
+  release_branch: main
+
+roles:
+  # v1.0 — exactamente 2 roles definidos en docs/security-design.md
+  - id: ADMIN
+    description: "Administrador del sistema; acceso total incluidos endpoints /admin/**"
+  - id: USER
+    description: "Jugador registrado; acceso a sus propios recursos (reservas, pagos, perfil)"
+  # Planificados para Fase 2+:
+  # - MANAGER_CLUB: responsable del club (subconjunto de capacidades de ADMIN)
+  # - INVITADO: lectura pública (consultar disponibilidad sin autenticación)
+
+phases:
+  - id: fase-1
+    name: "MVP — reservas, pagos Redsys y bot Telegram básico"
+    status: active
+    capabilities:
+      - auth-local
+      - auth-otp-telegram
+      - usuarios
+      - roles-permisos
+      - configuracion-club
+      - pistas
+      - reservas
+      - partidas
+      - pagos-redsys
+      - disponibilidad-pistas
+      - notificaciones
+      - auditoria
+      - exportaciones-rgpd
+  - id: fase-2
+    name: "Dashboard de gestión y partidas avanzadas"
+    status: planned
+    capabilities:
+      - administracion-club
+  - id: fase-3
+    name: "Multi-club y federaciones"
+    status: planned
+    capabilities: []
+
+business_rules:
+  source: docs/security-design.md
+  prefix: RN-
+  domains:
+    - RN-AUTH  # autenticación y autorización
+    - RN-RES   # reservas
+    - RN-PAY   # pagos
+    - RN-TEL   # Telegram
+    - RN-RGPD  # protección de datos
+    - RN-SEC   # seguridad transversal
+
+mapping_to_github:
+  capability_to_label: "area:<capability>"
+  user_story_format: "US-NNN · <descripción>"
+  ticket_format: "TICKET-NNN · <descripción>"
+  change_folder: "openspec/changes/<slug>/"
+
+# ─── Reglas por artefacto ─────────────────────────────────────────────────────
+rules:
+  proposal:
+    - Incluir siempre sección "Fuera de alcance"
+    - Referenciar capabilities afectadas con sus IDs exactos
+    - Indicar la fase del producto (fase-1, fase-2, fase-3)
+  design:
+    - Toda decisión de diseño debe referenciar la regla de negocio (RN-xx) que la motiva
+    - Los riesgos deben incluir su plan de mitigación
+    - Nunca incluir código de implementación — solo comportamiento y decisiones
+  tasks:
+    - Separar tareas por capa: Backend / Frontend / Testing / Infraestructura
+    - Cada tarea debe poder completarse en menos de 4 horas
+    - Las tareas de testing se escriben antes de las de implementación (TDD)
+  spec:
+    - Usar formato Given/When/Then estricto — sin prosa narrativa
+    - Referenciar RN-xx explícitamente en cada scenario donde aplique
+    - Las tablas de permisos usan solo los roles de v1.0: ADMIN y USER
+    - No incluir DDL, código Java ni detalles de implementación

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -1,0 +1,208 @@
+# PadelPro — Documento de Proyecto (OpenSpec)
+
+> Este documento es la referencia de dominio para todos los agentes que trabajan en PadelPro.
+> Se genera a partir de `README.md`, `docs/PROJECT.md`, `docs/data-model.md` y `docs/security-design.md`.
+> En caso de conflicto, las fuentes en `docs/` tienen precedencia sobre este fichero.
+
+---
+
+## 1. Qué es PadelPro
+
+**PadelPro** es una plataforma digital integral para la gestión de reservas de pistas de pádel en instalaciones pequeñas y medianas. Combina una aplicación web moderna con integración nativa en Telegram (v1.0), eliminando los problemas de gestión manual que se producen cuando las reservas se coordinan a través de grupos de mensajería sin ningún sistema centralizado.
+
+El sistema centraliza en un único punto la reserva de pistas, el control de disponibilidad en tiempo real, la gestión de participantes, el cobro de reservas mediante la pasarela Redsys, y el seguimiento de ingresos. Ofrece tanto una interfaz web como la posibilidad de operar directamente desde el grupo de Telegram ya existente en la comunidad de jugadores.
+
+PadelPro está diseñado para instalaciones de una sola pista (On-Premise, v1.0), sin multi-tenancy. La arquitectura hexagonal y el modelo de datos están preparados para escalar a múltiples pistas o instalaciones en fases posteriores, pero esta capacidad no forma parte del alcance actual.
+
+---
+
+## 2. Problema que resuelve
+
+Las instalaciones deportivas pequeñas (comunidades de vecinos, clubes de 1-4 pistas, grupos informales) coordinan sus reservas a través de grupos de WhatsApp o Telegram sin un sistema centralizado. Esto genera tres problemas críticos:
+
+1. **Solapamientos de reservas**: sin un calendario único y en tiempo real, dos usuarios pueden reservar la misma franja sin que el sistema lo detecte.
+2. **Falta de registro económico**: los pagos se realizan en efectivo sin trazabilidad digital, lo que impide al administrador conocer sus ingresos reales.
+3. **Dependencia de una persona gestora**: la sincronización entre canales (mensajería + app de pago externa) recae en una sola persona, creando un punto de fallo único.
+
+PadelPro resuelve los tres problemas con una única plataforma que actúa como fuente de verdad para reservas, pagos y comunicaciones.
+
+---
+
+## 3. Usuarios y roles
+
+### Roles en v1.0
+
+| Rol | Descripción | Acceso |
+|---|---|---|
+| `ADMIN` | Administrador del club. Gestiona usuarios, reservas, pagos y configuración del sistema. | Acceso total. Endpoints `/api/admin/**` exclusivos. |
+| `USER` | Jugador registrado. Gestiona sus propias reservas y pagos. | Acceso a sus propios recursos. |
+
+> **Roles planificados para Fase 2+** (no implementados en v1.0):
+> - `MANAGER_CLUB`: responsable del club con subconjunto de capacidades de ADMIN.
+> - `INVITADO`: acceso público de solo lectura para consultar disponibilidad sin autenticación.
+
+### Actor especial: Usuario Casual
+
+El jugador casual (sin cuenta en la plataforma) puede incorporarse a una reserva como participante respondiendo al mensaje del grupo de Telegram. **No tiene acceso a la API web** y no necesita rol en el sistema. Sus datos se almacenan como `external_name` y `external_phone` en la tabla `participants`.
+
+---
+
+## 4. Glosario del dominio
+
+| Término | Definición |
+|---|---|
+| **Pista** | Instalación física de pádel disponible para reservar. En v1.0, el sistema gestiona una única pista. |
+| **Reserva** | Asignación de una franja horaria de la pista a un titular. Tiene estado (`PENDING_CONFIRMATION`, `CONFIRMED`, `COMPLETED`, `CANCELLED`) y un pago asociado. |
+| **Franja horaria** | Periodo de tiempo con hora de inicio y duración (mínimo 60 min, máximo 180 min, en intervalos de 30 min). |
+| **Titular** | Usuario registrado (`USER` o `ADMIN`) que crea la reserva. Es el único responsable del pago. |
+| **Participante** | Persona asignada a una reserva como jugador. Puede ser un usuario registrado o un jugador casual externo. Máximo 4 por reserva. |
+| **Jugador casual** | Persona sin cuenta en la plataforma que participa en una reserva a través del grupo de Telegram. |
+| **Partida pública** | Reserva con huecos libres (menos de 4 participantes), visible para que otros usuarios puedan unirse. |
+| **Club** | La instalación deportiva que usa PadelPro. En v1.0 es una instalación única (single-tenant). |
+| **Política de cancelación** | Número mínimo de horas de antelación requeridas para cancelar una reserva sin coste. Configurable por el ADMIN en `system_config`. |
+| **Vinculación Telegram** | Proceso por el que un usuario asocia su cuenta de PadelPro con su chat personal de Telegram, habilitando la recepción de OTPs y notificaciones. |
+| **OTP** | Código de un solo uso (6 dígitos, TTL 10 min, máximo 3 intentos) enviado al Telegram personal del usuario para confirmar operaciones críticas. Se almacena como SHA-256. |
+| **Inscripción** | Acción de un usuario de unirse a una reserva con huecos disponibles. |
+| **Pago Redsys** | Transacción de pago online procesada mediante la pasarela bancaria Redsys (HMAC SHA-256). PadelPro nunca almacena datos de tarjeta. |
+| **Pago en efectivo** | Pago físico registrado por el ADMIN en el sistema, sin pasarela. |
+| **Disponibilidad** | Estado de las franjas horarias de una fecha concreta: libres u ocupadas. |
+| **Configuración del club** | Parámetros globales del sistema (precio por hora, horario de apertura/cierre, máximo de participantes, política de cancelación, divisa, zona horaria). Singleton en BD (`system_config`, id=1). |
+| **Anonimización RGPD** | Proceso de borrado lógico que sustituye los datos personales identificativos de un usuario por valores anónimos, preservando el historial de reservas y pagos por obligación fiscal. |
+| **Webhook Redsys** | Llamada HTTP POST que Redsys envía al backend para notificar el resultado de una transacción. Validado por HMAC SHA-256. |
+| **Webhook Telegram** | Llamada HTTP POST que Telegram envía al backend con cada mensaje del bot. Validado por el header `X-Telegram-Bot-Api-Secret-Token`. |
+
+---
+
+## 5. Capabilities
+
+| ID | Nombre | Fase | Descripción | Spec |
+|---|---|---|---|---|
+| `auth-local` | Autenticación local | Fase 1 | Registro, login, refresh token, logout y recuperación de contraseña con JWT HS256. | [spec](specs/auth-local/spec.md) |
+| `auth-otp-telegram` | Autenticación OTP Telegram | Fase 1 | Vinculación de cuenta con Telegram, generación y verificación de OTP para operaciones críticas. | [spec](specs/auth-otp-telegram/spec.md) |
+| `usuarios` | Gestión de usuarios | Fase 1 | Perfil propio, gestión administrativa por ADMIN, RGPD básico. | [spec](specs/usuarios/spec.md) |
+| `roles-permisos` | Roles y permisos | Fase 1 | Matriz RBAC (ADMIN/USER), protección de endpoints, asignación de roles. | [spec](specs/roles-permisos/spec.md) |
+| `configuracion-club` | Configuración del club | Fase 1 | Parámetros globales del sistema (singleton `system_config`). | [spec](specs/configuracion-club/spec.md) |
+| `pistas` | Gestión de pistas | Fase 1 | Consulta de disponibilidad horaria de la pista. | [spec](specs/pistas/spec.md) |
+| `reservas` | Gestión de reservas | Fase 1 | Ciclo de vida completo de una reserva: creación, consulta, cancelación, unión de participantes. | [spec](specs/reservas/spec.md) |
+| `partidas` | Partidas y participantes | Fase 1 | Gestión de participantes en una reserva, partidas públicas con huecos. | [spec](specs/partidas/spec.md) |
+| `pagos-redsys` | Pagos Redsys | Fase 1 | Inicio de pago online, webhook de confirmación, idempotencia y pago en efectivo. | [spec](specs/pagos-redsys/spec.md) |
+| `disponibilidad-pistas` | Disponibilidad de pistas | Fase 1 | Consulta de franjas libres/ocupadas para una fecha. | [spec](specs/disponibilidad-pistas/spec.md) |
+| `notificaciones` | Notificaciones | Fase 1 | Envío de mensajes por Telegram y email (confirmaciones, OTPs, avisos). | [spec](specs/notificaciones/spec.md) |
+| `auditoria` | Auditoría | Fase 1 | Registro inmutable de todas las acciones del sistema en `audit_log`. | [spec](specs/auditoria/spec.md) |
+| `exportaciones-rgpd` | Exportaciones RGPD | Fase 1 | Anonimización de usuarios, acceso a datos propios, derechos del titular. | [spec](specs/exportaciones-rgpd/spec.md) |
+| `administracion-club` | Administración de club | Fase 2 | Dashboard de gestión, métricas, informes. Sin superficie REST en v1.0. | — |
+
+---
+
+## 6. Fases del producto
+
+### Fase 1 — MVP (activa)
+
+**Objetivo:** Sistema operativo con reservas, pagos Redsys y bot Telegram básico.
+
+Capabilities incluidas: `auth-local`, `auth-otp-telegram`, `usuarios`, `roles-permisos`, `configuracion-club`, `pistas`, `reservas`, `partidas`, `pagos-redsys`, `disponibilidad-pistas`, `notificaciones`, `auditoria`, `exportaciones-rgpd`.
+
+Canal de mensajería: **Telegram Bot API** (WhatsApp Business API diferida a Fase 2).
+Instalación: **una sola pista** (sin multi-tenancy).
+Despliegue: **On-Premise** con Docker Compose.
+
+### Fase 2 — Dashboard y partidas avanzadas (planificada)
+
+**Objetivo:** Dashboard de gestión para MANAGER_CLUB, partidas avanzadas, integración WhatsApp Business API.
+
+Capabilities nuevas: `administracion-club`.
+Roles nuevos: `MANAGER_CLUB`.
+
+### Fase 3 — Multi-club y federaciones (planificada)
+
+**Objetivo:** Soporte multi-tenancy, federaciones de clubes.
+
+---
+
+## 7. Flujos críticos
+
+Los siguientes flujos tienen cobertura de tests obligatoria del 100% (unit + integration):
+
+### FC-01: Reserva y pago online
+
+```
+Usuario autenticado
+  → Consulta disponibilidad (GET /api/reservas/disponibles?fecha=X)
+  → Crea reserva (POST /api/reservas) → 201 + estado PENDING_CONFIRMATION
+  → Inicia pago (POST /api/pagos/iniciar) → URL TPV Redsys
+  → Usuario completa pago en Redsys
+  → Redsys envía webhook (POST /api/pagos/webhook) → validación HMAC → 200
+  → Reserva pasa a CONFIRMED + pago a PAID
+  → Notificación Telegram al titular
+```
+
+### FC-02: Vinculación de cuenta con Telegram y OTP
+
+```
+Usuario autenticado (web)
+  → Solicita vinculación (PATCH /api/usuarios/me con telegramLink)
+  → Backend genera OTP tipo TELEGRAM_LINK → envía al chat personal del bot
+  → Usuario envía /vincular XXXXXX al bot @PadelProBot
+  → Webhook Telegram validado por X-Telegram-Bot-Api-Secret-Token
+  → Backend valida OTP → UPDATE users SET telegram_chat_id
+  → Usuario puede recibir OTPs y notificaciones por Telegram
+```
+
+### FC-03: Eliminación RGPD (anonimización)
+
+```
+ADMIN
+  → DELETE /api/admin/usuarios/{id}
+  → Anonimización: first_name, last_name, phone, email, telegram_chat_id sustituidos
+  → Reservas y pagos preservados (obligación fiscal 5 años)
+  → Entrada en audit_log con acción USER_ANONYMIZED
+  → No se permite hard delete
+```
+
+### FC-04: Cancelación de reserva dentro del plazo
+
+```
+Titular autenticado
+  → DELETE /api/reservas/{id}
+  → Sistema verifica: owner_id == authenticatedUserId
+  → Sistema verifica: ahora + cancellation_deadline_hours <= start_time
+  → Reserva pasa a CANCELLED + pago a CANCELLED
+  → Notificación al grupo Telegram
+  → Entrada en audit_log con acción RESERVATION_CANCELLED
+```
+
+---
+
+## 8. Reglas de negocio
+
+Las reglas marcadas con (*) deben añadirse a `docs/security-design.md`.
+
+| Código | Dominio | Descripción |
+|---|---|---|
+| RN-AUTH-01 | Autorización | Un USER solo puede ver una reserva si es `owner_id` o aparece en `participants`. |
+| RN-AUTH-02 | Autorización | Un USER solo puede cancelar su propia reserva (`owner_id = authenticatedUserId`). |
+| RN-AUTH-03 | Autorización | Un USER no puede unirse dos veces a la misma reserva. |
+| RN-AUTH-04 | Autorización | Un USER solo puede iniciar pago de una reserva de la que es `owner_id`. |
+| RN-AUTH-05 | Autorización | Un ADMIN no puede desactivarse a sí mismo. |
+| RN-AUTH-06 (*) | Autenticación | Bloqueo tras 10 fallos en 10 min → 15 min de bloqueo. Se aplica por IP y por usuario de forma independiente. |
+| RN-AUTH-07 (*) | OTP | OTP de 6 dígitos, TTL 10 min, máximo 3 intentos, almacenado como SHA-256, de un solo uso. |
+| RN-AUTH-08 (*) | Contraseñas | Contraseña: mínimo 8 caracteres + 1 mayúscula + 1 número, máximo 128 caracteres, BCrypt cost 12. |
+| RN-AUTH-09 (*) | Tokens | Access token 15 min en memoria JavaScript; refresh token 7 días en cookie httpOnly. |
+| RN-RES-01 (*) | Reservas | No se permite solapamiento de franjas para la misma pista. Implementado con `SELECT FOR UPDATE`. |
+| RN-RES-02 (*) | Reservas | El máximo de participantes por reserva lo determina `system_config.max_participants` (por defecto 4). |
+| RN-RES-03 (*) | Reservas | El precio se calcula solo en backend; el importe enviado por el cliente es ignorado. |
+| RN-RES-04 (*) | Reservas | La ventana de reserva anticipada y la política de cancelación provienen de `system_config`. |
+| RN-RES-05 (*) | Reservas | Idempotencia: POST con misma `Idempotency-Key` devuelve la reserva existente sin crear duplicado. |
+| RN-PAY-01 (*) | Pagos | El webhook de Redsys debe validarse con HMAC SHA-256 antes de procesar cualquier campo. |
+| RN-PAY-02 (*) | Pagos | Idempotencia de pagos: `redsys_order_id` UNIQUE; webhook duplicado con `status=PAID` se ignora. |
+| RN-PAY-03 (*) | Pagos | Datos de tarjeta (PAN, CVV, fecha de caducidad) nunca se almacenan ni se registran en logs. |
+| RN-PAY-04 (*) | Pagos | Las transiciones de estado del pago son unidireccionales: `PENDING→IN_PROGRESS→PAID`. Sin reversión. |
+| RN-TEL-01 (*) | Telegram | El webhook de Telegram valida `X-Telegram-Bot-Api-Secret-Token` antes de procesar cualquier update. |
+| RN-TEL-02 (*) | Telegram | La vinculación de cuenta requiere OTP confirmado vía Telegram (TTL 10 min). |
+| RN-TEL-03 (*) | Telegram | Solo las cuentas con `telegram_chat_id NOT NULL` reciben notificaciones por Telegram. |
+| RN-RGPD-01 (*) | RGPD | La eliminación de usuario es anonimización (no hard delete); genera entrada en `audit_log`. |
+| RN-RGPD-02 (*) | RGPD | Datos financieros: retención mínima 5 años. Logs de auditoría: retención mínima 2 años. |
+| RN-RGPD-03 (*) | RGPD | Las respuestas de error no exponen datos personales de otros usuarios. |
+| RN-RGPD-04 (*) | RGPD | Los logs no contienen contraseñas, tokens JWT, códigos OTP ni datos de tarjeta. |
+| RN-SEC-01 (*) | Seguridad | Rate limiting: login 5/min/IP, registro 3/min/IP, solicitud de reset 3/min/IP. |
+| RN-SEC-02 (*) | Seguridad | Los secretos del sistema (`redsys_secret_key`, `telegram_bot_token`, `smtp_password`) se cifran con AES-256-GCM en BD. |

--- a/openspec/specs/administracion-club/spec.md
+++ b/openspec/specs/administracion-club/spec.md
@@ -1,0 +1,98 @@
+# Capability: `administracion-club`
+
+## Resumen
+Panel de administración del club con métricas de ocupación de pistas, ingresos por período
+y exportación de informes de uso. Proporciona al ADMIN una visión agregada del rendimiento
+del club para la toma de decisiones operativas. En v1.0, las métricas se obtienen desde el
+frontend aggregando datos de las capabilities `reservas` y `pagos-redsys` a través de los
+endpoints existentes. En Fase 2 se expondrán como endpoints REST dedicados bajo
+`/api/admin/dashboard/*`.
+
+## Fase
+🔵 Fase 2
+
+> **Nota de implementación v1.0:** En v1.0, esta capability no tiene backend REST propio.
+> El frontend construye las métricas de ocupación e ingresos consultando:
+> - `GET /api/admin/reservas?fecha=...&status=...` (paginado) para calcular ocupación.
+> - `GET /api/admin/pagos?status=PAID` (paginado) para calcular ingresos.
+> Esta aproximación tiene limitaciones de rendimiento para períodos largos. En Fase 2 se
+> expondrán como endpoints REST `/api/admin/dashboard/*` con agregaciones precalculadas en
+> backend.
+
+## Reglas de negocio implicadas
+- **RN-ADM-01**: Solo el rol ADMIN puede acceder a las métricas del dashboard; un USER nunca debe ver datos agregados de todos los usuarios.
+- **RN-ADM-02**: El porcentaje de ocupación se calcula como `(slots reservados con status != CANCELLED) / (total slots disponibles en el período)` × 100; los slots disponibles se derivan del horario de apertura configurado en `system_config`.
+- **RN-ADM-03**: Los ingresos del período se calculan como la suma de `payments.amount` donde `payments.status = 'PAID'` y `payments.paid_at` está dentro del rango de fechas solicitado.
+- **RN-ADM-04**: La exportación CSV de informes de uso debe respetar las mismas restricciones de acceso que la visualización en pantalla (solo ADMIN).
+- **RN-RGPD-04**: Los informes exportados no deben incluir datos de identificación personal directa en campos de resumen (nombres completos en exportaciones de uso agregado); solo IDs anonimizables o datos agregados.
+
+## Entidades implicadas
+- **`reservations`**: fuente de datos de ocupación. Campos relevantes: `reservation_date`, `start_time`, `end_time`, `duration_minutes`, `status`, `owner_id`, `channel`.
+- **`payments`**: fuente de datos de ingresos. Campos relevantes: `amount`, `status`, `paid_at`, `method`, `gateway`.
+- **`users`**: metadatos de jugadores frecuentes (Fase 2). Solo `id` y `login` para identificación sin exposición de datos personales en informes.
+- **`system_config`**: `price_per_hour` y `cancellation_deadline_hours` como parámetros de referencia para calcular ingresos esperados vs. reales.
+
+## Endpoints
+En v1.0: Sin endpoint REST directo para dashboard — aggregación en frontend sobre endpoints existentes.
+
+En Fase 2 (target behavior):
+- `GET /api/admin/dashboard/ocupacion` — métricas de ocupación por período (% slots utilizados vs disponibles).
+- `GET /api/admin/dashboard/ingresos` — suma de pagos PAID por período con desglose por método (REDSYS / CASH).
+- `GET /api/admin/dashboard/exportar` — exportación CSV del informe de uso.
+
+## Permisos
+| Operación | ADMIN | USER | No autenticado |
+|---|---|---|---|
+| Consultar métricas de ocupación | ✅ | ❌ | ❌ |
+| Consultar métricas de ingresos | ✅ | ❌ | ❌ |
+| Exportar informe CSV | ✅ | ❌ | ❌ |
+| Ver jugadores frecuentes | ✅ | ❌ | ❌ |
+
+## Requirements
+
+### Requirement 1: Consulta de ocupación de pistas por período
+**El sistema DEBE permitir al ADMIN consultar el porcentaje de ocupación de pistas para un rango de fechas, calculado como la proporción de slots de tiempo utilizados (reservas no canceladas) sobre el total de slots disponibles en el período.**
+
+#### Scenario 1: ADMIN consulta ocupación de la semana actual
+- **GIVEN** un ADMIN autenticado Y existen reservas con distintos estados en la semana en curso
+- **WHEN** el ADMIN invoca `GET /api/admin/dashboard/ocupacion?fechaInicio=2025-06-16&fechaFin=2025-06-22` (Fase 2)
+- **THEN** la respuesta incluye: `totalSlotsDisponibles` (todos los tramos horarios posibles del período según horario de apertura), `slotsOcupados` (reservas con `status != 'CANCELLED'`), `porcentajeOcupacion` (ratio como número entre 0 y 100 con 2 decimales), Y el cálculo excluye reservas en estado `CANCELLED`
+
+#### Scenario 2: USER intenta acceder a métricas de ocupación — 403
+- **GIVEN** un usuario con rol USER autenticado
+- **WHEN** intenta invocar `GET /api/admin/dashboard/ocupacion` (Fase 2)
+- **THEN** el sistema devuelve 403 Forbidden, Y no se expone ningún dato de reservas en la respuesta de error
+
+### Requirement 2: Consulta de ingresos por período
+**El sistema DEBE permitir al ADMIN consultar el total de ingresos para un rango de fechas, con desglose por método de pago (REDSYS, CASH), basándose en pagos con `status=PAID` cuyo `paid_at` cae dentro del rango.**
+
+#### Scenario 3: ADMIN consulta ingresos del mes anterior
+- **GIVEN** un ADMIN autenticado Y existen pagos en estado `PAID` en el mes anterior
+- **WHEN** el ADMIN invoca `GET /api/admin/dashboard/ingresos?fechaInicio=2025-05-01&fechaFin=2025-05-31` (Fase 2)
+- **THEN** la respuesta incluye: `totalIngresos` (suma de `payments.amount` con `status=PAID` en el período), `ingresosPorMetodo` (desglose por REDSYS y CASH), `numeroPagos` (conteo de pagos PAID), Y la moneda es siempre EUR (NUMERIC(12,2))
+
+#### Scenario 4: Período sin pagos — respuesta con totales en cero
+- **GIVEN** un ADMIN autenticado Y no existen pagos en estado `PAID` en el rango de fechas consultado
+- **WHEN** el ADMIN invoca `GET /api/admin/dashboard/ingresos?fechaInicio=2025-01-01&fechaFin=2025-01-31` (Fase 2)
+- **THEN** la respuesta devuelve `totalIngresos=0.00`, `numeroPagos=0`, `ingresosPorMetodo={"REDSYS":0.00,"CASH":0.00}`, Y el código HTTP es 200 (no 404)
+
+### Requirement 3: Exportación de informe de uso en CSV
+**El sistema DEBE permitir al ADMIN exportar un informe de uso en formato CSV con los datos de reservas del período seleccionado, sin incluir datos de identificación personal directa (nombres completos) en las columnas de resumen.**
+
+#### Scenario 5: ADMIN exporta informe CSV del mes — descarga generada
+- **GIVEN** un ADMIN autenticado Y existen reservas en el período seleccionado
+- **WHEN** el ADMIN invoca `GET /api/admin/dashboard/exportar?fechaInicio=2025-05-01&fechaFin=2025-05-31&formato=CSV` (Fase 2)
+- **THEN** la respuesta tiene `Content-Type: text/csv`, `Content-Disposition: attachment; filename="informe-uso-2025-05.csv"`, Y el CSV incluye columnas: `fecha`, `horaInicio`, `duracionMinutos`, `estadoReserva`, `metodoPago`, `importePagado`, `numeroParticipantes`, `canal` (WEB/TELEGRAM), Y el CSV NO incluye `first_name`, `last_name`, `email`, `phone` de los titulares (RN-RGPD-04 y RN-ADM-04)
+
+## Casos límite
+- El rango de fechas máximo consultable en un solo request es de 12 meses para evitar timeouts de consulta sin paginación; rangos mayores deben dividirse en múltiples peticiones.
+- En v1.0, si el frontend realiza múltiples consultas paginadas a `GET /api/admin/reservas` para construir las métricas, el total de páginas puede ser elevado para períodos largos; el ADMIN debe ser informado de la limitación.
+- Los slots de "horario de apertura" para el cálculo de ocupación deben basarse en un horario configurado (pendiente de resolución de decisión abierta P4 en `docs/data-model.md`); hasta que se resuelva, el denominador del porcentaje se calcula considerando 24h disponibles.
+- Las métricas de Fase 2 deben estar protegidas por el mismo rate limiting aplicado al resto de endpoints admin.
+- La exportación CSV de períodos de más de 6 meses se genera de forma asíncrona (respuesta 202 + URL de descarga) para evitar bloquear el hilo HTTP; en períodos menores, respuesta síncrona 200.
+
+## Dependencias con otras capabilities
+- **`reservas`**: fuente principal de datos de ocupación. En v1.0, el frontend usa `GET /api/admin/reservas` con filtros de fecha y estado.
+- **`pagos-redsys`**: fuente de datos de ingresos. En v1.0, el frontend usa `GET /api/admin/pagos?status=PAID` con filtros de fecha.
+- **`auditoria`**: las consultas de dashboard por ADMIN generan entradas `ADMIN_USER_DATA_ACCESS` en `audit_log` para trazabilidad de acceso a datos agregados.
+- **`exportaciones-rgpd`**: los informes CSV deben respetar las restricciones RGPD sobre exposición de datos personales (RN-RGPD-04); la capability de exportaciones-rgpd define qué campos están sujetos a protección.

--- a/openspec/specs/auditoria/spec.md
+++ b/openspec/specs/auditoria/spec.md
@@ -1,0 +1,125 @@
+# Capability: `auditoria`
+
+## Resumen
+Registro inmutable de todos los eventos sensibles del sistema para garantizar trazabilidad
+de seguridad, cumplimiento RGPD y soporte a la respuesta a incidentes. Las entradas en
+`audit_log` son generadas automáticamente por las capabilities de aplicación; el ADMIN puede
+leerlas a través de `GET /api/admin/audit` (Fase 2). En v1.0 el acceso es solo a través de
+consulta directa a BD por el administrador del servidor.
+
+## Fase
+🟢 Fase 1
+
+## Reglas de negocio implicadas
+- **RN-RGPD-02**: Los registros de `audit_log` deben conservarse un mínimo de 2 años; nunca se borran filas individualmente.
+- **RN-RGPD-04**: Los campos `details` y demás columnas de `audit_log` nunca contienen contraseñas, tokens JWT, códigos OTP en claro ni datos de tarjeta.
+- **RN-AUD-01**: Toda acción sensible (autenticación, gestión de usuarios, reservas, pagos, configuración, webhooks) genera una entrada en `audit_log` de forma síncrona dentro de la misma transacción de negocio cuando sea posible, o inmediatamente después si la acción es asíncrona (webhook).
+- **RN-AUD-02**: Las entradas de `audit_log` son inmutables: no existe ningún endpoint ni proceso que permita modificarlas o eliminarlas.
+- **RN-AUD-03**: El campo `user_id` puede ser NULL para acciones del sistema (webhooks Redsys, job de recordatorios) o cuando el usuario ha sido anonimizado (la FK es SET NULL).
+- **RN-SEC-01**: Los fallos de autenticación (login fallido, OTP fallido, webhook con firma inválida) se registran con prioridad ALTA en `audit_log`.
+
+## Entidades implicadas
+- **`audit_log`**: tabla inmutable con una fila por evento auditado.
+  - `id` (BIGSERIAL PK), `user_id` (FK nullable → `users` SET NULL), `action` (VARCHAR 100), `entity_type` (VARCHAR 50), `entity_id` (VARCHAR 36, UUID o BIGINT como texto), `details` (TEXT JSON sin datos sensibles), `ip_address` (VARCHAR 45), `channel` (WEB / TELEGRAM / SYSTEM), `created_at` (TIMESTAMPTZ inmutable).
+- **`users`**: origen del `user_id` referenciado; en anonimización SET NULL preserva la traza histórica.
+
+## Endpoints
+Sin endpoint REST directo en v1.0 — las entradas se generan internamente.
+
+> En v1.0 no existe endpoint `GET /api/admin/audit`. El ADMIN accede al log directamente
+> en la base de datos PostgreSQL. En Fase 2 se expondrá como `GET /api/admin/audit` con
+> filtros por `action`, `user_id`, `entity_type` y rango de fechas, con paginación obligatoria.
+
+## Permisos
+| Operación | ADMIN | USER | No autenticado |
+|---|---|---|---|
+| Generar entrada (interno) | N/A — sistema | N/A — sistema | N/A — sistema |
+| Leer `audit_log` propio (Fase 2) | ✅ | ❌ | ❌ |
+| Leer `audit_log` de cualquier usuario (Fase 2) | ✅ | ❌ | ❌ |
+| Modificar o eliminar entradas | ❌ | ❌ | ❌ |
+
+## Requirements
+
+### Requirement 1: Registro automático de eventos sensibles de autenticación
+**El sistema DEBE registrar en `audit_log` todos los eventos de autenticación: login exitoso, login fallido y bloqueo de cuenta, con timestamp, IP de origen, login del usuario y canal.**
+
+#### Scenario 1: Login fallido genera entrada `USER_LOGIN_FAILED`
+- **GIVEN** un usuario registrado con `status=ACTIVE`
+- **WHEN** se realiza `POST /api/auth/login` con credenciales incorrectas
+- **THEN** se inserta una fila en `audit_log` con `action='USER_LOGIN_FAILED'`, `entity_type='USER'`, `entity_id` = id del usuario (si el login existe) o NULL, `ip_address` = IP del cliente, `channel='WEB'`, `created_at` = instante actual, Y `details` no contiene la contraseña introducida
+
+#### Scenario 2: Décimo fallo consecutivo de login genera `USER_ACCOUNT_LOCKED`
+- **GIVEN** un usuario con 9 intentos fallidos previos dentro de la ventana de 10 minutos
+- **WHEN** se realiza el décimo intento fallido de login
+- **THEN** se insertan dos filas en `audit_log`: una con `action='USER_LOGIN_FAILED'` y otra con `action='USER_ACCOUNT_LOCKED'`, Y el `details` de `USER_ACCOUNT_LOCKED` incluye la duración del bloqueo (15 min) sin datos sensibles
+
+#### Scenario 3: Login exitoso genera `USER_LOGIN_SUCCESS`
+- **GIVEN** un usuario con `status=ACTIVE` y credenciales correctas
+- **WHEN** se realiza `POST /api/auth/login` con éxito
+- **THEN** se inserta una fila en `audit_log` con `action='USER_LOGIN_SUCCESS'`, `user_id` = id del usuario, `ip_address` = IP del cliente, Y el `details` no contiene el access token ni el refresh token generados
+
+### Requirement 2: Registro de eventos de reservas y pagos
+**El sistema DEBE registrar en `audit_log` la creación, cancelación y cambio de estado de reservas, así como la confirmación e invalidación de pagos.**
+
+#### Scenario 4: Creación de reserva genera `RESERVATION_CREATED`
+- **GIVEN** un usuario autenticado con `status=ACTIVE`
+- **WHEN** `POST /api/reservas` crea una reserva correctamente
+- **THEN** se inserta una fila en `audit_log` con `action='RESERVATION_CREATED'`, `entity_type='RESERVATION'`, `entity_id` = UUID de la reserva, `user_id` = id del titular, `channel` según el canal de creación (WEB o TELEGRAM)
+
+#### Scenario 5: Webhook Redsys con firma inválida genera `PAYMENT_WEBHOOK_INVALID_SIGNATURE`
+- **GIVEN** el backend recibe `POST /api/pagos/webhook` con un `Ds_Signature` que no supera la validación HMAC SHA-256
+- **WHEN** `PagoWebhookAdapter` rechaza el webhook
+- **THEN** se inserta una fila en `audit_log` con `action='PAYMENT_WEBHOOK_INVALID_SIGNATURE'`, `entity_type='PAYMENT'`, `channel='SYSTEM'`, `ip_address` = IP del remitente, Y `details` incluye el `Ds_MerchantParameters` truncado sin la firma completa ni datos de tarjeta
+
+### Requirement 3: Registro de eventos de seguridad en webhooks
+**El sistema DEBE registrar en `audit_log` cualquier intento de llamada al webhook de Telegram con un `X-Telegram-Bot-Api-Secret-Token` inválido.**
+
+#### Scenario 6: Webhook Telegram con secret inválido genera `TELEGRAM_WEBHOOK_INVALID_SECRET`
+- **GIVEN** el backend recibe `POST /api/bot/telegram` con un header `X-Telegram-Bot-Api-Secret-Token` que no coincide con el secret configurado
+- **WHEN** `BotTelegramAdapter` rechaza el request con 403
+- **THEN** se inserta una fila en `audit_log` con `action='TELEGRAM_WEBHOOK_INVALID_SECRET'`, `channel='SYSTEM'`, `ip_address` = IP del remitente, Y el secret inválido nunca aparece en `details` ni en ningún campo de la fila
+
+### Requirement 4: Los logs de auditoría no contienen datos sensibles
+**El sistema DEBE garantizar que ningún campo de `audit_log` contiene contraseñas, tokens JWT, códigos OTP en claro, claves de API ni datos de tarjeta.**
+
+#### Scenario 7: Cambio de contraseña — `audit_log` no contiene la nueva contraseña
+- **GIVEN** un usuario que realiza `PATCH /api/usuarios/me` con un nuevo valor de `password`
+- **WHEN** `UsuarioApplicationService` procesa el cambio
+- **THEN** se inserta una fila en `audit_log` con `action='PASSWORD_CHANGED'`, Y el campo `details` contiene únicamente metadatos (ej. `{"updatedFields":["password"]}`) sin el hash BCrypt ni la contraseña en claro
+
+#### Scenario 8: ADMIN no puede leer `audit_log` de otro usuario vía endpoint USER
+- **GIVEN** dos usuarios A y B con rol USER, ambos autenticados
+- **WHEN** el usuario A intenta acceder a los registros de auditoría de B (en Fase 2 con endpoint hipotético `GET /api/audit?userId={B}`)
+- **THEN** el sistema devuelve 403 Forbidden, Y no se devuelve ningún dato de `audit_log` de B al usuario A
+
+### Requirement 5: Anonimización de usuario genera entrada de auditoría
+**El sistema DEBE registrar en `audit_log` la anonimización de un usuario (RGPD Art. 17) con `action='USER_ANONYMIZED'` sin incluir los datos previos del usuario en `details`.**
+
+#### Scenario 9: Anonimización genera `USER_ANONYMIZED`
+- **GIVEN** un ADMIN que ejecuta `DELETE /api/admin/usuarios/{id}` para anonimizar una cuenta
+- **WHEN** `UsuarioApplicationService` completa el proceso de anonimización
+- **THEN** se inserta una fila en `audit_log` con `action='USER_ANONYMIZED'`, `entity_type='USER'`, `entity_id` = id del usuario anonimizado, `user_id` = id del ADMIN que ejecutó la acción, Y `details` no contiene el nombre, email, teléfono ni `telegram_chat_id` anteriores del usuario
+
+### Requirement 6: Retención mínima de 2 años y consulta por ADMIN
+**El sistema DEBE preservar todas las entradas de `audit_log` durante un mínimo de 2 años (RN-RGPD-02). Ningún proceso automático debe eliminar filas antes de ese plazo.**
+
+#### Scenario 10: Job de purga no elimina registros con menos de 2 años
+- **GIVEN** el job nocturno de mantenimiento de `audit_log` se ejecuta
+- **WHEN** el job evalúa las filas a eliminar
+- **THEN** solo se eliminan (o archivan) filas con `created_at < NOW() - INTERVAL '2 years'`, Y el número de filas eliminadas queda registrado en el log de aplicación a nivel INFO sin incluir el contenido de las filas
+
+## Casos límite
+- Si la transacción de negocio principal hace rollback (ej. reserva no creada por solapamiento), la entrada de `audit_log` asociada también se revierte (están en la misma transacción); el sistema no genera entradas de auditoría huérfanas de operaciones fallidas.
+- En webhooks (Redsys, Telegram), el registro en `audit_log` es siempre la primera operación y no depende del éxito del procesamiento posterior.
+- Si `user_id` está referenciado y el usuario es anonimizado posteriormente, la FK pasa a NULL (SET NULL); la entrada preexistente en `audit_log` conserva todos los demás campos para mantener la trazabilidad histórica.
+- El campo `ip_address` puede ser NULL si la acción proviene de un job del sistema (`channel='SYSTEM'`).
+- `audit_log` no tiene `UPDATE` ni `DELETE` permitidos a nivel de aplicación; solo `INSERT` y `SELECT`.
+- La tabla de `audit_log` debe disponer de particionamiento por año (recomendado) cuando supere 500.000 filas, para mantener el rendimiento de las consultas de ADMIN sin degradar los `INSERT` de producción.
+
+## Dependencias con otras capabilities
+- **`autenticacion`**: genera eventos USER_LOGIN_SUCCESS, USER_LOGIN_FAILED, USER_ACCOUNT_LOCKED, OTP_GENERATED, OTP_VALIDATED, OTP_FAILED, PASSWORD_CHANGED, PASSWORD_RESET, USER_REGISTERED, USER_APPROVED, TELEGRAM_LINKED, TELEGRAM_UNLINKED.
+- **`reservas`**: genera eventos RESERVATION_CREATED, RESERVATION_CANCELLED, RESERVATION_JOINED, RESERVATION_STATUS_CHANGED.
+- **`pagos-redsys`**: genera eventos PAYMENT_INITIATED, PAYMENT_CONFIRMED, PAYMENT_REJECTED, PAYMENT_CASH_REGISTERED, PAYMENT_WEBHOOK_INVALID_SIGNATURE.
+- **`exportaciones-rgpd`**: genera eventos USER_ANONYMIZED.
+- **`notificaciones`**: el fallo de webhook Telegram (secret inválido) genera TELEGRAM_WEBHOOK_INVALID_SECRET a través del adaptador de entrada del bot.
+- **`administracion-club`** (Fase 2): leerá `audit_log` para mostrar historial de actividad administrativa.

--- a/openspec/specs/auth-local/spec.md
+++ b/openspec/specs/auth-local/spec.md
@@ -1,0 +1,206 @@
+# Capability: auth-local
+
+## Resumen
+
+Gestiona el ciclo de autenticación local de PadelPro: registro de nuevos usuarios, inicio de sesión con login y contraseña, renovación del access token, cierre de sesión y recuperación de contraseña mediante OTP enviado por Telegram. Implementa el modelo de doble token (access + refresh) con JWT HS256.
+
+## Fase
+
+Fase 1
+
+## Reglas de negocio implicadas
+
+- **RN-AUTH-06**: Bloqueo de cuenta tras 10 fallos de login en 10 minutos (15 min de bloqueo), aplicado de forma independiente por IP y por usuario.
+- **RN-AUTH-07**: OTP de 6 dígitos, TTL 10 min, máximo 3 intentos, almacenado como SHA-256, de un solo uso.
+- **RN-AUTH-08**: Contraseña: mínimo 8 caracteres + 1 mayúscula + 1 número; máximo 128 caracteres; hash BCrypt cost 12.
+- **RN-AUTH-09**: Access token 15 min almacenado en memoria JavaScript; refresh token 7 días en cookie httpOnly.
+- **RN-RGPD-04**: Los logs no contienen contraseñas, tokens JWT, códigos OTP ni datos de tarjeta.
+- **RN-SEC-01**: Rate limiting: login 5/min/IP, registro 3/min/IP, solicitud de reset 3/min/IP.
+
+## Entidades implicadas
+
+**users** (tabla `users`):
+- `id`, `login`, `password_hash`, `first_name`, `last_name`, `phone`, `email`, `status` (`PENDING|ACTIVE|INACTIVE`), `role` (`ADMIN|USER`), `telegram_chat_id`, `registered_at`, `updated_at`
+
+**refresh_tokens** (tabla `refresh_tokens`):
+- `id`, `user_id`, `token_hash` (SHA-256 del token), `expires_at`, `revoked`, `ip_address`, `created_at`
+
+**otp_codes** (tabla `otp_codes`):
+- `id`, `user_id`, `code` (SHA-256), `type` (`PASSWORD_RESET`), `expires_at`, `used`, `created_at`
+
+## Endpoints
+
+Todos los endpoints de esta capability tienen `security: []` (no requieren JWT salvo `/auth/logout`).
+
+| Método | Path | OperationId | Autenticación |
+|---|---|---|---|
+| `POST` | `/api/auth/login` | `login` | Pública |
+| `POST` | `/api/auth/register` | `register` | Pública |
+| `POST` | `/api/auth/refresh` | `refreshToken` | Pública (cookie httpOnly) |
+| `POST` | `/api/auth/logout` | `logout` | JWT requerido |
+| `POST` | `/api/auth/password/solicitar-reset` | `solicitarResetPassword` | Pública |
+| `POST` | `/api/auth/password/confirmar-reset` | `confirmarResetPassword` | Pública |
+
+## Permisos
+
+| Operación | ADMIN | USER | No autenticado |
+|---|---|---|---|
+| `POST /api/auth/login` | Permitido | Permitido | Permitido |
+| `POST /api/auth/register` | No aplica | No aplica | Permitido |
+| `POST /api/auth/refresh` | Permitido | Permitido | Permitido (con cookie) |
+| `POST /api/auth/logout` | Permitido | Permitido | Denegado (401) |
+| `POST /api/auth/password/solicitar-reset` | Permitido | Permitido | Permitido |
+| `POST /api/auth/password/confirmar-reset` | Permitido | Permitido | Permitido |
+
+## Requirements
+
+### Requirement 1: Login con doble token
+
+**El sistema DEBE autenticar al usuario con login y contraseña, devolver un access token JWT HS256 con TTL de 15 minutos y establecer un refresh token en cookie httpOnly con TTL de 7 días.**
+
+#### Scenario: Login exitoso con credenciales válidas
+
+- **GIVEN** un usuario existe en el sistema con `status=ACTIVE` y `role=USER`
+- **AND** el usuario no está bloqueado por intentos fallidos
+- **WHEN** se envía `POST /api/auth/login` con `login` y `password` correctos
+- **THEN** el sistema responde con código `200`
+- **AND** el cuerpo contiene un `accessToken` JWT HS256 válido con `exp` a 15 minutos vista
+- **AND** la respuesta incluye `Set-Cookie: refresh_token=...; HttpOnly; Secure; SameSite=Strict; Path=/api/auth/refresh; Max-Age=604800`
+- **AND** el token contiene los claims `sub`, `login`, `role`, `iat`, `exp`, `jti`
+
+#### Scenario: Login fallido con contraseña incorrecta (timing-safe)
+
+- **GIVEN** un usuario existe en el sistema con `status=ACTIVE`
+- **WHEN** se envía `POST /api/auth/login` con `login` correcto y `password` incorrecto
+- **THEN** el sistema responde con código `401`
+- **AND** el cuerpo sigue el esquema `ErrorResponse` sin revelar si el login existe
+- **AND** el sistema registra el intento fallido en el contador de bloqueo (IP + usuario)
+- **AND** el tiempo de respuesta es similar al de un login exitoso (resistencia a timing attacks)
+
+#### Scenario: Login bloqueado por exceso de intentos fallidos (RN-AUTH-06)
+
+- **GIVEN** un usuario ha fallado 10 intentos de login en los últimos 10 minutos
+- **WHEN** se envía `POST /api/auth/login` con cualquier contraseña
+- **THEN** el sistema responde con código `429`
+- **AND** el cuerpo indica que la cuenta está bloqueada temporalmente
+- **AND** la respuesta incluye el tiempo restante de bloqueo (15 minutos)
+
+#### Scenario: Login denegado para cuenta PENDING
+
+- **GIVEN** un usuario existe con `status=PENDING` (auto-registro no aprobado)
+- **WHEN** se envía `POST /api/auth/login` con credenciales correctas
+- **THEN** el sistema responde con código `403`
+- **AND** el mensaje indica que la cuenta está pendiente de aprobación
+
+---
+
+### Requirement 2: Registro de nuevo usuario
+
+**El sistema DEBE permitir el auto-registro de nuevos usuarios. La cuenta se crea en estado PENDING hasta que un administrador la apruebe.**
+
+#### Scenario: Registro exitoso con datos válidos
+
+- **GIVEN** no existe ningún usuario con el mismo `login`, `email` ni `phone`
+- **WHEN** se envía `POST /api/auth/register` con `login`, `password`, `firstName`, `lastName`, `email` y `phone` válidos
+- **THEN** el sistema responde con código `201`
+- **AND** el usuario se crea con `status=PENDING` y `role=USER`
+- **AND** la contraseña se almacena como hash BCrypt con cost 12 (RN-AUTH-08)
+- **AND** la contraseña en claro nunca aparece en logs ni en la respuesta
+
+#### Scenario: Registro rechazado por login duplicado
+
+- **GIVEN** ya existe un usuario con `login=jdoe`
+- **WHEN** se envía `POST /api/auth/register` con `login=jdoe`
+- **THEN** el sistema responde con código `409`
+- **AND** el mensaje indica conflicto de login sin revelar datos del usuario existente
+
+#### Scenario: Registro rechazado por contraseña débil (RN-AUTH-08)
+
+- **GIVEN** el sistema tiene configurada la política de contraseñas
+- **WHEN** se envía `POST /api/auth/register` con `password` que no cumple los requisitos (menos de 8 chars, sin mayúscula o sin número)
+- **THEN** el sistema responde con código `400`
+- **AND** el mensaje detalla qué requisito de contraseña no se cumple
+
+---
+
+### Requirement 3: Renovación y revocación de tokens
+
+**El sistema DEBE permitir renovar el access token usando el refresh token almacenado en la cookie httpOnly, e invalidar el refresh token al hacer logout.**
+
+#### Scenario: Renovación exitosa con refresh token válido
+
+- **GIVEN** el usuario tiene un refresh token activo (no revocado, no expirado) en cookie
+- **WHEN** se envía `POST /api/auth/refresh` con la cookie `refresh_token`
+- **THEN** el sistema responde con código `200`
+- **AND** el cuerpo contiene un nuevo `accessToken` JWT válido
+- **AND** el refresh token en la cookie se mantiene (o se rota si está habilitada la rotación)
+
+#### Scenario: Renovación fallida con refresh token revocado
+
+- **GIVEN** el usuario ha hecho logout y su refresh token fue marcado como `revoked=true`
+- **WHEN** se envía `POST /api/auth/refresh` con ese refresh token
+- **THEN** el sistema responde con código `401`
+- **AND** la cookie `refresh_token` se borra (Max-Age=0)
+
+#### Scenario: Logout invalida el refresh token
+
+- **GIVEN** el usuario tiene un access token válido y un refresh token activo
+- **WHEN** se envía `POST /api/auth/logout` con el access token en `Authorization: Bearer`
+- **THEN** el sistema responde con código `204`
+- **AND** el refresh token se marca como `revoked=true` en base de datos
+- **AND** la cookie `refresh_token` se borra (`Max-Age=0`)
+- **AND** un intento posterior de `POST /api/auth/refresh` con ese token responde `401`
+
+---
+
+### Requirement 4: Recuperación de contraseña mediante OTP
+
+**El sistema DEBE permitir restablecer la contraseña mediante un OTP enviado al Telegram personal del usuario. El OTP es de un solo uso con TTL de 10 minutos (RN-AUTH-07).**
+
+#### Scenario: Solicitud de reset con email registrado
+
+- **GIVEN** existe un usuario con `email=jdoe@example.com` y `telegram_chat_id` vinculado
+- **WHEN** se envía `POST /api/auth/password/solicitar-reset` con ese email
+- **THEN** el sistema responde con código `200` (respuesta neutral, no revela si el email existe)
+- **AND** se genera un OTP de tipo `PASSWORD_RESET` almacenado como SHA-256 con TTL 10 min
+- **AND** el OTP se envía al chat personal de Telegram del usuario
+
+#### Scenario: Solicitud de reset con email no registrado (respuesta neutral)
+
+- **GIVEN** no existe ningún usuario con el email proporcionado
+- **WHEN** se envía `POST /api/auth/password/solicitar-reset` con ese email
+- **THEN** el sistema responde con código `200` con el mismo mensaje neutral
+- **AND** no se genera ningún OTP ni se envía ningún mensaje
+
+#### Scenario: Confirmación de reset exitosa con OTP válido
+
+- **GIVEN** existe un OTP de tipo `PASSWORD_RESET` válido (no usado, no expirado) para el usuario
+- **WHEN** se envía `POST /api/auth/password/confirmar-reset` con el `email`, el `otpCode` correcto y la nueva `password`
+- **THEN** el sistema responde con código `200`
+- **AND** la nueva contraseña se almacena como BCrypt cost 12
+- **AND** el OTP queda marcado como `used=true`
+- **AND** todos los refresh tokens del usuario se revocan
+
+#### Scenario: Confirmación de reset fallida con OTP expirado (RN-AUTH-07)
+
+- **GIVEN** existe un OTP de tipo `PASSWORD_RESET` para el usuario, pero `expires_at` es anterior al momento actual
+- **WHEN** se envía `POST /api/auth/password/confirmar-reset` con ese OTP
+- **THEN** el sistema responde con código `422`
+- **AND** el mensaje indica que el código ha expirado sin revelar información adicional
+
+---
+
+## Casos límite
+
+- Si el usuario no tiene `telegram_chat_id` vinculado y solicita reset de contraseña, el sistema responde `200` pero no puede enviar el OTP. El administrador debe gestionar el caso manualmente.
+- El rate limiting de `POST /api/auth/login` (5/min/IP) se aplica antes de la validación de credenciales para no revelar si el login existe.
+- Si un usuario en estado `INACTIVE` intenta hacer login, responde `403` con mensaje genérico.
+- El `jti` en el JWT permite blacklisting puntual sin invalidar todos los tokens del usuario.
+- El refresh token se almacena como `token_hash = SHA256(token)` en BD, nunca el token en claro.
+
+## Dependencias con otras capabilities
+
+- **`auth-otp-telegram`**: la recuperación de contraseña (`confirmar-reset`) consume el servicio OTP y requiere que la capability de vinculación Telegram esté operativa para enviar el código.
+- **`usuarios`**: el registro crea un usuario en la tabla `users`; la aprobación de cuenta es responsabilidad de la capability `usuarios` (endpoint `PATCH /api/admin/usuarios/{id}/aprobar`).
+- **`auditoria`**: cada evento de autenticación (login exitoso/fallido, logout, reset) genera una entrada en `audit_log`.
+- **`roles-permisos`**: los endpoints admin requieren que la capa de seguridad valide el rol `ADMIN` antes de permitir el acceso.

--- a/openspec/specs/auth-otp-telegram/spec.md
+++ b/openspec/specs/auth-otp-telegram/spec.md
@@ -1,0 +1,188 @@
+# Capability: auth-otp-telegram
+
+## Resumen
+
+Gestiona la vinculación de la cuenta de PadelPro con el chat personal de Telegram del usuario, la generación y verificación de códigos OTP para operaciones críticas (confirmación de reserva, cancelación, reset de contraseña), y la desvinculación de la cuenta. El canal Telegram actúa como segundo factor de seguridad para operaciones de alto impacto.
+
+## Fase
+
+Fase 1
+
+## Reglas de negocio implicadas
+
+- **RN-AUTH-07**: OTP de 6 dígitos, TTL 10 min, máximo 3 intentos, almacenado como SHA-256, de un solo uso. Tras 3 intentos fallidos el OTP se invalida automáticamente.
+- **RN-TEL-01**: El webhook de Telegram valida `X-Telegram-Bot-Api-Secret-Token` antes de procesar cualquier update. Requests sin el header o con valor incorrecto responden `403`.
+- **RN-TEL-02**: La vinculación de cuenta requiere OTP confirmado vía Telegram (TTL 10 min).
+- **RN-TEL-03**: Solo las cuentas con `telegram_chat_id NOT NULL` reciben notificaciones por Telegram.
+- **RN-RGPD-04**: Los logs no contienen códigos OTP en claro.
+
+## Entidades implicadas
+
+**users** (tabla `users`):
+- `id`, `login`, `telegram_chat_id` (NULL si no vinculado), `telegram_linked_at`, `status`
+
+**otp_codes** (tabla `otp_codes`):
+- `id`, `user_id`, `code` (almacenado como SHA-256), `type` (`TELEGRAM_LINK` | `RESERVATION_CONFIRM` | `CANCELLATION_CONFIRM` | `PASSWORD_RESET`), `expires_at` (10 min), `used`, `created_at`
+
+## Endpoints
+
+| Método | Path | OperationId | Autenticación |
+|---|---|---|---|
+| `POST` | `/api/otp/verificar` | `verificarOtp` | JWT requerido (USER o ADMIN) |
+| `PATCH` | `/api/usuarios/me` | `actualizarMiPerfil` | JWT requerido | (para iniciar/revocar vinculación) |
+| `POST` | `/api/bot/telegram` | webhook interno | Secret token header (RN-TEL-01) |
+
+> La vinculación se inicia a través de `PATCH /api/usuarios/me` con el campo de vinculación, y se completa cuando el usuario envía el OTP al bot de Telegram. El webhook `POST /api/bot/telegram` procesa el mensaje del bot.
+
+## Permisos
+
+| Operación | ADMIN | USER | No autenticado |
+|---|---|---|---|
+| Iniciar vinculación Telegram | Permitido | Permitido | Denegado (401) |
+| Verificar OTP (`POST /api/otp/verificar`) | Permitido | Permitido | Denegado (401) |
+| Desvincular Telegram | Permitido | Permitido (propio) | Denegado (401) |
+| Recibir webhook Telegram | No aplica | No aplica | Solo con secret token |
+
+## Requirements
+
+### Requirement 1: Vinculación de cuenta con Telegram
+
+**El sistema DEBE permitir que un usuario autenticado vincule su cuenta de PadelPro con su chat personal de Telegram mediante un OTP temporal de tipo TELEGRAM_LINK.**
+
+#### Scenario: Vinculación exitosa en dos pasos
+
+- **GIVEN** un usuario autenticado con `telegram_chat_id IS NULL`
+- **WHEN** el usuario solicita la vinculación de Telegram a través de su perfil
+- **THEN** el sistema genera un OTP de 6 dígitos de tipo `TELEGRAM_LINK` con TTL 10 minutos (RN-TEL-02)
+- **AND** el OTP se almacena como SHA-256 en `otp_codes` (RN-AUTH-07)
+- **AND** el sistema devuelve instrucciones: "Envía `/vincular XXXXXX` al bot @PadelProBot"
+
+- **WHEN** el usuario envía `/vincular XXXXXX` al bot de Telegram desde su chat personal
+- **AND** el webhook `POST /api/bot/telegram` recibe el update con el header `X-Telegram-Bot-Api-Secret-Token` válido
+- **THEN** el sistema valida el OTP (SHA-256 del código, no expirado, no usado, tipo correcto)
+- **AND** el sistema actualiza `users SET telegram_chat_id = <chat_id>, telegram_linked_at = now()`
+- **AND** el OTP queda marcado como `used=true`
+- **AND** el bot responde al usuario: confirmación de vinculación exitosa
+- **AND** el sistema registra la acción `TELEGRAM_LINKED` en `audit_log`
+
+#### Scenario: Vinculación rechazada por OTP expirado (RN-AUTH-07)
+
+- **GIVEN** un usuario tiene un OTP de tipo `TELEGRAM_LINK` con `expires_at` anterior al momento actual
+- **WHEN** el usuario envía el comando de vinculación con ese OTP al bot
+- **THEN** el sistema responde con código `422` en el procesamiento interno
+- **AND** el bot responde al usuario: "El código ha expirado. Solicita uno nuevo desde tu perfil."
+- **AND** el OTP no se usa y no se crea ninguna vinculación
+
+#### Scenario: Vinculación rechazada porque el chat_id ya está vinculado a otra cuenta
+
+- **GIVEN** el `telegram_chat_id` del usuario ya está registrado en otro `users.id`
+- **WHEN** el usuario envía el comando de vinculación con un OTP válido
+- **THEN** el sistema rechaza la vinculación
+- **AND** el bot responde: "Este Telegram ya está vinculado a otra cuenta. Contacta con el administrador."
+- **AND** no se modifica ninguna cuenta
+
+---
+
+### Requirement 2: Verificación de OTP para operaciones críticas
+
+**El sistema DEBE verificar códigos OTP para confirmar operaciones de alto impacto. Un OTP es válido solo si no ha expirado, no ha sido usado y el número de intentos fallidos es menor de 3 (RN-AUTH-07).**
+
+#### Scenario: Verificación exitosa de OTP RESERVATION_CONFIRM
+
+- **GIVEN** el usuario tiene un OTP de tipo `RESERVATION_CONFIRM` válido (no expirado, no usado)
+- **WHEN** se envía `POST /api/otp/verificar` con el `otpCode` correcto y `type=RESERVATION_CONFIRM`
+- **THEN** el sistema responde con código `200`
+- **AND** el OTP queda marcado como `used=true`
+- **AND** la operación asociada (confirmación de reserva) puede proceder
+
+#### Scenario: Verificación fallida con OTP incorrecto — conteo de intentos
+
+- **GIVEN** el usuario tiene un OTP de tipo `RESERVATION_CONFIRM` válido con 0 intentos previos
+- **WHEN** se envía `POST /api/otp/verificar` con un `otpCode` incorrecto
+- **THEN** el sistema responde con código `422`
+- **AND** el contador interno de intentos fallidos para ese OTP se incrementa
+- **AND** el OTP sigue siendo válido para un nuevo intento (si hay menos de 3 fallos)
+
+#### Scenario: OTP invalidado automáticamente tras el 4º intento (RN-AUTH-07)
+
+- **GIVEN** el usuario ha fallado exactamente 3 intentos de verificación del mismo OTP
+- **WHEN** se envía `POST /api/otp/verificar` con cualquier código
+- **THEN** el sistema responde con código `422`
+- **AND** el OTP queda marcado como `used=true` (invalidado automáticamente)
+- **AND** el mensaje indica que el código ha sido invalidado por exceso de intentos
+- **AND** el usuario debe solicitar un nuevo OTP
+
+#### Scenario: Verificación fallida con OTP ya utilizado
+
+- **GIVEN** existe un OTP con `used=true` para el usuario
+- **WHEN** se envía `POST /api/otp/verificar` con ese código
+- **THEN** el sistema responde con código `422`
+- **AND** el mensaje indica que el código ya fue utilizado, sin revelar información adicional
+
+---
+
+### Requirement 3: Desvinculación de cuenta Telegram
+
+**El sistema DEBE permitir al usuario autenticado desvincular su cuenta de Telegram, eliminando el `telegram_chat_id` y revocando los OTPs activos relacionados.**
+
+#### Scenario: Desvinculación exitosa
+
+- **GIVEN** el usuario tiene `telegram_chat_id NOT NULL`
+- **WHEN** el usuario solicita la desvinculación a través de su perfil (`PATCH /api/usuarios/me`)
+- **THEN** el sistema actualiza `users SET telegram_chat_id = NULL, telegram_linked_at = NULL`
+- **AND** todos los OTPs activos del usuario quedan invalidados (`used=true`)
+- **AND** el sistema registra la acción `TELEGRAM_UNLINKED` en `audit_log`
+- **AND** el usuario deja de recibir notificaciones por Telegram (RN-TEL-03)
+
+#### Scenario: Operación vía Telegram bloqueada para cuentas no vinculadas
+
+- **GIVEN** un usuario sin `telegram_chat_id` vinculado envía un comando al bot de Telegram
+- **WHEN** el webhook procesa el mensaje
+- **THEN** el bot responde al remitente: "Vincula primero tu cuenta en [URL de perfil]"
+- **AND** el sistema no ejecuta ninguna operación de negocio
+
+---
+
+### Requirement 4: Validación de webhook de Telegram
+
+**El sistema DEBE rechazar cualquier request al endpoint del webhook de Telegram que no incluya el header `X-Telegram-Bot-Api-Secret-Token` con el valor correcto (RN-TEL-01).**
+
+#### Scenario: Webhook procesado con secret token válido
+
+- **GIVEN** el sistema tiene configurado `telegram_bot_token` en `system_config`
+- **WHEN** Telegram envía `POST /api/bot/telegram` con `X-Telegram-Bot-Api-Secret-Token` correcto
+- **THEN** el sistema responde con código `200`
+- **AND** el update se procesa normalmente
+
+#### Scenario: Webhook rechazado sin header de secret token (RN-TEL-01)
+
+- **GIVEN** el sistema tiene configurado el webhook secret
+- **WHEN** se envía `POST /api/bot/telegram` sin el header `X-Telegram-Bot-Api-Secret-Token`
+- **THEN** el sistema responde con código `403`
+- **AND** la acción `TELEGRAM_WEBHOOK_INVALID_SECRET` se registra en `audit_log`
+- **AND** no se procesa ningún update
+
+#### Scenario: Webhook rechazado con secret token incorrecto (RN-TEL-01)
+
+- **GIVEN** el sistema tiene configurado el webhook secret
+- **WHEN** se envía `POST /api/bot/telegram` con un valor incorrecto en `X-Telegram-Bot-Api-Secret-Token`
+- **THEN** el sistema responde con código `403`
+- **AND** la acción `TELEGRAM_WEBHOOK_INVALID_SECRET` se registra en `audit_log`
+
+---
+
+## Casos límite
+
+- Un usuario puede solicitar un nuevo OTP antes de que el anterior expire. El nuevo OTP invalida el anterior del mismo tipo (`used=true` en el anterior) para evitar acumulación de OTPs activos.
+- El OTP nunca se registra en claro en logs ni en respuestas de la API (RN-RGPD-04).
+- Si el servicio de Telegram está caído durante la generación del OTP, el sistema devuelve error `503` y no persiste el OTP (para evitar OTPs huérfanos).
+- El bot nunca ejecuta operaciones administrativas independientemente del remitente del mensaje.
+- La comparación del OTP se realiza comparando `SHA-256(codigo_introducido)` con el `code_hash` almacenado, nunca en claro.
+
+## Dependencias con otras capabilities
+
+- **`auth-local`**: la recuperación de contraseña de `auth-local` consume el servicio OTP de esta capability.
+- **`reservas`**: la confirmación y cancelación de reservas vía bot Telegram generan OTPs de tipo `RESERVATION_CONFIRM` y `CANCELLATION_CONFIRM`.
+- **`usuarios`**: la vinculación se refleja en el campo `telegram_chat_id` de la tabla `users`.
+- **`notificaciones`**: una vez vinculada la cuenta, el módulo de notificaciones puede usar el `telegram_chat_id` para enviar mensajes directos.
+- **`auditoria`**: todos los eventos OTP (generación, validación exitosa, fallo, invalidación) se registran en `audit_log`.

--- a/openspec/specs/configuracion-club/spec.md
+++ b/openspec/specs/configuracion-club/spec.md
@@ -1,0 +1,139 @@
+# Capability: configuracion-club
+
+## Resumen
+
+Gestiona los parámetros globales del club almacenados en la tabla `system_config` (singleton, `id=1`). Incluye precio por hora, horario de apertura y cierre, máximo de participantes por reserva, política de cancelación, divisa, zona horaria y configuración de los servicios externos (Redsys, Telegram, SMTP). Los campos sensibles (`redsys_secret_key`, `telegram_bot_token`, `smtp_password`) se cifran con AES-256-GCM y nunca se devuelven en claro en las respuestas de la API (RN-SEC-02).
+
+## Fase
+
+Fase 1
+
+## Reglas de negocio implicadas
+
+- **RN-RES-02**: El máximo de participantes por reserva lo determina `system_config.max_participants` (por defecto 4). Ninguna reserva puede superar este valor.
+- **RN-RES-04**: La ventana de reserva anticipada y la política de cancelación provienen de `system_config.cancellation_deadline_hours`.
+- **RN-SEC-02**: Los secretos del sistema (`redsys_secret_key`, `telegram_bot_token`, `smtp_password`) se cifran con AES-256-GCM en base de datos. Las respuestas de la API nunca devuelven estos campos en claro.
+
+## Entidades implicadas
+
+**system_config** (tabla `system_config`, singleton `id=1`):
+- `id` (siempre 1, CHECK id=1)
+- `price_per_hour` (`NUMERIC(12,2)`) — precio base por hora de pista
+- `cancellation_deadline_hours` (`INTEGER`) — horas mínimas de antelación para cancelar sin coste
+- `max_participants` (`INTEGER`) — máximo de jugadores por reserva (por defecto 4)
+- `payment_gateway` (`payment_gateway ENUM`) — pasarela activa (ej. `REDSYS`)
+- `redsys_merchant_code` (`VARCHAR(50)`) — código de comercio Redsys
+- `redsys_terminal` (`VARCHAR(5)`) — terminal Redsys
+- `redsys_secret_key` (`VARCHAR(255)`) — cifrado AES-256-GCM
+- `telegram_bot_token` (`VARCHAR(255)`) — cifrado AES-256-GCM
+- `telegram_group_id` (`VARCHAR(50)`) — ID del grupo de Telegram donde se publican reservas
+- `smtp_host`, `smtp_port`, `smtp_user` — configuración SMTP
+- `smtp_password` (`VARCHAR(255)`) — cifrado AES-256-GCM
+- `updated_by_id` (FK → `users.id`) — último ADMIN que actualizó la config
+- `updated_at` (`TIMESTAMPTZ`)
+
+## Endpoints
+
+| Método | Path | OperationId | Autenticación |
+|---|---|---|---|
+| `GET` | `/api/admin/sistema/config` | `getSystemConfig` | JWT requerido (ADMIN) |
+| `PATCH` | `/api/admin/sistema/config` | `actualizarSystemConfig` | JWT requerido (ADMIN) |
+
+## Permisos
+
+| Operación | ADMIN | USER | No autenticado |
+|---|---|---|---|
+| `GET /api/admin/sistema/config` | Permitido | Denegado (403) | Denegado (401) |
+| `PATCH /api/admin/sistema/config` | Permitido | Denegado (403) | Denegado (401) |
+
+## Requirements
+
+### Requirement 1: Lectura de configuración del sistema
+
+**El sistema DEBE devolver la configuración global del club al ADMIN, omitiendo los valores en claro de los campos sensibles cifrados.**
+
+#### Scenario: ADMIN lee la configuración del sistema
+
+- **GIVEN** un administrador autenticado con `role=ADMIN`
+- **AND** existe la fila `system_config` con `id=1`
+- **WHEN** se envía `GET /api/admin/sistema/config`
+- **THEN** el sistema responde con código `200`
+- **AND** el cuerpo contiene `pricePerHour`, `cancellationDeadlineHours`, `maxParticipants`, `paymentGateway`, `telegramGroupId`, `smtpHost`, `smtpPort`, `smtpUser`
+- **AND** los campos `redsysSecretKey`, `telegramBotToken` y `smtpPassword` no aparecen en el cuerpo o aparecen enmascarados (ej. `"****"`) (RN-SEC-02)
+
+#### Scenario: USER intenta acceder a la configuración
+
+- **GIVEN** un usuario autenticado con `role=USER`
+- **WHEN** se envía `GET /api/admin/sistema/config`
+- **THEN** el sistema responde con código `403`
+
+---
+
+### Requirement 2: Actualización de configuración del sistema
+
+**El sistema DEBE permitir al ADMIN actualizar uno o más parámetros de la configuración global con semántica PATCH. Solo los campos incluidos en el cuerpo se actualizan.**
+
+#### Scenario: ADMIN actualiza el máximo de participantes
+
+- **GIVEN** un administrador autenticado con `role=ADMIN`
+- **AND** `system_config.max_participants = 4`
+- **WHEN** se envía `PATCH /api/admin/sistema/config` con body `{ "maxParticipants": 3 }`
+- **THEN** el sistema responde con código `200`
+- **AND** `system_config.max_participants = 3` en base de datos
+- **AND** `updated_by_id` se actualiza con el `id` del ADMIN autenticado
+- **AND** `updated_at` se actualiza al momento actual
+- **AND** la acción `CONFIG_UPDATED` se registra en `audit_log`
+
+#### Scenario: ADMIN actualiza el precio por hora
+
+- **GIVEN** un administrador autenticado
+- **WHEN** se envía `PATCH /api/admin/sistema/config` con body `{ "pricePerHour": 12.50 }`
+- **THEN** el sistema responde con código `200`
+- **AND** `system_config.price_per_hour = 12.50` en base de datos
+- **AND** el precio nuevo se aplica a todas las reservas futuras (no retroactivamente a reservas existentes)
+
+#### Scenario: Valores inválidos son rechazados
+
+- **GIVEN** un administrador autenticado
+- **WHEN** se envía `PATCH /api/admin/sistema/config` con `maxParticipants = 0` o `maxParticipants` negativo
+- **THEN** el sistema responde con código `400`
+- **AND** el cuerpo sigue el esquema `ErrorResponse` indicando qué campo es inválido
+
+#### Scenario: Actualización de secretos cifrados (RN-SEC-02)
+
+- **GIVEN** un administrador autenticado
+- **WHEN** se envía `PATCH /api/admin/sistema/config` con body `{ "redsysSecretKey": "nuevo-valor" }`
+- **THEN** el sistema responde con código `200`
+- **AND** el valor `nuevo-valor` se cifra con AES-256-GCM antes de persistir en base de datos
+- **AND** la respuesta devuelve el campo enmascarado (ej. `"****"`), nunca en claro
+
+---
+
+### Requirement 3: Integridad del singleton de configuración
+
+**El sistema DEBE garantizar que siempre existe exactamente una fila en `system_config` (id=1). No se permiten operaciones de creación ni eliminación de la configuración.**
+
+#### Scenario: La configuración siempre existe (inicialización)
+
+- **GIVEN** el sistema se inicializa por primera vez (migración Flyway)
+- **WHEN** se ejecuta la migración inicial de datos
+- **THEN** la tabla `system_config` contiene exactamente una fila con `id=1` y valores por defecto sensatos
+- **AND** el constraint `CHECK (id = 1)` de la tabla impide insertar filas adicionales
+
+---
+
+## Casos límite
+
+- La primera lectura de `system_config` en un backend recién desplegado no debe fallar aunque los campos de Redsys y Telegram estén vacíos. El sistema debe indicar en la respuesta qué integraciones están configuradas y cuáles no.
+- Si `max_participants` se reduce (ej. de 4 a 3), las reservas existentes con 4 participantes no se ven afectadas retroactivamente.
+- El campo `price_per_hour` solo se usa para calcular el importe de nuevas reservas. Las reservas ya creadas conservan el precio calculado en el momento de su creación.
+- Los campos sensibles cifrados se descifran en memoria solo cuando son necesarios (para construir la firma Redsys o para el cliente SMTP), nunca se exponen en ningún log ni en ninguna respuesta HTTP.
+
+## Dependencias con otras capabilities
+
+- **`reservas`**: la capability `reservas` consulta `system_config.max_participants` al crear una reserva y `system_config.cancellation_deadline_hours` al cancelarla (RN-RES-02, RN-RES-04).
+- **`pagos-redsys`**: la capability `pagos-redsys` usa `system_config.redsys_merchant_code`, `redsys_terminal` y `redsys_secret_key` (descifrada) para construir la firma HMAC de Redsys.
+- **`auth-otp-telegram`**: el webhook de Telegram se valida usando `system_config.telegram_bot_token` (descifrado).
+- **`notificaciones`**: las notificaciones por email usan la configuración SMTP de `system_config`.
+- **`auditoria`**: toda actualización de `system_config` genera una entrada en `audit_log`.
+- **`roles-permisos`**: ambos endpoints de esta capability requieren `role=ADMIN`.

--- a/openspec/specs/disponibilidad-pistas/spec.md
+++ b/openspec/specs/disponibilidad-pistas/spec.md
@@ -1,0 +1,101 @@
+# Capability: disponibilidad-pistas
+
+## Resumen
+Consulta de franjas horarias libres de la pista para una fecha concreta. Permite a los usuarios autenticados conocer qué horas tienen plazas disponibles antes de crear o unirse a una reserva. El cálculo tiene en cuenta las reservas activas (`status <> 'CANCELLED'`) que solapan la franja, el estado operativo de la pista y el número máximo de participantes configurado. Los resultados se cachean 30 segundos e se invalidan automáticamente al crearse o cancelarse una reserva.
+
+## Fase
+🟢 Fase 1
+
+## Reglas de negocio implicadas
+- **RN-RES-01**: El anti-solapamiento de franjas se basa en el mismo rango horario que la consulta de disponibilidad; un tramo solo aparece como libre si ninguna reserva activa lo ocupa completamente.
+- **RN-RES-02**: Un tramo con reserva existente pero con plazas libres (`participants_count < max_participants`) aparece en la respuesta con las plazas restantes.
+- **RN-RES-04**: Un tramo cubierto por una pista en estado MANTENIMIENTO no aparece en `tramosDisponibles` (0 plazas disponibles).
+
+## Entidades implicadas
+
+| Entidad | Tabla | Rol |
+|---|---|---|
+| Reserva | `reservations` | Fuente de franjas ocupadas; se filtran las que tienen `status <> 'CANCELLED'` |
+| Participante | `participants` | Permite contar cuántas plazas de una franja con reserva existente están ocupadas |
+| Configuración del sistema | `system_config` | Fuente de `max_participants` (para calcular plazas libres) y estado operativo de la pista |
+
+## Endpoints
+*(de docs/openapi.yaml)*
+
+| Método | Ruta | Descripción |
+|---|---|---|
+| `GET` | `/api/reservas/disponibles` | Consultar tramos horarios con plazas libres para una fecha concreta |
+
+## Permisos
+
+| Operación | ADMIN | USER | No autenticado |
+|---|---|---|---|
+| Consultar disponibilidad (`GET /api/reservas/disponibles`) | Permitido | Permitido | Denegado (401) |
+
+---
+
+## Requirements
+
+### Requirement 1: Devolver tramos libres para una fecha sin reservas activas
+
+**El sistema DEBE devolver todos los tramos horarios del día como disponibles cuando no existe ninguna reserva activa para esa fecha.**
+
+#### Scenario: Consulta de un día sin ninguna reserva activa
+- **GIVEN** un usuario autenticado (USER o ADMIN)
+- **AND** no existe ninguna reserva con `reservation_date = 2025-08-01` y `status <> 'CANCELLED'`
+- **WHEN** envía `GET /api/reservas/disponibles?fecha=2025-08-01`
+- **THEN** el sistema responde 200 con la fecha `2025-08-01` y la lista `tramosDisponibles` con todos los tramos del horario del club
+- **AND** cada tramo tiene `plazasLibres` igual a `system_config.max_participants`
+
+### Requirement 2: Devolver tramos con plazas parciales cuando existe una reserva incompleta
+
+**El sistema DEBE devolver el tramo horario con el número correcto de plazas libres cuando existe una reserva activa en ese tramo con menos participantes que el máximo.**
+
+#### Scenario: Consulta de un día con una reserva parcialmente ocupada
+- **GIVEN** existe la reserva UUID-D con `reservation_date=2025-08-05`, `start_time=10:00`, `duration_minutes=60`, `status=CONFIRMED` y 2 participantes
+- **AND** `system_config.max_participants = 4`
+- **WHEN** un usuario autenticado envía `GET /api/reservas/disponibles?fecha=2025-08-05`
+- **THEN** el sistema responde 200
+- **AND** el tramo `horaInicio: "10:00"` con `duracionMinutos: 60` aparece en `tramosDisponibles` con `plazasLibres: 2`
+
+#### Scenario: Consulta de un día con múltiples reservas en distintos tramos
+- **GIVEN** existen reservas `CONFIRMED` en 09:00–10:00 (3 participantes) y 11:00–12:00 (4 participantes) para 2025-08-10
+- **AND** el tramo 10:00–11:00 no tiene ninguna reserva activa
+- **WHEN** un usuario envía `GET /api/reservas/disponibles?fecha=2025-08-10`
+- **THEN** el tramo 09:00 aparece con `plazasLibres: 1`
+- **AND** el tramo 10:00 aparece con `plazasLibres: 4` (sin reserva)
+- **AND** el tramo 11:00 NO aparece (0 plazas libres)
+
+### Requirement 3: Devolver lista vacía cuando la pista está en mantenimiento
+
+**El sistema DEBE devolver `tramosDisponibles` vacío para cualquier fecha cuando la pista está en estado MANTENIMIENTO, sin revelar el motivo en la respuesta de disponibilidad.**
+
+#### Scenario: Consulta de disponibilidad con pista en mantenimiento
+- **GIVEN** la configuración del sistema indica que la pista está en estado MANTENIMIENTO (via `system_config`)
+- **WHEN** un usuario autenticado envía `GET /api/reservas/disponibles?fecha=2025-09-01`
+- **THEN** el sistema responde 200 con `tramosDisponibles: []`
+- **AND** la respuesta no incluye ningún campo que revele explícitamente que el motivo es MANTENIMIENTO (para no exponer información operativa innecesaria)
+
+#### Scenario: Consulta con parámetro `fecha` en formato inválido
+- **GIVEN** un usuario autenticado
+- **WHEN** envía `GET /api/reservas/disponibles?fecha=15-06-2025` (formato incorrecto, no YYYY-MM-DD)
+- **THEN** el sistema responde 400 con `code: "VALIDATION_ERROR"`
+- **AND** el mensaje de error indica que el formato de fecha debe ser `YYYY-MM-DD`
+
+#### Scenario: Consulta sin el parámetro `fecha` requerido
+- **GIVEN** un usuario autenticado
+- **WHEN** envía `GET /api/reservas/disponibles` sin el parámetro `fecha`
+- **THEN** el sistema responde 400 con `code: "VALIDATION_ERROR"`
+
+## Casos límite
+- Fecha en el pasado: el sistema puede responder con los tramos (histórico) o con 400; en v1.0 se acepta responder 200 con los tramos históricos para facilitar la consulta del ADMIN, pero no se garantiza exactitud si los datos fueron modificados.
+- Fecha fuera del rango de la ventana de reserva anticipada (`system_config`): el sistema puede devolver tramos pero la creación de reserva para esa fecha fallará; la disponibilidad no filtra por ventana anticipada.
+- Reservas en estado `PENDING_CONFIRMATION` se tratan igual que `CONFIRMED` para el cálculo de disponibilidad: bloquean franjas y reducen plazas libres.
+- El endpoint usa caché de 30 segundos con clave `fecha`; los cambios de reservas en el mismo segundo pueden no reflejarse inmediatamente.
+- Si `system_config.max_participants` cambia, la caché se invalida y el siguiente request refleja el nuevo valor.
+- El endpoint requiere autenticación (JWT válido); una petición con token expirado recibe 401, no 200 con datos.
+
+## Dependencias con otras capabilities
+- **reservas**: La disponibilidad se calcula a partir de las reservas activas; cada creación o cancelación de reserva invalida la caché de `available-slots` para la fecha afectada.
+- **partidas**: La vista de partidas joinables se basa en la misma consulta de disponibilidad, filtrando los tramos con `plazasLibres > 0` asociados a reservas existentes con huecos.
+- **pistas**: El estado operativo de la pista (MANTENIMIENTO) afecta directamente al resultado de disponibilidad; se lee de `system_config`.

--- a/openspec/specs/exportaciones-rgpd/spec.md
+++ b/openspec/specs/exportaciones-rgpd/spec.md
@@ -1,0 +1,120 @@
+# Capability: `exportaciones-rgpd`
+
+## Resumen
+Implementación de los derechos del titular de datos conforme al Reglamento General de
+Protección de Datos (RGPD): derecho al olvido (Art. 17, anonimización), portabilidad
+(Art. 20, exportación JSON), y acceso (Art. 15, perfil propio). Esta capability es crítica
+para el cumplimiento legal; cualquier fallo en su implementación expone al club a sanciones
+de la AEPD. La anonimización es irreversible y no elimina registros contables ni de auditoría.
+
+## Fase
+🟢 Fase 1
+
+## Reglas de negocio implicadas
+- **RN-RGPD-01**: La eliminación de cuenta de usuario se implementa como anonimización (no borrado físico): `first_name='ANONIMIZADO'`, `last_name='ANONIMIZADO'`, `email='anonimized-{id}@padelpro.local'`, `phone=NULL`, `telegram_chat_id=NULL`, `telegram_linked_at=NULL`; genera entrada `audit_log` con `action='USER_ANONYMIZED'`.
+- **RN-RGPD-02**: Los datos financieros (`payments`, `reservations`) se conservan un mínimo de 5 años por obligación fiscal (AEAT); la anonimización no elimina ni modifica estas tablas, aunque la FK `registered_by_id` en `payments` pasa a NULL por el SET NULL de la FK.
+- **RN-RGPD-03**: Las respuestas de error de los endpoints de exportaciones-rgpd no exponen datos personales de otros usuarios.
+- **RN-RGPD-04**: Los logs del proceso de anonimización y exportación no contienen los datos personales procesados.
+- **RN-RGPD-05**: El derecho al olvido no elimina registros de `audit_log` (son inmutables por diseño legal); la FK `user_id` pasa a NULL (SET NULL) tras la anonimización.
+- **RN-RGPD-06**: El usuario anonimizado no puede autenticarse porque su `email` ya no es válido y su `login` permanece (aunque el `password_hash` podría anularse opcionalmente para impedir acceso); se recomienda además marcar `status=INACTIVE`.
+- **RN-RGPD-07**: Los `refresh_tokens` activos del usuario anonimizado se revocan (`revoked=true`) y los `otp_codes` activos se invalidan (`used=true`) como parte del proceso de anonimización.
+
+## Entidades implicadas
+- **`users`**: entidad principal afectada por la anonimización. Campos anonimizados: `first_name`, `last_name`, `email`, `phone`, `telegram_chat_id`, `telegram_linked_at`. Campos preservados: `id`, `login`, `registered_at`, `status` (→ INACTIVE).
+- **`participants`**: `external_name='ANONIMIZADO'` y `external_phone=NULL` para los registros vinculados al usuario anonimizado (cuando `user_id = {id}`).
+- **`refresh_tokens`**: `revoked=true` para todos los tokens del usuario.
+- **`otp_codes`**: `used=true` para todos los OTP activos del usuario.
+- **`payments`**: NO se modifican. `registered_by_id` pasa a NULL por FK SET NULL si el usuario era admin que registró pagos en efectivo. Los pagos vinculados a sus reservas permanecen intactos.
+- **`reservations`**: NO se modifican. Las reservas históricas del usuario permanecen con `owner_id` intacto (FK RESTRICT, el usuario anonimizado sigue existiendo en la tabla).
+- **`audit_log`**: NO se modifica. La FK `user_id` pasa a NULL (SET NULL) si había entradas previas; se genera una nueva entrada `USER_ANONYMIZED`.
+
+## Endpoints
+**Anonimización (derecho al olvido — Art. 17):**
+- `DELETE /api/admin/usuarios/{id}` — Requerido ROLE_ADMIN. En v1.0 este endpoint implementa la anonimización (soft-delete: `status=INACTIVE` + anonimización de campos personales). Ver `docs/openapi.yaml` operationId `desactivarUsuario`.
+
+**Acceso al perfil propio (Art. 15, parcial):**
+- `GET /api/usuarios/me` — Requerido ROLE_USER o ROLE_ADMIN. Devuelve los datos del propio usuario autenticado. Ver `docs/openapi.yaml` operationId `getMiPerfil`.
+
+**Portabilidad (Art. 20) — Decisión abierta D-SEC-03:**
+- No existe endpoint de exportación en v1.0. Proceso manual: el ADMIN exporta los datos del usuario mediante consulta directa a la BD. En Fase 2 se implementará `GET /api/usuarios/me/exportar` que devuelva un JSON con todos los datos del titular.
+
+> **Nota:** La decisión D-SEC-03 de `docs/security-design.md` tiene pendiente de confirmación
+> si `GET /api/usuarios/me/exportar` es requisito para el lanzamiento de v1.0.
+
+## Permisos
+| Operación | ADMIN | USER | No autenticado |
+|---|---|---|---|
+| Anonimizar cuenta propia (Art. 17) | ✅ (sobre sí mismo) | ✅ (solicitud manual; Admin ejecuta) | ❌ |
+| Anonimizar cuenta ajena (Art. 17) | ✅ | ❌ | ❌ |
+| Consultar perfil propio (Art. 15) | ✅ | ✅ | ❌ |
+| Exportar datos propios JSON (Art. 20, Fase 2) | ✅ | ✅ | ❌ |
+| Exportar datos de otro usuario | ✅ | ❌ | ❌ |
+
+## Requirements
+
+### Requirement 1: Derecho al olvido — anonimización irreversible de datos personales
+**El sistema DEBE, cuando se invoca `DELETE /api/admin/usuarios/{id}`, sobrescribir los campos de datos personales del usuario con valores neutros, marcar la cuenta como `INACTIVE`, revocar todos los tokens activos e invalidar todos los OTP activos, en una única transacción atómica.**
+
+#### Scenario 1: ADMIN anonimiza una cuenta — datos personales sobrescritos
+- **GIVEN** un usuario con `id=42`, `status=ACTIVE`, `email='jugador@example.com'`, `telegram_chat_id='987654321'`
+- **WHEN** el ADMIN invoca `DELETE /api/admin/usuarios/42`
+- **THEN** en una única transacción: `users.first_name='ANONIMIZADO'`, `users.last_name='ANONIMIZADO'`, `users.email='anonimized-42@padelpro.local'`, `users.phone=NULL`, `users.telegram_chat_id=NULL`, `users.telegram_linked_at=NULL`, `users.status='INACTIVE'`, AND todos los `refresh_tokens` con `user_id=42` pasan a `revoked=true`, AND todos los `otp_codes` activos con `user_id=42` pasan a `used=true`, AND se inserta en `audit_log` con `action='USER_ANONYMIZED'`, `user_id`= id del ADMIN ejecutor, `entity_type='USER'`, `entity_id='42'`, AND la respuesta HTTP es 204 No Content
+
+#### Scenario 2: Usuario anonimizado no puede autenticarse
+- **GIVEN** un usuario previamente anonimizado con `status=INACTIVE` y `email='anonimized-42@padelpro.local'`
+- **WHEN** se intenta `POST /api/auth/login` con las credenciales originales del usuario
+- **THEN** el sistema devuelve 403 Forbidden (estado INACTIVE), Y se genera entrada `audit_log` con `action='USER_LOGIN_FAILED'`, Y no se revelan los datos actuales del usuario en la respuesta de error (RN-RGPD-03)
+
+#### Scenario 3: ADMIN no puede anonimizarse a sí mismo
+- **GIVEN** un ADMIN autenticado con `id=1`
+- **WHEN** el ADMIN invoca `DELETE /api/admin/usuarios/1` (su propio id)
+- **THEN** el sistema devuelve 422 Unprocessable Entity con código de error `SELF_DEACTIVATION_FORBIDDEN`, Y ningún dato del ADMIN es modificado en BD (RN-AUTH-05)
+
+### Requirement 2: Datos financieros preservados tras anonimización
+**El sistema DEBE conservar todos los registros de `payments` y `reservations` vinculados al usuario anonimizado, sin modificar su contenido, para cumplir la obligación de retención fiscal de 5 años (RN-RGPD-02).**
+
+#### Scenario 4: Pagos del usuario anonimizado permanecen intactos
+- **GIVEN** un usuario con id=42 que tiene 3 reservas con pagos en estado `PAID`
+- **WHEN** el ADMIN anonimiza la cuenta del usuario (id=42)
+- **THEN** los 3 registros en `payments` vinculados a esas reservas permanecen en BD sin modificación de `amount`, `status`, `paid_at`, `redsys_order_id` ni `transaction_id`, AND las reservas con `owner_id=42` permanecen en BD con todos sus datos (la FK RESTRICT previene el borrado físico del usuario), AND los `participants` con `user_id=42` mantienen el `user_id` (FK SET NULL no aplica aquí — el usuario sigue existiendo como entidad con datos anonimizados)
+
+#### Scenario 5: `audit_log` no se modifica tras anonimización — FK pasa a NULL
+- **GIVEN** un usuario con id=42 que tiene 15 entradas en `audit_log` con `user_id=42`
+- **WHEN** el ADMIN anonimiza la cuenta del usuario
+- **THEN** las 15 entradas de `audit_log` permanecen intactas en sus campos `action`, `entity_type`, `entity_id`, `details`, `ip_address`, `channel` y `created_at`, AND el campo `user_id` de esas 15 filas pasa a NULL (FK SET NULL), AND se genera UNA NUEVA fila en `audit_log` con `action='USER_ANONYMIZED'`
+
+### Requirement 3: Portabilidad de datos — exportación en JSON (Art. 20)
+**El sistema DEBE, cuando se invoque el endpoint de exportación (Fase 2), devolver un JSON estructurado con todos los datos personales del titular: perfil, historial de reservas y pagos, sin incluir datos de terceros.**
+
+#### Scenario 6: Usuario exporta sus propios datos (Fase 2)
+- **GIVEN** un usuario autenticado con `status=ACTIVE` que tiene 5 reservas y 3 pagos
+- **WHEN** el usuario invoca `GET /api/usuarios/me/exportar` (Fase 2)
+- **THEN** la respuesta es un JSON con: `perfil` (campos no sensibles del usuario: login, email, phone, firstName, lastName, registeredAt), `reservas` (lista de reservas donde es `owner_id`: fecha, hora, estado, participantes propios sin datos de terceros), `pagos` (lista de pagos propios: importe, estado, fecha), Y el JSON no contiene `password_hash`, tokens, OTP codes ni datos de tarjeta
+
+### Requirement 4: Acceso a datos propios — perfil completo (Art. 15)
+**El sistema DEBE devolver al usuario autenticado todos sus datos personales almacenados cuando invoque `GET /api/usuarios/me`, sin exponer datos de otros usuarios.**
+
+#### Scenario 7: Usuario accede a su propio perfil
+- **GIVEN** un usuario autenticado con `status=ACTIVE`
+- **WHEN** el usuario invoca `GET /api/usuarios/me`
+- **THEN** la respuesta incluye los campos del `UsuarioResponse`: `id`, `login`, `email`, `phone`, `firstName`, `lastName`, `role`, `status`, `telegramLinked`, `telegramLinkedAt`, `registeredAt`, Y no incluye `password_hash` ni ningún campo sensible
+
+#### Scenario 8: ADMIN anonimiza cuenta con `telegram_chat_id` vinculado — campo nullificado
+- **GIVEN** un usuario con `telegram_chat_id='987654321'` vinculado
+- **WHEN** el ADMIN ejecuta la anonimización sobre esa cuenta
+- **THEN** `users.telegram_chat_id=NULL` y `users.telegram_linked_at=NULL` en BD, AND si el bot de Telegram intentara identificar al usuario por ese `chat_id` en el futuro, la búsqueda `SELECT ... WHERE telegram_chat_id='987654321'` devuelve 0 resultados, AND el usuario ya no puede recibir notificaciones ni comandos del bot vía ese chat_id
+
+## Casos límite
+- Si el usuario a anonimizar ya está en `status=INACTIVE` (desactivado previamente sin anonimizar), la operación de anonimización debe ejecutarse igualmente para sobrescribir los campos personales.
+- Si cualquier paso de la transacción de anonimización falla (ej. error en `UPDATE users`), toda la transacción hace rollback y los datos del usuario permanecen sin cambios; se debe generar un log de error de aplicación sin incluir datos del usuario.
+- El `login` del usuario anonimizado NO se modifica para preservar la unicidad de la restricción y evitar colisiones; el `login` de un usuario anonimizado queda "congelado" y no puede ser reutilizado por otro usuario.
+- La anonimización de `participants.external_name` solo aplica cuando `participants.user_id = {id_usuario_anonimizado}`, es decir, para los registros de participación del propio usuario, no para los jugadores externos (`user_id IS NULL`).
+- En Fase 2, el endpoint de exportación debe responder con `Content-Type: application/json` y `Content-Disposition: attachment; filename="mis-datos-padelpro-{fecha}.json"` para facilitar la descarga.
+- El plazo legal de respuesta al derecho al olvido (Art. 17) es 30 días; PadelPro debe poder ejecutar la anonimización en ese plazo desde la solicitud del titular.
+
+## Dependencias con otras capabilities
+- **`autenticacion`**: el proceso de anonimización revoca `refresh_tokens` e invalida `otp_codes`; también impide futuros logins del usuario anonimizado.
+- **`auditoria`**: la anonimización genera la entrada `USER_ANONYMIZED` en `audit_log` (Requirement 1, Scenario 1), que es inmutable y permanece aunque el usuario sea anonimizado.
+- **`notificaciones`**: tras la anonimización, el usuario no puede recibir notificaciones porque `email` y `telegram_chat_id` han sido nullificados; `MensajeriaPort` debe manejar esta condición sin lanzar excepción.
+- **`reservas`**: las reservas históricas del usuario permanecen intactas con `owner_id` apuntando al usuario anonimizado (que sigue existiendo en la tabla).
+- **`pagos-redsys`**: los pagos históricos permanecen intactos; `registered_by_id` pasa a NULL por FK SET NULL si el usuario anonimizado era el admin que registró pagos en efectivo.

--- a/openspec/specs/notificaciones/spec.md
+++ b/openspec/specs/notificaciones/spec.md
@@ -1,0 +1,113 @@
+# Capability: `notificaciones`
+
+## Resumen
+Gestión del envío de notificaciones automáticas por email y Telegram en respuesta a eventos
+de negocio: confirmación de reserva, cancelación, recordatorio previo al partido y recibo de
+pago. Es una capability interna disparada por los servicios de aplicación de `reservas`,
+`pagos-redsys` y `autenticacion`; no expone ningún endpoint REST directo.
+
+## Fase
+🟢 Fase 1
+
+## Reglas de negocio implicadas
+- **RN-TEL-03**: Solo las cuentas con `telegram_chat_id NOT NULL` reciben notificaciones vía Telegram; las demás solo reciben email.
+- **RN-RGPD-04**: Los logs no deben contener contraseñas, tokens JWT, códigos OTP ni datos de tarjeta; los campos `recipient` y `message` de `notification_log` nunca incluyen esos datos.
+- **RN-NOT-01**: Un fallo en el envío de Telegram (cuenta no vinculada, bot bloqueado, timeout de API) no bloquea el flujo principal de negocio; el sistema continúa y registra el fallo en `notification_log`.
+- **RN-NOT-02**: Un fallo en el envío de email (SMTP caído, timeout) se registra en `notification_log` con `status=FAILED` y se reintenta en el siguiente ciclo del job de reintentos (máx. 3 intentos con backoff exponencial).
+- **RN-NOT-03**: Cada notificación enviada genera un registro en `notification_log` con `status=SENT` o `status=FAILED`.
+
+## Entidades implicadas
+- **`notification_log`**: registro de cada intento de envío de notificación.
+  - `id` (BIGSERIAL PK), `user_id` (FK nullable → `users`), `type` (EMAIL / TELEGRAM_DIRECT / TELEGRAM_GROUP), `recipient`, `subject` (solo email), `message`, `status` (PENDING / SENT / FAILED), `error_message`, `related_entity_type`, `related_entity_id`, `sent_at`, `created_at`.
+- **`users`**: columna `telegram_chat_id` determina elegibilidad para notificaciones Telegram directas; `email` para notificaciones por correo.
+- **`system_config`**: contiene `telegram_bot_token` (cifrado AES-256), `telegram_group_id`, `smtp_host`, `smtp_port`, `smtp_user`, `smtp_password` (cifrado AES-256).
+- **`reservations`**: evento origen de notificaciones de confirmación, cancelación y recordatorio.
+- **`payments`**: evento origen de notificaciones de recibo de pago.
+
+## Endpoints
+Sin endpoint REST directo — procesamiento interno/event-driven.
+Las notificaciones se disparan desde `ReservaApplicationService` y `PagoApplicationService`
+a través del puerto de salida `MensajeriaPort`. El job de recordatorios usa `@Scheduled`.
+
+## Permisos
+| Operación | ADMIN | USER | No autenticado |
+|---|---|---|---|
+| Disparar notificación (interno) | N/A — lógica de aplicación | N/A — lógica de aplicación | — |
+| Consultar `notification_log` (futuro) | — | — | — |
+
+> Nota: en v1.0 no existe endpoint de lectura de `notification_log`. El ADMIN accede a los
+> registros directamente en BD para diagnóstico de fallos.
+
+## Requirements
+
+### Requirement 1: Notificación de confirmación de reserva
+**El sistema DEBE enviar una notificación de confirmación cuando una reserva pase al estado `CONFIRMED`, incluyendo los datos de la pista, fecha, hora, duración e importe total.**
+
+#### Scenario 1: Reserva confirmada con Telegram vinculado — se envían email y Telegram
+- **GIVEN** un usuario con `telegram_chat_id NOT NULL` y `status=ACTIVE` que acaba de confirmar una reserva
+- **WHEN** `ReservaApplicationService` transiciona la reserva al estado `CONFIRMED`
+- **THEN** el sistema envía un email de confirmación a `users.email` con los detalles de la reserva Y envía un mensaje directo por Telegram al `telegram_chat_id` del usuario, Y registra dos entradas en `notification_log` con `status=SENT`
+
+#### Scenario 2: Reserva confirmada sin Telegram vinculado — solo email
+- **GIVEN** un usuario con `telegram_chat_id IS NULL` que acaba de confirmar una reserva
+- **WHEN** `ReservaApplicationService` transiciona la reserva al estado `CONFIRMED`
+- **THEN** el sistema envía únicamente el email de confirmación, Y registra una entrada en `notification_log` con `type=EMAIL` y `status=SENT`, Y no se crea ningún intento de envío Telegram
+
+### Requirement 2: Fallo en el envío de Telegram no bloquea el flujo principal
+**El sistema DEBE continuar el flujo de negocio normal aunque el envío de la notificación por Telegram falle, registrando el error en `notification_log`.**
+
+#### Scenario 3: Envío Telegram falla (bot bloqueado) — flujo principal continúa
+- **GIVEN** un usuario con `telegram_chat_id NOT NULL` cuya reserva acaba de ser confirmada, Y el bot de Telegram está bloqueado por ese usuario
+- **WHEN** `MensajeriaPort` intenta enviar el mensaje Telegram
+- **THEN** la reserva permanece en estado `CONFIRMED`, Y se registra en `notification_log` con `type=TELEGRAM_DIRECT`, `status=FAILED`, `error_message` con la descripción del error de la API de Telegram, Y el email de confirmación se envía igualmente si el SMTP está disponible
+
+#### Scenario 4: Telegram API devuelve timeout — flujo principal no se bloquea
+- **GIVEN** una reserva recién confirmada con usuario que tiene `telegram_chat_id NOT NULL`
+- **WHEN** la llamada a la API de Telegram supera el timeout configurado (10 s lectura)
+- **THEN** la transacción de negocio (reserva `CONFIRMED`) ya está commiteada, Y la notificación Telegram se registra en `notification_log` con `status=FAILED`, Y el sistema no lanza excepción no controlada al hilo principal
+
+### Requirement 3: Fallo SMTP — registro en `notification_log` y reintento
+**El sistema DEBE registrar en `notification_log` con `status=FAILED` cualquier fallo en el envío de email, y reintentarlo automáticamente hasta 3 veces con backoff exponencial.**
+
+#### Scenario 5: SMTP caído — notificación pasa a FAILED y se reintenta
+- **GIVEN** una reserva recién confirmada Y el servidor SMTP está caído
+- **WHEN** `MensajeriaPort` intenta enviar el email de confirmación
+- **THEN** se crea una entrada en `notification_log` con `status=FAILED` y `error_message` describiendo el error SMTP, Y el job de reintentos (`@Scheduled`) detecta la entrada FAILED y reintenta el envío en el siguiente ciclo (máx. 3 intentos), Y si el tercer intento falla, `status` permanece `FAILED` sin más reintentos automáticos
+
+### Requirement 4: Notificación de cancelación de reserva
+**El sistema DEBE enviar una notificación de cancelación cuando una reserva pase al estado `CANCELLED`, indicando el motivo de cancelación si está disponible.**
+
+#### Scenario 6: Reserva cancelada — notificación enviada al titular
+- **GIVEN** una reserva en estado `CONFIRMED` cuyo titular la cancela mediante `DELETE /api/reservas/{id}`
+- **WHEN** `ReservaApplicationService` transiciona la reserva al estado `CANCELLED`
+- **THEN** el sistema envía notificación de cancelación al titular (email siempre, Telegram si `telegram_chat_id NOT NULL`), Y registra las entradas correspondientes en `notification_log`, Y no se envían notificaciones a los participantes que no son titulares en v1.0
+
+### Requirement 5: Notificación de recibo de pago confirmado
+**El sistema DEBE enviar un recibo de pago al titular de la reserva cuando el estado de `payments` pase a `PAID`.**
+
+#### Scenario 7: Pago confirmado vía webhook Redsys — recibo enviado
+- **GIVEN** un pago en estado `IN_PROGRESS` cuyo webhook Redsys válido llega al backend confirmando el pago (Ds_Response en rango 0000-0099)
+- **WHEN** `PagoApplicationService` transiciona el pago a `PAID`
+- **THEN** el sistema envía un recibo de pago al email del titular con importe, fecha y referencia Redsys, Y si el titular tiene `telegram_chat_id NOT NULL` también recibe confirmación por Telegram, Y se registran las entradas correspondientes en `notification_log`
+
+### Requirement 6: Notificación al grupo de Telegram tras confirmar reserva
+**El sistema DEBE publicar un mensaje en el grupo de Telegram configurado en `system_config.telegram_group_id` cuando una reserva pase a `CONFIRMED`, indicando la fecha, hora y plazas disponibles para que otros jugadores puedan unirse.**
+
+#### Scenario 8: Reserva confirmada — mensaje publicado en el grupo
+- **GIVEN** una reserva recién confirmada Y `system_config.telegram_group_id NOT NULL`
+- **WHEN** `ReservaApplicationService` completa la transición a `CONFIRMED`
+- **THEN** el bot publica un mensaje en el grupo con los datos de la reserva y las plazas libres, Y el `reservations.telegram_message_id` se actualiza con el ID del mensaje publicado, Y se registra en `notification_log` con `type=TELEGRAM_GROUP` y `status=SENT`
+
+## Casos límite
+- Si `system_config.telegram_bot_token IS NULL`, no se intentan envíos Telegram; solo email.
+- Si `system_config.telegram_group_id IS NULL`, no se publica en el grupo; solo mensajes directos.
+- Si tanto SMTP como Telegram fallan simultáneamente, ambos quedan registrados en `notification_log` con `status=FAILED`; el flujo de negocio no se revierte.
+- Un usuario anonimizado (RGPD) no recibe notificaciones porque `email` y `telegram_chat_id` han sido nullificados; el sistema omite el envío sin error.
+- El campo `message` de `notification_log` no debe contener códigos OTP, tokens JWT ni contraseñas (RN-RGPD-04).
+- El job de recordatorios no debe disparar notificaciones para reservas en estado `CANCELLED` o `COMPLETED`.
+
+## Dependencias con otras capabilities
+- **`reservas`**: los eventos `RESERVATION_CREATED` y `RESERVATION_CANCELLED` disparan notificaciones.
+- **`pagos-redsys`**: el evento `PAYMENT_CONFIRMED` dispara el recibo de pago.
+- **`autenticacion`**: el flujo de reset de contraseña usa `MensajeriaPort` para enviar el OTP por Telegram.
+- **`auditoria`**: los fallos de envío Telegram con secret inválido generan entradas en `audit_log` con `action=TELEGRAM_WEBHOOK_INVALID_SECRET`.

--- a/openspec/specs/pagos-redsys/spec.md
+++ b/openspec/specs/pagos-redsys/spec.md
@@ -1,0 +1,164 @@
+# Capability: pagos-redsys
+
+## Resumen
+Gestión del ciclo de pago online mediante la pasarela Redsys (HMAC SHA-256) y del registro de pagos en efectivo por parte del ADMIN. Incluye la generación del formulario de pago firmado, el procesamiento del webhook de notificación de Redsys con validación de firma, la idempotencia ante webhooks duplicados, y la visualización del historial de pagos. Los datos de tarjeta (PAN, CVV, fecha de caducidad) nunca son almacenados ni registrados en logs.
+
+## Fase
+🟢 Fase 1
+
+## Reglas de negocio implicadas
+- **RN-AUTH-04**: Un USER solo puede iniciar el pago de una reserva de la que es `owner_id`; los participantes no-owner no pueden iniciar el pago.
+- **RN-RES-03**: El importe del pago se calcula exclusivamente en backend (`price_per_hour × duration_minutes / 60`); el importe enviado por el cliente es ignorado.
+- **RN-PAY-01**: El webhook de Redsys valida la firma HMAC SHA-256 antes de procesar cualquier campo; una firma inválida resulta en rechazo silencioso (200 a Redsys) y registro en `audit_log`.
+- **RN-PAY-02**: Idempotencia de pago: `redsys_order_id` es UNIQUE; un webhook duplicado para un pago ya en `status=PAID` se ignora sin reprocesar.
+- **RN-PAY-03**: Los datos de tarjeta (PAN, CVV, fecha de caducidad, titular) nunca se almacenan ni aparecen en logs; PadelPro solo almacena `redsys_order_id` y `transaction_id` (Ds_AuthorisationCode).
+- **RN-PAY-04**: Las transiciones de estado de pago son unidireccionales: `PENDING → IN_PROGRESS → PAID`; `PAID → REFUNDED`; `PENDING → CANCELLED`; `IN_PROGRESS → FAILED`. No se admite retroceso.
+
+## Entidades implicadas
+
+| Entidad | Tabla | Rol |
+|---|---|---|
+| Pago | `payments` | Entidad principal; creada atómicamente con la reserva en `status=PENDING` |
+| Reserva | `reservations` | Referenciada por el pago; su estado puede actualizarse tras confirmación de pago |
+| Usuario | `users` | El `owner_id` de la reserva inicia el pago; el admin registra pagos en efectivo |
+| Configuración del sistema | `system_config` | Fuente de `redsys_merchant_code`, `redsys_terminal`, `redsys_secret_key` (cifrada AES-256) y `payment_gateway` |
+| Log de auditoría | `audit_log` | Registra todos los eventos de pago: `PAYMENT_INITIATED`, `PAYMENT_CONFIRMED`, `PAYMENT_REJECTED`, `PAYMENT_WEBHOOK_INVALID_SIGNATURE`, `PAYMENT_CASH_REGISTERED` |
+
+## Endpoints
+*(de docs/openapi.yaml)*
+
+| Método | Ruta | Descripción |
+|---|---|---|
+| `POST` | `/api/pagos/iniciar` | Iniciar pago online Redsys (genera URL y parámetros firmados) |
+| `GET` | `/api/pagos` | Listar pagos del usuario autenticado |
+| `POST` | `/api/admin/pagos/{reservaId}/efectivo` | Registrar pago en efectivo (ADMIN) |
+| `GET` | `/api/admin/pagos` | Listar todos los pagos (ADMIN) |
+| Webhook | `POST /api/pagos/webhook` | Notificación de pago Redsys (server-to-server, sin JWT, validado por HMAC) |
+
+## Permisos
+
+| Operación | ADMIN | USER | No autenticado |
+|---|---|---|---|
+| Iniciar pago Redsys (`POST /api/pagos/iniciar`) | Permitido | Permitido (solo si owner) | Denegado (401) |
+| Ver historial de pagos propios (`GET /api/pagos`) | Permitido (ve todos) | Permitido (solo propios) | Denegado (401) |
+| Registrar pago en efectivo (`POST /api/admin/pagos/{reservaId}/efectivo`) | Permitido | Denegado (403) | Denegado (401) |
+| Listar todos los pagos (`GET /api/admin/pagos`) | Permitido | Denegado (403) | Denegado (401) |
+| Webhook Redsys (`POST /api/pagos/webhook`) | No aplica (validación HMAC) | No aplica | Validado por firma HMAC SHA-256 |
+
+---
+
+## Requirements
+
+### Requirement 1: Iniciar pago online — generación de formulario Redsys firmado
+
+**El sistema DEBE generar los parámetros de pago firmados con HMAC SHA-256 y devolver la URL del TPV virtual de Redsys cuando el owner de la reserva inicie el pago (RN-RES-03, RN-PAY-01).**
+
+#### Scenario: USER owner inicia el pago de su reserva correctamente
+- **GIVEN** el usuario autenticado "usuarioA" es `owner_id` de la reserva UUID-X con status `CONFIRMED`
+- **AND** el pago asociado está en `status: PENDING`
+- **AND** `system_config` tiene `redsys_merchant_code`, `redsys_terminal` y `redsys_secret_key` configurados
+- **WHEN** "usuarioA" envía `POST /api/pagos/iniciar` con `reservaId: UUID-X` y `participanteId: <id-del-owner>`
+- **THEN** el sistema responde 200 con `pagoId`, `redsysOrderId`, `redsysUrl`, `amount` y `status: "IN_PROGRESS"`
+- **AND** el campo `amount` corresponde al importe calculado en backend (`price_per_hour × duration_minutes / 60`)
+- **AND** el pago en BD pasa a `status: IN_PROGRESS`
+- **AND** se registra `PAYMENT_INITIATED` en `audit_log`
+
+#### Scenario: USER no-owner intenta iniciar el pago de una reserva ajena (RN-AUTH-04)
+- **GIVEN** el usuario autenticado "usuarioB" es participante (no owner) de la reserva UUID-Y
+- **WHEN** "usuarioB" envía `POST /api/pagos/iniciar` con `reservaId: UUID-Y` y `participanteId: <id-de-usuarioB>`
+- **THEN** el sistema responde 403 con `code: "FORBIDDEN"`
+- **AND** el pago no cambia de estado
+
+#### Scenario: Intento de iniciar pago de reserva no existente
+- **GIVEN** el UUID-INEXISTENTE no corresponde a ninguna reserva
+- **WHEN** un usuario envía `POST /api/pagos/iniciar` con `reservaId: UUID-INEXISTENTE`
+- **THEN** el sistema responde 404 con `code: "NOT_FOUND"`
+
+#### Scenario: El importe del cliente es ignorado (RN-RES-03)
+- **GIVEN** el pago tiene `amount=15.00` calculado en backend para una reserva de 60 min
+- **WHEN** el cliente intenta pasar un importe diferente en el body (campo no previsto en el schema)
+- **THEN** el sistema ignora cualquier campo de importe proveniente del cliente
+- **AND** el parámetro `DS_MERCHANT_AMOUNT` enviado a Redsys corresponde siempre al importe calculado en backend (15.00 EUR = 1500 céntimos)
+
+### Requirement 2: Procesar webhook Redsys con firma válida
+
+**El sistema DEBE validar la firma HMAC SHA-256 del webhook de Redsys y, si es válida, actualizar el estado del pago a `PAID` y registrar el evento en `audit_log` (RN-PAY-01).**
+
+#### Scenario: Webhook Redsys con firma válida — pago aprobado
+- **GIVEN** existe un pago con `redsys_order_id: "ORDER-20250615-001"` en `status: IN_PROGRESS`
+- **WHEN** Redsys envía `POST /api/pagos/webhook` con `Ds_SignatureVersion: "HMAC_SHA256_V1"`, `Ds_MerchantParameters` con `Ds_Response: "0000"` y `Ds_Signature` válida
+- **THEN** el sistema responde 200 (siempre, para que Redsys no reintente)
+- **AND** el pago pasa a `status: PAID` con `paid_at` registrado
+- **AND** `transaction_id` se actualiza con `Ds_AuthorisationCode`
+- **AND** se registra `PAYMENT_CONFIRMED` en `audit_log`
+
+#### Scenario: Webhook Redsys con firma válida — pago rechazado
+- **GIVEN** existe un pago con `redsys_order_id: "ORDER-20250615-002"` en `status: IN_PROGRESS`
+- **WHEN** Redsys envía webhook con `Ds_Response: "0190"` (rechazo) y firma HMAC válida
+- **THEN** el sistema responde 200
+- **AND** el pago pasa a `status: FAILED`
+- **AND** se registra `PAYMENT_REJECTED` en `audit_log`
+
+### Requirement 3: Rechazo silencioso de webhook con firma inválida
+
+**El sistema DEBE ignorar el webhook y registrar el intento cuando la firma HMAC SHA-256 no coincide, respondiendo siempre 200 a Redsys para evitar reintentos (RN-PAY-01).**
+
+#### Scenario: Webhook con firma HMAC inválida
+- **GIVEN** llega un `POST /api/pagos/webhook` con `Ds_Signature` que no corresponde a la clave configurada
+- **WHEN** el sistema calcula la firma esperada y la compara con la recibida
+- **THEN** el sistema responde 200 a Redsys (no revela el rechazo al posible atacante)
+- **AND** el estado del pago en BD no cambia
+- **AND** se registra `PAYMENT_WEBHOOK_INVALID_SIGNATURE` en `audit_log` con nivel CRÍTICO
+- **AND** los datos de la petición no se procesan en ninguna lógica de negocio
+
+### Requirement 4: Idempotencia ante webhooks duplicados
+
+**El sistema DEBE ignorar un webhook duplicado sin reprocesar el pago cuando el `redsys_order_id` ya está en `status=PAID` (RN-PAY-02).**
+
+#### Scenario: Webhook duplicado para un pago ya confirmado
+- **GIVEN** el pago con `redsys_order_id: "ORDER-20250615-003"` está en `status: PAID`
+- **WHEN** Redsys reenvía el mismo webhook con firma válida (reintento automático de Redsys)
+- **THEN** el sistema responde 200
+- **AND** el pago permanece en `status: PAID` sin modificación
+- **AND** no se registra un nuevo `PAYMENT_CONFIRMED` en `audit_log` (o se registra con nota de duplicado)
+
+#### Scenario: Segundo pago con redsys_order_id duplicado (RN-PAY-02)
+- **GIVEN** ya existe un pago con `redsys_order_id: "ORDER-20250615-004"` en cualquier estado
+- **WHEN** el sistema intenta crear un nuevo pago con el mismo `redsys_order_id`
+- **THEN** la constraint UNIQUE de BD rechaza la operación
+- **AND** el sistema devuelve 409 al cliente o maneja el conflicto internamente como idempotencia
+
+### Requirement 5: Registro de pago en efectivo por ADMIN
+
+**El sistema DEBE registrar el pago en efectivo de una reserva y actualizar el estado del pago a `PAID` cuando el ADMIN confirme la recepción del dinero.**
+
+#### Scenario: ADMIN registra pago en efectivo de una reserva pendiente
+- **GIVEN** la reserva UUID-C tiene un pago asociado en `status: PENDING`
+- **AND** un usuario con rol ADMIN autenticado
+- **WHEN** el ADMIN envía `POST /api/admin/pagos/UUID-C/efectivo`
+- **THEN** el sistema responde 200 con `reservaId`, `pagosActualizados` y `totalCobrado`
+- **AND** el pago pasa a `status: PAID`, `method: CASH`, `registered_by_id` apunta al ADMIN que registró el cobro
+- **AND** se registra `PAYMENT_CASH_REGISTERED` en `audit_log`
+
+#### Scenario: USER intenta registrar pago en efectivo (denegado)
+- **GIVEN** un usuario con rol USER autenticado
+- **WHEN** envía `POST /api/admin/pagos/UUID-D/efectivo`
+- **THEN** el sistema responde 403 con `code: "FORBIDDEN"`
+
+#### Scenario: ADMIN intenta registrar pago en efectivo de una reserva ya cobrada
+- **GIVEN** la reserva UUID-E ya tiene su pago en `status: PAID`
+- **WHEN** el ADMIN envía `POST /api/admin/pagos/UUID-E/efectivo`
+- **THEN** el sistema responde 422 indicando que todos los pagos de la reserva ya están completados
+
+## Casos límite
+- Iniciar pago para una reserva en estado `CANCELLED`: el sistema responde 422 indicando que la reserva no admite pagos en ese estado (RN-PAY-04).
+- Iniciar pago cuando el pago ya está en `status: IN_PROGRESS` o `PAID`: el sistema responde 409 (conflicto, ya existe un pago activo o completado).
+- Webhook recibido para un `redsys_order_id` que no existe en BD: el sistema registra alerta en `audit_log` y responde 200 (no revelar inconsistencia a posible atacante).
+- Datos de tarjeta (PAN, CVV, fecha): nunca llegan al backend de PadelPro (el formulario Redsys redirige directamente al TPV de Redsys); si por error llegaran en algún campo de petición, el sistema los ignora y nunca los persiste ni los registra en logs (RN-PAY-03).
+- Comparación de firma HMAC: debe realizarse en tiempo constante para evitar ataques de timing; no usar comparación de strings estándar con cortocircuito.
+- Timeout del webhook: si Redsys no recibe 200 en 30 segundos, reintenta; el sistema debe ser idempotente ante cualquier número de reintentos.
+- Transición inversa (`PAID → PENDING`): denegada; se registra el intento en `audit_log` (RN-PAY-04).
+
+## Dependencias con otras capabilities
+- **reservas**: Cada pago está asociado a una reserva (FK UNIQUE); la reserva se crea atómicamente con el pago en `status=PENDING`. El estado de la reserva puede actualizarse tras la confirmación del pago (ej. `PENDING_CONFIRMATION → CONFIRMED`).
+- **pistas**: La configuración del sistema (incluidas las credenciales Redsys) se gestiona desde la capability `pistas` via `system_config`.

--- a/openspec/specs/partidas/spec.md
+++ b/openspec/specs/partidas/spec.md
@@ -1,0 +1,112 @@
+# Capability: partidas
+
+## Resumen
+Permite a los usuarios ver las reservas con plazas libres (partidas abiertas) y unirse a ellas como participantes adicionales, así como abandonar una reserva en la que ya participan. En PadelPro v1.0 no existe una entidad "partida" separada: una partida pública es una reserva en estado `CONFIRMED` o `PENDING_CONFIRMATION` con `participants_count < system_config.max_participants`. El endpoint `GET /api/reservas/disponibles` con el parámetro `soloDisponibles=true` filtra estas reservas joinables.
+
+## Fase
+🟢 Fase 1
+
+## Reglas de negocio implicadas
+- **RN-AUTH-03**: Un USER no puede unirse dos veces a la misma reserva; el sistema debe detectar la duplicidad y responder 409.
+- **RN-RES-02**: El máximo de participantes por reserva se lee de `system_config.max_participants` (default 4); si la reserva ya tiene el máximo de participantes, no se puede unir ninguno más.
+
+## Entidades implicadas
+
+| Entidad | Tabla | Rol |
+|---|---|---|
+| Reserva | `reservations` | La "partida abierta" es una reserva con plazas libres en status CONFIRMED o PENDING_CONFIRMATION |
+| Participante | `participants` | Al unirse, se crea un nuevo registro con `slot_position` asignado, `is_owner=false`, `user_id` del usuario que se une |
+| Usuario | `users` | Usuario que se une a la reserva; debe estar ACTIVE |
+| Configuración del sistema | `system_config` | Fuente de `max_participants` para validar si quedan plazas |
+
+## Endpoints
+*(de docs/openapi.yaml)*
+
+| Método | Ruta | Descripción |
+|---|---|---|
+| `GET` | `/api/reservas/disponibles` | Consultar disponibilidad (incluye tramos con plazas libres en reservas existentes) |
+| `GET` | `/api/reservas` | Listar reservas del usuario autenticado (para ver en cuáles participa) |
+| `POST` | `/api/reservas/{id}/unirse` | Unirse a una reserva existente como participante adicional |
+
+## Permisos
+
+| Operación | ADMIN | USER | No autenticado |
+|---|---|---|---|
+| Ver tramos con reservas joinables | Permitido | Permitido | Denegado (401) |
+| Unirse a una reserva | Permitido | Permitido | Denegado (401) |
+| Listar propias reservas (incluyendo en las que participa) | Permitido | Permitido | Denegado (401) |
+
+---
+
+## Requirements
+
+### Requirement 1: Ver reservas con plazas libres
+
+**El sistema DEBE devolver los tramos horarios en los que existen reservas con plazas disponibles cuando el usuario autenticado consulta la disponibilidad.**
+
+#### Scenario: USER consulta tramos disponibles y ve una reserva con plazas libres
+- **GIVEN** existe una reserva `CONFIRMED` para 2025-06-15 10:00–11:00 con 2 participantes (max=4)
+- **AND** un usuario autenticado consulta `GET /api/reservas/disponibles?fecha=2025-06-15`
+- **WHEN** la petición llega al sistema
+- **THEN** el sistema responde 200
+- **AND** el tramo 10:00 con `duracionMinutos: 60` aparece en `tramosDisponibles` con `plazasLibres: 2`
+
+#### Scenario: USER no ve plazas libres cuando la reserva está completa
+- **GIVEN** existe una reserva `CONFIRMED` para 2025-06-15 10:00–11:00 con 4 participantes (max=4)
+- **WHEN** un usuario consulta `GET /api/reservas/disponibles?fecha=2025-06-15`
+- **THEN** el tramo 10:00 no aparece en `tramosDisponibles` (0 plazas libres no se devuelve)
+
+### Requirement 2: Unirse a una reserva con plazas disponibles
+
+**El sistema DEBE añadir al usuario autenticado como participante en la reserva y responder 200 con los datos del nuevo participante, siempre que la reserva tenga plazas y el usuario no sea ya participante (RN-AUTH-03, RN-RES-02).**
+
+#### Scenario: USER se une a una reserva con plazas libres
+- **GIVEN** existe la reserva UUID-P con status `CONFIRMED`, 2 participantes y `max_participants=4`
+- **AND** el usuario autenticado "usuarioC" no es participante de UUID-P
+- **WHEN** "usuarioC" envía `POST /api/reservas/UUID-P/unirse`
+- **THEN** el sistema responde 200 con `participanteId`, `reservaId`, `userId`, `nombre` y `statusPago`
+- **AND** la reserva UUID-P tiene ahora 3 participantes
+- **AND** se crea un registro en `participants` con `is_owner: false` para "usuarioC"
+
+#### Scenario: USER intenta unirse a una reserva donde ya es participante (RN-AUTH-03)
+- **GIVEN** el usuario autenticado "usuarioD" ya está en `participants` de la reserva UUID-Q
+- **WHEN** "usuarioD" envía `POST /api/reservas/UUID-Q/unirse`
+- **THEN** el sistema responde 409 con `code: "CONFLICT"` indicando que el usuario ya es participante
+- **AND** no se crea un registro duplicado en `participants`
+
+#### Scenario: USER intenta unirse a una reserva ya completa
+- **GIVEN** la reserva UUID-R tiene `max_participants=4` y 4 participantes actuales
+- **WHEN** un usuario autenticado envía `POST /api/reservas/UUID-R/unirse`
+- **THEN** el sistema responde 422 indicando que la reserva está completa y no admite más participantes
+
+#### Scenario: USER intenta unirse a una reserva que no existe
+- **GIVEN** el UUID-INEXISTENTE no corresponde a ninguna reserva en el sistema
+- **WHEN** un usuario envía `POST /api/reservas/UUID-INEXISTENTE/unirse`
+- **THEN** el sistema responde 404 con `code: "NOT_FOUND"`
+
+### Requirement 3: Listado de reservas en las que el usuario participa
+
+**El sistema DEBE incluir en `GET /api/reservas` las reservas en las que el usuario autenticado aparece como participante (aunque no sea el owner), permitiéndole saber cuáles son sus partidas activas.**
+
+#### Scenario: USER lista sus reservas y ve una en la que es participante no-owner
+- **GIVEN** el usuario autenticado "usuarioE" está en `participants` de la reserva UUID-S como `is_owner: false`
+- **AND** la reserva UUID-S tiene como `owner_id` a "usuarioF"
+- **WHEN** "usuarioE" envía `GET /api/reservas`
+- **THEN** el sistema responde 200
+- **AND** UUID-S aparece en la lista de reservas del usuario
+- **AND** el detalle de UUID-S muestra a "usuarioE" en la lista `participants` con `isOwner: false`
+
+#### Scenario: USER no autenticado intenta ver reservas
+- **GIVEN** una petición sin cabecera `Authorization`
+- **WHEN** envía `POST /api/reservas/UUID-P/unirse`
+- **THEN** el sistema responde 401 con `code: "UNAUTHORIZED"`
+
+## Casos límite
+- Unirse a una reserva en estado `CANCELLED` o `COMPLETED`: el sistema responde 422 indicando que la reserva no admite nuevos participantes en ese estado.
+- El `owner_id` de la reserva intenta unirse de nuevo via `/unirse`: el sistema responde 409 (ya es participante y owner).
+- Unirse a una reserva en estado `PENDING_CONFIRMATION`: la openapi.yaml permite esta operación; la reserva no necesita estar `CONFIRMED` para admitir participantes adicionales.
+- El mismo `user_id` ya registrado como participante externo (con `external_name`) e intenta unirse como usuario registrado: el sistema trata ambas entradas como distintas; aun así, si existe un registro `participants` con `user_id` coincidente, responde 409.
+
+## Dependencias con otras capabilities
+- **reservas**: Las partidas son un subconjunto de reservas. La lógica de creación, estado y cancelación de la reserva base pertenece a la capability `reservas`.
+- **disponibilidad-pistas**: La consulta de disponibilidad (`GET /api/reservas/disponibles`) alimenta también la vista de partidas joinables.

--- a/openspec/specs/pistas/spec.md
+++ b/openspec/specs/pistas/spec.md
@@ -1,0 +1,110 @@
+# Capability: pistas
+
+## Resumen
+Gestión del catálogo de pistas (courts) del club. Permite al ADMIN crear, consultar y cambiar el estado de las pistas (ACTIVA / MANTENIMIENTO). Los USERs pueden listar las pistas disponibles para hacer reservas. Una pista en estado MANTENIMIENTO no admite nuevas reservas, pero las reservas preexistentes no se cancelan automáticamente.
+
+## Fase
+🟢 Fase 1
+
+## Reglas de negocio implicadas
+- **RN-AUTH-01**: Un USER solo puede consultar pistas; nunca crear, modificar ni desactivar.
+- **RN-RES-01**: Las pistas son la unidad sobre la que se valida el anti-solapamiento de franjas horarias.
+- **RN-RES-04**: Una pista en estado MANTENIMIENTO bloquea la creación de nuevas reservas sobre ella; las reservas activas preexistentes se mantienen.
+
+## Entidades implicadas
+
+| Entidad | Tabla | Rol |
+|---|---|---|
+| `system_config` | `system_config` | Fuente de `max_participants` y precio por hora que aplica a las reservas de la pista |
+| `reservations` | `reservations` | Las reservas referencian la pista implícitamente (una sola pista en v1.0) |
+
+> **Nota de modelado v1.0:** En la versión actual PadelPro gestiona una única pista física. El concepto de "pista" está presente en el API a través de la disponibilidad y las reglas de solapamiento (`excl_res_no_overlap`), pero no existe una tabla `courts` separada. Los endpoints de gestión de pistas son los de disponibilidad y configuración del sistema. Esta spec documenta el comportamiento de "gestión de la pista única" tal como se expone a través del API.
+
+## Endpoints
+*(de docs/openapi.yaml)*
+
+| Método | Ruta | Descripción |
+|---|---|---|
+| `GET` | `/api/reservas/disponibles` | Consultar disponibilidad de la pista (tramos libres por fecha) |
+| `GET` | `/api/admin/sistema/config` | Obtener configuración del sistema, incluyendo estado operativo (ADMIN) |
+| `PATCH` | `/api/admin/sistema/config` | Actualizar configuración del sistema (incluye política de pista) (ADMIN) |
+
+## Permisos
+
+| Operación | ADMIN | USER | No autenticado |
+|---|---|---|---|
+| Consultar disponibilidad de la pista | Permitido | Permitido | Denegado (401) |
+| Obtener configuración del sistema | Permitido | Denegado (403) | Denegado (401) |
+| Actualizar configuración del sistema | Permitido | Denegado (403) | Denegado (401) |
+
+---
+
+## Requirements
+
+### Requirement 1: Consulta de disponibilidad de la pista
+
+**El sistema DEBE devolver los tramos horarios con plazas libres para una fecha concreta cuando un usuario autenticado los solicite.**
+
+#### Scenario: USER consulta disponibilidad en un día con franjas libres
+- **GIVEN** un usuario con rol USER autenticado
+- **WHEN** envía `GET /api/reservas/disponibles?fecha=2025-06-15`
+- **THEN** el sistema responde 200 con la lista de `tramosDisponibles`, cada uno con `horaInicio`, `duracionMinutos` y `plazasLibres >= 1`
+
+#### Scenario: USER consulta disponibilidad en un día completamente ocupado
+- **GIVEN** un usuario con rol USER autenticado
+- **AND** todas las franjas del día 2025-06-16 tienen reservas activas (status CONFIRMED o PENDING_CONFIRMATION) que cubren el horario completo del club
+- **WHEN** envía `GET /api/reservas/disponibles?fecha=2025-06-16`
+- **THEN** el sistema responde 200 con `tramosDisponibles` vacío (`[]`)
+
+#### Scenario: Usuario no autenticado intenta consultar disponibilidad
+- **GIVEN** una petición sin cabecera `Authorization`
+- **WHEN** envía `GET /api/reservas/disponibles?fecha=2025-06-15`
+- **THEN** el sistema responde 401
+
+### Requirement 2: Restricción de modificación de configuración a ADMIN
+
+**El sistema DEBE denegar a cualquier usuario con rol USER el acceso a los endpoints de configuración del sistema y devolver 403.**
+
+#### Scenario: USER intenta acceder a configuración del sistema
+- **GIVEN** un usuario con rol USER autenticado con token JWT válido
+- **WHEN** envía `GET /api/admin/sistema/config`
+- **THEN** el sistema responde 403 con `code: "FORBIDDEN"`
+
+#### Scenario: USER intenta modificar la configuración del sistema
+- **GIVEN** un usuario con rol USER autenticado
+- **WHEN** envía `PATCH /api/admin/sistema/config` con body `{"pricePerHour": 5.00}`
+- **THEN** el sistema responde 403
+
+#### Scenario: ADMIN actualiza configuración del sistema con datos válidos
+- **GIVEN** un usuario con rol ADMIN autenticado
+- **WHEN** envía `PATCH /api/admin/sistema/config` con body `{"maxParticipants": 4, "cancellationDeadlineHours": 2}`
+- **THEN** el sistema responde 200 con la configuración actualizada
+- **AND** los campos `maxParticipants` y `cancellationDeadlineHours` reflejan los nuevos valores
+
+### Requirement 3: Bloqueo de nuevas reservas cuando la pista está en mantenimiento
+
+**El sistema DEBE rechazar la creación de nuevas reservas cuando la configuración de la pista indica estado MANTENIMIENTO, sin cancelar las reservas preexistentes.**
+
+#### Scenario: ADMIN deshabilita nuevas reservas poniendo la pista en mantenimiento
+- **GIVEN** existen reservas CONFIRMED para la fecha 2025-07-01
+- **AND** un usuario con rol ADMIN cambia el estado operativo de la pista a MANTENIMIENTO via `PATCH /api/admin/sistema/config`
+- **WHEN** un USER intenta `POST /api/reservas` para el 2025-07-01
+- **THEN** el sistema responde 422 indicando que la pista no está disponible para nuevas reservas
+- **AND** las reservas CONFIRMED preexistentes para el 2025-07-01 permanecen sin cambio
+
+#### Scenario: Consulta de disponibilidad con pista en mantenimiento
+- **GIVEN** la pista está en estado MANTENIMIENTO
+- **WHEN** un USER envía `GET /api/reservas/disponibles?fecha=2025-07-01`
+- **THEN** el sistema responde 200 con `tramosDisponibles` vacío (`[]`)
+- **AND** la respuesta no expone internamente el motivo (mantenimiento vs. ocupación completa) para no revelar información operativa
+
+## Casos límite
+- Consulta de disponibilidad para una fecha en el pasado: el sistema puede responder 200 con lista vacía o 400 según la validación de fecha configurada; en v1.0 se acepta 400.
+- Consulta con `fecha` en formato inválido (ej. `2025-13-40`): el sistema responde 400 con `code: "VALIDATION_ERROR"`.
+- Actualización de `system_config` con `maxParticipants` fuera del rango 1-4: el sistema responde 400.
+- Actualización de `system_config` con `pricePerHour <= 0`: el sistema responde 400.
+- Los campos sensibles (`redsys_secret_key`, `telegram_bot_token`, `smtp_password`) nunca se devuelven en claro en la respuesta de `GET /api/admin/sistema/config` (RN-RGPD-03).
+
+## Dependencias con otras capabilities
+- **reservas**: La disponibilidad de la pista es prerrequisito para crear reservas. La capability `reservas` consume los tramos devueltos por `/api/reservas/disponibles`.
+- **disponibilidad-pistas**: Esta capability es la vista de consulta de disponibilidad; `pistas` es el plano de configuración que la controla.

--- a/openspec/specs/reservas/spec.md
+++ b/openspec/specs/reservas/spec.md
@@ -1,0 +1,172 @@
+# Capability: reservas
+
+## Resumen
+Gestión del ciclo de vida completo de una reserva de pista: creación, consulta, cambio de estado y cancelación. Es la capability central del sistema. Implementa las barreras de anti-solapamiento de franjas horarias, la idempotencia por `Idempotency-Key`, el cálculo de precio en backend y las políticas de cancelación configurables. Toda reserva nace atómica junto con su registro de pago asociado.
+
+## Fase
+🟢 Fase 1
+
+## Reglas de negocio implicadas
+- **RN-AUTH-01**: USER solo puede leer su propia reserva si es `owner_id` o aparece en `participants`.
+- **RN-AUTH-02**: USER solo puede cancelar la reserva de la que es `owner_id`.
+- **RN-RES-01**: Sin solapamiento de franja en la misma pista; doble barrera: `SELECT FOR UPDATE` en Application + `EXCLUDE USING gist` en BD.
+- **RN-RES-02**: Máximo de participantes por reserva leído de `system_config.max_participants` (default 4).
+- **RN-RES-03**: El precio total se calcula exclusivamente en backend (`price_per_hour × duration_minutes / 60`); el importe del cliente es ignorado.
+- **RN-RES-04**: La ventana de cancelación anticipada y la política de reembolso se leen de `system_config.cancellation_deadline_hours`.
+- **RN-RES-05**: Idempotencia: un `POST /api/reservas` con la misma `Idempotency-Key` devuelve la reserva existente sin crear un duplicado.
+- **RN-RGPD-03**: Los errores no exponen datos personales de otros usuarios.
+- **RN-RGPD-04**: Los logs no almacenan contraseñas, tokens, OTPs ni datos de tarjeta.
+
+## Entidades implicadas
+
+| Entidad | Tabla | Rol |
+|---|---|---|
+| Reserva | `reservations` | Entidad principal: fecha, hora, duración, estado, canal, titular |
+| Participante | `participants` | Jugadores asignados a la reserva (1..4); el titular ocupa `slot_position=1` con `is_owner=true` |
+| Pago | `payments` | Creado atómicamente con la reserva; `status=PENDING`, `amount` congelado en el momento de crear |
+| Configuración del sistema | `system_config` | Fuente de `price_per_hour`, `max_participants`, `cancellation_deadline_hours` |
+| Usuario | `users` | Titular (`owner_id`) y participantes registrados |
+| Código OTP | `otp_codes` | Código `RESERVATION_CONFIRM` o `CANCELLATION_CONFIRM` para operaciones críticas vía Telegram |
+
+## Endpoints
+*(de docs/openapi.yaml)*
+
+| Método | Ruta | Descripción |
+|---|---|---|
+| `GET` | `/api/reservas` | Listar reservas del usuario autenticado (owner o participante) |
+| `POST` | `/api/reservas` | Crear nueva reserva |
+| `GET` | `/api/reservas/{id}` | Obtener detalle de una reserva |
+| `DELETE` | `/api/reservas/{id}` | Cancelar reserva (solo el owner o ADMIN) |
+| `GET` | `/api/admin/reservas` | Listar todas las reservas (ADMIN) |
+| `PATCH` | `/api/admin/reservas/{id}/estado` | Cambiar estado de reserva (ADMIN) |
+
+## Permisos
+
+| Operación | ADMIN | USER | No autenticado |
+|---|---|---|---|
+| Listar reservas propias (`GET /api/reservas`) | Permitido (ve todas) | Permitido (solo propias) | Denegado (401) |
+| Crear reserva (`POST /api/reservas`) | Permitido | Permitido | Denegado (401) |
+| Ver detalle de reserva (`GET /api/reservas/{id}`) | Permitido (cualquiera) | Permitido (solo si owner o participante) | Denegado (401) |
+| Cancelar reserva (`DELETE /api/reservas/{id}`) | Permitido (cualquiera) | Permitido (solo si owner) | Denegado (401) |
+| Listar todas las reservas (`GET /api/admin/reservas`) | Permitido | Denegado (403) | Denegado (401) |
+| Cambiar estado de reserva (`PATCH /api/admin/reservas/{id}/estado`) | Permitido | Denegado (403) | Denegado (401) |
+
+---
+
+## Requirements
+
+### Requirement 1: Crear reserva en franja libre
+
+**El sistema DEBE crear la reserva con estado `PENDING_CONFIRMATION` cuando la franja horaria solicitada está libre, el usuario es ACTIVE, y los datos de la petición son válidos.**
+
+#### Scenario: USER crea reserva en franja libre con datos válidos
+- **GIVEN** un usuario con rol USER y estado ACTIVE autenticado
+- **AND** no existe ninguna reserva activa (`status <> 'CANCELLED'`) que solape la franja 2025-06-15 09:00–10:00
+- **WHEN** envía `POST /api/reservas` con `reservationDate: "2025-06-15"`, `startTime: "09:00"`, `durationMinutes: 60`
+- **THEN** el sistema responde 201 con la reserva en estado `PENDING_CONFIRMATION`
+- **AND** el campo `priceTotal` refleja `system_config.price_per_hour × (60/60)` calculado en backend
+- **AND** el creador aparece como participante con `is_owner: true` y `slot_position: 1`
+- **AND** se crea atómicamente un registro en `payments` con `status=PENDING` y el mismo `amount`
+
+#### Scenario: USER crea reserva con participante adicional externo
+- **GIVEN** un usuario con rol USER y estado ACTIVE autenticado
+- **AND** la franja 2025-06-20 11:00–12:30 está libre
+- **WHEN** envía `POST /api/reservas` con `durationMinutes: 90` y `participantesAdicionales: [{externalName: "Carlos García"}]`
+- **THEN** el sistema responde 201 con la reserva en estado `PENDING_CONFIRMATION`
+- **AND** la lista `participants` contiene 2 entradas: el titular (`is_owner: true`) y el participante externo
+
+#### Scenario: Datos de entrada inválidos (fecha pasada)
+- **GIVEN** un usuario autenticado
+- **WHEN** envía `POST /api/reservas` con `reservationDate` igual a una fecha en el pasado
+- **THEN** el sistema responde 400 con `code: "VALIDATION_ERROR"`
+
+### Requirement 2: Rechazo de reserva por conflicto de horario
+
+**El sistema DEBE rechazar la creación de una reserva con 409 cuando ya existe una reserva activa que solapa la misma franja horaria (RN-RES-01).**
+
+#### Scenario: Conflicto de horario directo
+- **GIVEN** existe una reserva activa en la franja 2025-06-15 09:00–10:00 con `status=CONFIRMED`
+- **WHEN** un usuario envía `POST /api/reservas` con `reservationDate: "2025-06-15"`, `startTime: "09:00"`, `durationMinutes: 60`
+- **THEN** el sistema responde 409 con `code: "CONFLICT"` y mensaje indicando que la franja está ocupada
+- **AND** no se crea ninguna nueva reserva ni registro de pago
+
+#### Scenario: Conflicto de horario parcial (solapamiento de inicio)
+- **GIVEN** existe una reserva activa en la franja 2025-06-15 08:00–09:30 con `status=CONFIRMED`
+- **WHEN** un usuario envía `POST /api/reservas` con `startTime: "09:00"`, `durationMinutes: 60` (franja 09:00–10:00 solapa con 08:00–09:30)
+- **THEN** el sistema responde 409 con `code: "CONFLICT"`
+
+#### Scenario: Concurrencia — dos usuarios intentan la misma franja simultáneamente
+- **GIVEN** la franja 2025-06-15 10:00–11:00 está libre
+- **AND** dos usuarios envían `POST /api/reservas` para esa franja simultáneamente
+- **THEN** exactamente uno recibe 201 y el otro recibe 409
+- **AND** el constraint `EXCLUDE USING gist` de la BD garantiza que no se generan dos reservas solapadas bajo ninguna condición de carrera
+
+### Requirement 3: Cancelar reserva dentro del plazo — con reembolso
+
+**El sistema DEBE cancelar la reserva y marcar el pago para reembolso cuando la cancelación se realiza con al menos `cancellation_deadline_hours` de antelación (RN-RES-04).**
+
+#### Scenario: USER cancela su propia reserva con suficiente antelación
+- **GIVEN** un usuario con rol USER es `owner_id` de la reserva UUID-X con status `CONFIRMED`
+- **AND** quedan más de `system_config.cancellation_deadline_hours` horas hasta `reservation_date + start_time`
+- **AND** el pago asociado está en estado `PAID`
+- **WHEN** envía `DELETE /api/reservas/UUID-X`
+- **THEN** el sistema responde 204
+- **AND** la reserva pasa a `status: CANCELLED`
+- **AND** el pago asociado pasa a `status: REFUNDED` (o se inicia el proceso de devolución Redsys)
+
+#### Scenario: USER intenta cancelar la reserva de otro usuario
+- **GIVEN** un usuario con rol USER autenticado como "usuarioB"
+- **AND** la reserva UUID-X tiene `owner_id` correspondiente a "usuarioA"
+- **WHEN** "usuarioB" envía `DELETE /api/reservas/UUID-X`
+- **THEN** el sistema responde 403 con `code: "FORBIDDEN"` (RN-AUTH-02)
+- **AND** la reserva no cambia de estado
+
+### Requirement 4: Cancelar reserva fuera del plazo — sin reembolso
+
+**El sistema DEBE cancelar la reserva sin generar reembolso cuando la cancelación se realiza con menos de `cancellation_deadline_hours` de antelación (RN-RES-04).**
+
+#### Scenario: USER intenta cancelar fuera del plazo permitido
+- **GIVEN** un usuario con rol USER es `owner_id` de la reserva UUID-Y con status `CONFIRMED`
+- **AND** quedan menos de `system_config.cancellation_deadline_hours` horas hasta la reserva
+- **WHEN** envía `DELETE /api/reservas/UUID-Y`
+- **THEN** el sistema responde 422 con mensaje indicando que la cancelación está fuera del plazo permitido
+- **AND** la reserva permanece en estado `CONFIRMED`
+
+#### Scenario: ADMIN cancela una reserva fuera del plazo (bypass de política)
+- **GIVEN** un usuario con rol ADMIN autenticado
+- **AND** la reserva UUID-Z tiene status `CONFIRMED` y la cancelación está fuera del plazo
+- **WHEN** el ADMIN envía `PATCH /api/admin/reservas/UUID-Z/estado` con `status: "CANCELLED"`
+- **THEN** el sistema responde 200 con la reserva en estado `CANCELLED`
+- **AND** la política de plazo no aplica a operaciones administrativas
+
+### Requirement 5: Idempotencia en creación de reserva
+
+**El sistema DEBE devolver la reserva existente sin crear un duplicado cuando recibe una segunda petición `POST /api/reservas` con la misma `Idempotency-Key` (RN-RES-05).**
+
+#### Scenario: Segunda petición con la misma Idempotency-Key
+- **GIVEN** un usuario autenticado envió `POST /api/reservas` con cabecera `Idempotency-Key: abc-123` y recibió 201 con la reserva UUID-W
+- **WHEN** el mismo usuario reenvía `POST /api/reservas` con la misma `Idempotency-Key: abc-123` (ej. reintento de red)
+- **THEN** el sistema responde 201 con los mismos datos de la reserva UUID-W
+- **AND** no se crea ninguna nueva reserva ni nuevo pago
+
+#### Scenario: Petición con Idempotency-Key nueva crea una nueva reserva
+- **GIVEN** un usuario autenticado
+- **WHEN** envía `POST /api/reservas` con `Idempotency-Key: xyz-999` para una franja libre
+- **THEN** el sistema responde 201 creando una nueva reserva
+- **AND** la `Idempotency-Key: xyz-999` queda registrada asociada a esa reserva
+
+## Casos límite
+- Reserva con `durationMinutes` no incluido en `[60, 90, 120, 150, 180]`: el sistema responde 400.
+- Reserva con `startTime` que no es en punto ni en media hora (ej. `09:15`): el sistema responde 400.
+- Reserva con más de `system_config.max_participants - 1` participantes adicionales (el titular ocupa slot 1): el sistema responde 422 con `PARTICIPANTS_LIMIT_EXCEEDED`.
+- Cancelar una reserva ya en estado `CANCELLED`: el sistema responde 422 indicando que la transición no está permitida.
+- Cancelar una reserva con `status: PENDING_CONFIRMATION` y pago `IN_PROGRESS`: el sistema responde 422 hasta que el pago se resuelva, o el ADMIN puede forzar vía endpoint admin.
+- `GET /api/reservas/{id}` por un USER que no es ni owner ni participante: responde 403, nunca 404, para no revelar existencia del recurso (BOLA prevention).
+- Transición de estado `COMPLETED → CONFIRMED` intentada por ADMIN: el sistema responde 422; las transiciones son unidireccionales.
+- Máximo de participantes desde `system_config`: si se cambia `max_participants` a 3, las reservas existentes con 4 participantes no se ven afectadas; solo las nuevas aplican el nuevo límite.
+
+## Dependencias con otras capabilities
+- **pistas**: La creación de reservas verifica disponibilidad de la pista; el estado MANTENIMIENTO bloquea nuevas reservas.
+- **disponibilidad-pistas**: La disponibilidad se calcula a partir de las reservas activas en `reservations`.
+- **partidas**: Las reservas con plazas libres y status `CONFIRMED` o `PENDING_CONFIRMATION` son joinables desde la capability `partidas`.
+- **pagos-redsys**: Cada reserva crea atómicamente un registro de pago; el flujo de pago Redsys referencia el `payments.id` y el `reservations.id`.

--- a/openspec/specs/roles-permisos/spec.md
+++ b/openspec/specs/roles-permisos/spec.md
@@ -1,0 +1,184 @@
+# Capability: roles-permisos
+
+## Resumen
+
+Define y hace cumplir la matriz de control de acceso basada en roles (RBAC) de PadelPro v1.0. Gestiona la asignación del rol `ADMIN` o `USER` a cada cuenta, protege todos los endpoints bajo `/api/admin/**` con verificación de rol en la capa de seguridad, e implementa las reglas de autorización fina que van más allá del rol (verificación de propiedad de recursos). Esta capability es transversal: todas las demás capabilities dependen de ella.
+
+## Fase
+
+Fase 1
+
+## Reglas de negocio implicadas
+
+- **RN-AUTH-01**: Un USER solo puede ver una reserva si es `owner_id` o aparece en `participants`. La verificación ocurre en la capa Application (no en el Controller).
+- **RN-AUTH-02**: Un USER solo puede cancelar su propia reserva (`owner_id = authenticatedUserId`).
+- **RN-AUTH-03**: Un USER no puede unirse dos veces a la misma reserva.
+- **RN-AUTH-04**: Un USER solo puede iniciar pago de una reserva de la que es `owner_id`.
+- **RN-AUTH-05**: Un ADMIN no puede desactivarse a sí mismo.
+
+## Entidades implicadas
+
+**users** (tabla `users`):
+- `id`, `role` (`ADMIN|USER`), `status` (`PENDING|ACTIVE|INACTIVE`)
+
+## Endpoints
+
+Los endpoints de esta capability no tienen rutas propias; la protección se aplica de forma transversal a todos los endpoints del sistema.
+
+**Endpoints protegidos exclusivamente para ADMIN:**
+
+| Método | Path |
+|---|---|
+| `GET` | `/api/admin/usuarios` |
+| `POST` | `/api/admin/usuarios` |
+| `GET` | `/api/admin/usuarios/{id}` |
+| `PATCH` | `/api/admin/usuarios/{id}` |
+| `PATCH` | `/api/admin/usuarios/{id}/aprobar` |
+| `DELETE` | `/api/admin/usuarios/{id}` |
+| `GET` | `/api/admin/reservas` |
+| `PATCH` | `/api/admin/reservas/{id}/estado` |
+| `POST` | `/api/admin/pagos/{reservaId}/efectivo` |
+| `GET` | `/api/admin/pagos` |
+| `GET` | `/api/admin/sistema/config` |
+| `PATCH` | `/api/admin/sistema/config` |
+
+**Endpoints de asignación de rol** (operación incluida en `PATCH /api/admin/usuarios/{id}`):
+
+| Método | Path | Rol requerido |
+|---|---|---|
+| `PATCH` | `/api/admin/usuarios/{id}` | ADMIN — modifica campo `role` |
+
+## Permisos
+
+### Matriz RBAC completa (Fase 1)
+
+| Recurso / Acción | No autenticado | USER | ADMIN |
+|---|---|---|---|
+| `POST /api/auth/login` | Permitido | Permitido | Permitido |
+| `POST /api/auth/register` | Permitido | No aplica | No aplica |
+| `POST /api/auth/refresh` | Permitido | Permitido | Permitido |
+| `POST /api/auth/logout` | Denegado (401) | Permitido | Permitido |
+| `POST /api/auth/password/solicitar-reset` | Permitido | Permitido | Permitido |
+| `POST /api/auth/password/confirmar-reset` | Permitido | Permitido | Permitido |
+| `GET /api/usuarios/me` | Denegado (401) | Permitido | Permitido |
+| `PATCH /api/usuarios/me` | Denegado (401) | Permitido | Permitido |
+| `GET /api/admin/usuarios` | Denegado (401) | Denegado (403) | Permitido |
+| `POST /api/admin/usuarios` | Denegado (401) | Denegado (403) | Permitido |
+| `GET /api/admin/usuarios/{id}` | Denegado (401) | Denegado (403) | Permitido |
+| `PATCH /api/admin/usuarios/{id}` | Denegado (401) | Denegado (403) | Permitido |
+| `PATCH /api/admin/usuarios/{id}/aprobar` | Denegado (401) | Denegado (403) | Permitido |
+| `DELETE /api/admin/usuarios/{id}` | Denegado (401) | Denegado (403) | Permitido (no sobre sí mismo) |
+| `GET /api/reservas/disponibles` | Denegado (401) | Permitido | Permitido |
+| `GET /api/reservas` | Denegado (401) | Permitido (propias) | Permitido (todas) |
+| `POST /api/reservas` | Denegado (401) | Permitido | Permitido |
+| `GET /api/reservas/{id}` | Denegado (401) | Permitido (si owner o participante) | Permitido |
+| `DELETE /api/reservas/{id}` | Denegado (401) | Permitido (solo si owner) | Permitido |
+| `POST /api/reservas/{id}/unirse` | Denegado (401) | Permitido | Permitido |
+| `GET /api/admin/reservas` | Denegado (401) | Denegado (403) | Permitido |
+| `PATCH /api/admin/reservas/{id}/estado` | Denegado (401) | Denegado (403) | Permitido |
+| `GET /api/pagos` | Denegado (401) | Permitido (propios) | Permitido |
+| `POST /api/pagos/iniciar` | Denegado (401) | Permitido (si owner) | Permitido |
+| `POST /api/admin/pagos/{reservaId}/efectivo` | Denegado (401) | Denegado (403) | Permitido |
+| `GET /api/admin/pagos` | Denegado (401) | Denegado (403) | Permitido |
+| `POST /api/otp/verificar` | Denegado (401) | Permitido | Permitido |
+| `GET /api/admin/sistema/config` | Denegado (401) | Denegado (403) | Permitido |
+| `PATCH /api/admin/sistema/config` | Denegado (401) | Denegado (403) | Permitido |
+| `POST /api/bot/telegram` (webhook) | Solo con secret token | No aplica | No aplica |
+| `POST /api/pagos/webhook` (webhook Redsys) | Solo con HMAC | No aplica | No aplica |
+
+> **Leyenda:** Los webhooks de Telegram y Redsys no usan JWT. Se validan por header específico (ver capabilities `auth-otp-telegram` y `pagos-redsys`).
+
+## Requirements
+
+### Requirement 1: Protección de endpoints admin
+
+**El sistema DEBE denegar el acceso a cualquier endpoint bajo `/api/admin/**` para usuarios con rol USER o sin autenticar, devolviendo el código de estado apropiado.**
+
+#### Scenario: USER intenta acceder a endpoint admin
+
+- **GIVEN** un usuario autenticado con `role=USER`
+- **WHEN** se envía `GET /api/admin/usuarios` con su token JWT
+- **THEN** el sistema responde con código `403`
+- **AND** el cuerpo sigue el esquema `ErrorResponse`
+- **AND** la acción se registra en `audit_log` como intento de acceso no autorizado
+
+#### Scenario: Request no autenticado a endpoint admin
+
+- **GIVEN** no se incluye ningún token JWT en la cabecera `Authorization`
+- **WHEN** se envía `GET /api/admin/pagos`
+- **THEN** el sistema responde con código `401`
+- **AND** el cuerpo indica que se requiere autenticación
+
+#### Scenario: ADMIN accede correctamente a endpoint admin
+
+- **GIVEN** un usuario autenticado con `role=ADMIN` y `status=ACTIVE`
+- **WHEN** se envía `GET /api/admin/usuarios` con su token JWT
+- **THEN** el sistema responde con código `200`
+- **AND** devuelve la lista paginada de usuarios
+
+---
+
+### Requirement 2: Asignación de rol por ADMIN
+
+**El sistema DEBE permitir que un ADMIN cambie el rol de cualquier usuario entre ADMIN y USER mediante `PATCH /api/admin/usuarios/{id}`.**
+
+#### Scenario: ADMIN asigna rol ADMIN a un USER
+
+- **GIVEN** un administrador autenticado y un usuario con `role=USER` e `id=55`
+- **WHEN** se envía `PATCH /api/admin/usuarios/55` con body `{ "role": "ADMIN" }`
+- **THEN** el sistema responde con código `200`
+- **AND** el usuario con `id=55` tiene `role=ADMIN` en base de datos
+- **AND** la acción `USER_ROLE_CHANGED` se registra en `audit_log` con el actor y el valor anterior/nuevo
+
+#### Scenario: USER no puede modificar su propio rol
+
+- **GIVEN** un usuario autenticado con `role=USER`
+- **WHEN** se envía `PATCH /api/usuarios/me` con body `{ "role": "ADMIN" }`
+- **THEN** el sistema responde con código `200`
+- **AND** el campo `role` no cambia en base de datos (campo ignorado en el DTO de actualización de perfil propio)
+
+---
+
+### Requirement 3: Autorización fina basada en propiedad de recurso
+
+**El sistema DEBE verificar la propiedad del recurso en la capa Application antes de devolver datos o ejecutar operaciones, independientemente del rol. Esta verificación usa el `userId` del JWT, nunca un parámetro de la petición.**
+
+#### Scenario: USER intenta ver la reserva de otro usuario (RN-AUTH-01)
+
+- **GIVEN** la reserva con `id=abc` pertenece al usuario con `id=10`
+- **AND** el usuario autenticado tiene `id=20` y no es participante de esa reserva
+- **WHEN** se envía `GET /api/reservas/abc` con el token del usuario `id=20`
+- **THEN** el sistema responde con código `403`
+- **AND** la respuesta no revela si la reserva existe (no `404`)
+
+#### Scenario: USER intenta cancelar la reserva de otro usuario (RN-AUTH-02)
+
+- **GIVEN** la reserva con `id=abc` tiene `owner_id=10`
+- **AND** el usuario autenticado tiene `id=20`
+- **WHEN** se envía `DELETE /api/reservas/abc` con el token del usuario `id=20`
+- **THEN** el sistema responde con código `403`
+- **AND** la reserva no se cancela
+
+#### Scenario: USER intenta iniciar pago de reserva ajena (RN-AUTH-04)
+
+- **GIVEN** la reserva con `id=abc` tiene `owner_id=10`
+- **AND** el usuario autenticado tiene `id=20`
+- **WHEN** se envía `POST /api/pagos/iniciar` con `reservaId=abc` y el token del usuario `id=20`
+- **THEN** el sistema responde con código `403`
+- **AND** no se inicia ningún proceso de pago
+
+---
+
+## Casos límite
+
+- Los tokens JWT contienen el `userId` y el `role` en el payload. La capa de seguridad valida la firma y la vigencia del token antes de extraer estos valores.
+- La verificación de propiedad de recurso ocurre siempre en la capa Application (servicio), nunca en el Controller. Esto garantiza que la lógica de acceso no se bypasea por ningún adaptador (web, bot).
+- Un usuario con `status=PENDING` o `status=INACTIVE` que tenga un token válido (generado antes de cambiar su estado) recibe `403` en todos los endpoints protegidos.
+- Los endpoints de webhook (`/api/bot/telegram`, `/api/pagos/webhook`) no usan JWT. Su validación es por header específico y están configurados como `permitAll()` en Spring Security, delegando la validación al adaptador correspondiente.
+
+## Dependencias con otras capabilities
+
+- **Todas las capabilities**: esta capability es transversal. Todas las demás dependen de la capa RBAC para proteger sus endpoints.
+- **`auth-local`**: proporciona el JWT que contiene los claims `userId` y `role` usados por la verificación de acceso.
+- **`usuarios`**: la asignación de rol se implementa en la capability `usuarios` (endpoint `PATCH /api/admin/usuarios/{id}`).
+- **`auditoria`**: los accesos denegados (403) se registran en `audit_log`.

--- a/openspec/specs/usuarios/spec.md
+++ b/openspec/specs/usuarios/spec.md
@@ -1,0 +1,154 @@
+# Capability: usuarios
+
+## Resumen
+
+Gestiona el perfil del usuario autenticado (lectura y actualización de datos propios), la administración de cuentas por parte del ADMIN (creación directa, aprobación de registros pendientes, actualización de datos y desactivación), y el derecho de acceso a datos propios según el RGPD. El borrado de usuarios es siempre una anonimización lógica, nunca un hard delete.
+
+## Fase
+
+Fase 1
+
+## Reglas de negocio implicadas
+
+- **RN-AUTH-05**: Un ADMIN no puede desactivarse a sí mismo.
+- **RN-AUTH-08**: Las contraseñas creadas o actualizadas cumplen la política: mínimo 8 chars + 1 mayúscula + 1 número; máximo 128 chars; BCrypt cost 12.
+- **RN-RGPD-01**: La eliminación de usuario es anonimización (no hard delete); genera entrada en `audit_log` con acción `USER_ANONYMIZED`.
+- **RN-RGPD-02**: Los datos de cuenta se retienen durante la vida de la cuenta más 5 años tras la inactivación.
+- **RN-RGPD-03**: Las respuestas de error no exponen datos personales de otros usuarios.
+
+## Entidades implicadas
+
+**users** (tabla `users`):
+- `id`, `login`, `password_hash`, `first_name`, `last_name`, `phone`, `email`, `status` (`PENDING|ACTIVE|INACTIVE`), `role` (`ADMIN|USER`), `telegram_chat_id`, `telegram_linked_at`, `registered_at`, `updated_at`
+
+## Endpoints
+
+| Método | Path | OperationId | Autenticación |
+|---|---|---|---|
+| `GET` | `/api/usuarios/me` | `getMiPerfil` | JWT requerido |
+| `PATCH` | `/api/usuarios/me` | `actualizarMiPerfil` | JWT requerido |
+| `GET` | `/api/admin/usuarios` | `listarUsuarios` | JWT requerido (ADMIN) |
+| `POST` | `/api/admin/usuarios` | `crearUsuario` | JWT requerido (ADMIN) |
+| `GET` | `/api/admin/usuarios/{id}` | `getUsuario` | JWT requerido (ADMIN) |
+| `PATCH` | `/api/admin/usuarios/{id}` | `actualizarUsuario` | JWT requerido (ADMIN) |
+| `PATCH` | `/api/admin/usuarios/{id}/aprobar` | `aprobarUsuario` | JWT requerido (ADMIN) |
+| `DELETE` | `/api/admin/usuarios/{id}` | `desactivarUsuario` | JWT requerido (ADMIN) |
+
+## Permisos
+
+| Operación | ADMIN | USER | No autenticado |
+|---|---|---|---|
+| `GET /api/usuarios/me` | Permitido (propio) | Permitido (propio) | Denegado (401) |
+| `PATCH /api/usuarios/me` | Permitido (propio) | Permitido (propio) | Denegado (401) |
+| `GET /api/admin/usuarios` | Permitido | Denegado (403) | Denegado (401) |
+| `POST /api/admin/usuarios` | Permitido | Denegado (403) | Denegado (401) |
+| `GET /api/admin/usuarios/{id}` | Permitido | Denegado (403) | Denegado (401) |
+| `PATCH /api/admin/usuarios/{id}` | Permitido | Denegado (403) | Denegado (401) |
+| `PATCH /api/admin/usuarios/{id}/aprobar` | Permitido | Denegado (403) | Denegado (401) |
+| `DELETE /api/admin/usuarios/{id}` | Permitido (no sobre sí mismo) | Denegado (403) | Denegado (401) |
+
+## Requirements
+
+### Requirement 1: Consulta y actualización del perfil propio
+
+**El sistema DEBE permitir que cualquier usuario autenticado consulte y actualice sus propios datos de perfil. Los campos `role` y `status` son de solo lectura para el propio usuario.**
+
+#### Scenario: USER consulta su propio perfil
+
+- **GIVEN** un usuario autenticado con `role=USER`
+- **WHEN** se envía `GET /api/usuarios/me` con su token JWT
+- **THEN** el sistema responde con código `200`
+- **AND** el cuerpo contiene `id`, `login`, `firstName`, `lastName`, `email`, `phone`, `status`, `role`, y el estado de vinculación de Telegram
+- **AND** la respuesta no incluye `password_hash` ni datos de otros usuarios
+
+#### Scenario: USER actualiza campos permitidos de su perfil
+
+- **GIVEN** un usuario autenticado con `role=USER`
+- **WHEN** se envía `PATCH /api/usuarios/me` con `firstName`, `lastName`, `email` o `phone` nuevos y válidos
+- **THEN** el sistema responde con código `200`
+- **AND** los campos actualizados se persisten en base de datos
+- **AND** `updated_at` se actualiza al momento actual
+
+#### Scenario: USER no puede modificar su propio rol ni estado
+
+- **GIVEN** un usuario autenticado con `role=USER`
+- **WHEN** se envía `PATCH /api/usuarios/me` con body que incluye `role: "ADMIN"` o `status: "ACTIVE"`
+- **THEN** el sistema responde con código `200` pero los campos `role` y `status` no cambian en base de datos
+- **AND** el sistema ignora silenciosamente los campos no permitidos (deserialización restrictiva)
+
+#### Scenario: Conflicto al actualizar email ya registrado
+
+- **GIVEN** otro usuario tiene el email `otro@example.com`
+- **WHEN** el usuario autenticado envía `PATCH /api/usuarios/me` con `email=otro@example.com`
+- **THEN** el sistema responde con código `409`
+- **AND** el mensaje indica conflicto de email sin revelar datos del otro usuario (RN-RGPD-03)
+
+---
+
+### Requirement 2: Administración de usuarios por ADMIN
+
+**El sistema DEBE permitir que el ADMIN cree usuarios directamente (sin proceso de aprobación), apruebe registros pendientes y actualice cualquier campo incluidos `role` y `status`.**
+
+#### Scenario: ADMIN crea usuario directamente con estado ACTIVE
+
+- **GIVEN** un administrador autenticado con `role=ADMIN`
+- **WHEN** se envía `POST /api/admin/usuarios` con datos válidos de un nuevo usuario
+- **THEN** el sistema responde con código `201`
+- **AND** el usuario se crea con `status=ACTIVE` (sin paso de aprobación)
+- **AND** la contraseña se almacena como BCrypt cost 12 (RN-AUTH-08)
+
+#### Scenario: ADMIN aprueba cuenta en estado PENDING
+
+- **GIVEN** existe un usuario con `status=PENDING` (auto-registrado, no aprobado)
+- **WHEN** se envía `PATCH /api/admin/usuarios/{id}/aprobar`
+- **THEN** el sistema responde con código `200`
+- **AND** el usuario pasa a `status=ACTIVE`
+- **AND** se registra la acción `USER_APPROVED` en `audit_log`
+
+#### Scenario: ADMIN intenta aprobar cuenta que no está en PENDING
+
+- **GIVEN** existe un usuario con `status=ACTIVE` o `status=INACTIVE`
+- **WHEN** se envía `PATCH /api/admin/usuarios/{id}/aprobar`
+- **THEN** el sistema responde con código `422`
+- **AND** el mensaje indica que el usuario no está en estado PENDING
+
+#### Scenario: ADMIN desactiva un usuario (soft-delete / borrado lógico — RN-RGPD-01)
+
+- **GIVEN** existe un usuario con `status=ACTIVE` cuyo `id` es diferente al del ADMIN autenticado
+- **WHEN** se envía `DELETE /api/admin/usuarios/{id}`
+- **THEN** el sistema responde con código `204`
+- **AND** el usuario pasa a `status=INACTIVE`
+- **AND** el registro permanece en base de datos con sus datos intactos
+- **AND** se registra la acción `USER_DEACTIVATED` en `audit_log`
+
+---
+
+### Requirement 3: Protección de la identidad del ADMIN (RN-AUTH-05)
+
+**El sistema DEBE impedir que un ADMIN se desactive a sí mismo.**
+
+#### Scenario: ADMIN intenta desactivarse a sí mismo
+
+- **GIVEN** un administrador autenticado cuyo `id` es `42`
+- **WHEN** se envía `DELETE /api/admin/usuarios/42` con el token JWT del propio admin
+- **THEN** el sistema responde con código `422`
+- **AND** el mensaje indica que un administrador no puede desactivarse a sí mismo
+- **AND** el estado del admin no cambia en base de datos
+
+---
+
+## Casos límite
+
+- El `login` de un usuario nunca cambia una vez creado; no hay endpoint para modificarlo.
+- La lista de usuarios (`GET /api/admin/usuarios`) está paginada (máximo 100 por página) y soporta filtrado por `status`.
+- Si se intenta crear un usuario con `login`, `email` o `phone` duplicado, el sistema responde `409`.
+- Un usuario en estado `INACTIVE` no puede autenticarse. Si intenta hacer login, recibe `403`.
+- El campo `telegram_chat_id` solo puede modificarse a través del flujo de vinculación/desvinculación (capability `auth-otp-telegram`), no directamente en `PATCH /api/usuarios/me` ni en `PATCH /api/admin/usuarios/{id}`.
+
+## Dependencias con otras capabilities
+
+- **`auth-local`**: el registro crea el usuario en estado `PENDING`; la aprobación es responsabilidad de esta capability.
+- **`auth-otp-telegram`**: la vinculación Telegram modifica `telegram_chat_id` en la entidad `users`.
+- **`roles-permisos`**: los endpoints `/api/admin/usuarios/**` están protegidos por la capa RBAC que verifica `role=ADMIN`.
+- **`auditoria`**: cada operación administrativa (creación, aprobación, desactivación, cambio de rol) genera una entrada en `audit_log`.
+- **`exportaciones-rgpd`**: la anonimización completa de datos personales (derecho de supresión RGPD) se implementa como extensión del endpoint `DELETE /api/admin/usuarios/{id}`.


### PR DESCRIPTION
## Resumen

- Añadida sección `## Mockups asociados` a los 14 specs de `openspec/specs/*/spec.md` con tabla de pantallas, permisos y links directos a los HTMLs de alta fidelidad.
- Añadida sección `## Cruce con OpenSpec` en `docs/ux/README.md` con tabla inversa capability → pantallas, permitiendo navegar bidireccional entre spec funcional y mockup visual.
- Validados 25 links relativos entre specs y mockups — todos OK.

## Tabla de cruce capability → pantallas

| Capability | Pantallas UX |
|---|---|
| `auth-local` | [01-login](docs/ux/mockups/01-login.html), [02-registro](docs/ux/mockups/02-registro.html), [03-recuperar-password](docs/ux/mockups/03-recuperar-password.html) |
| `auth-otp-telegram` | [11-verificar-otp](docs/ux/mockups/11-verificar-otp.html) |
| `usuarios` | [02-registro](docs/ux/mockups/02-registro.html), [20-perfil](docs/ux/mockups/20-perfil.html), [21-editar-perfil](docs/ux/mockups/21-editar-perfil.html), [24-eliminar-cuenta](docs/ux/mockups/24-eliminar-cuenta.html) |
| `roles-permisos` | [06-dashboard-club](docs/ux/mockups/06-dashboard-club.html) |
| `configuracion-club` | [06-dashboard-club](docs/ux/mockups/06-dashboard-club.html) |
| `pistas` | [04-home](docs/ux/mockups/04-home.html), [08-pistas](docs/ux/mockups/08-pistas.html), [09-reservar](docs/ux/mockups/09-reservar.html) |
| `reservas` | [04-home](docs/ux/mockups/04-home.html), [05-mis-reservas](docs/ux/mockups/05-mis-reservas.html), [09-reservar](docs/ux/mockups/09-reservar.html), [10-pago](docs/ux/mockups/10-pago.html), [12-confirmacion-reserva](docs/ux/mockups/12-confirmacion-reserva.html), [13-detalle-reserva](docs/ux/mockups/13-detalle-reserva.html), [14-cancelar-reserva](docs/ux/mockups/14-cancelar-reserva.html) |
| `partidas` | [15-unirse-partida](docs/ux/mockups/15-unirse-partida.html), [16-detalle-partida](docs/ux/mockups/16-detalle-partida.html) |
| `pagos-redsys` | [10-pago](docs/ux/mockups/10-pago.html), [11-verificar-otp](docs/ux/mockups/11-verificar-otp.html), [12-confirmacion-reserva](docs/ux/mockups/12-confirmacion-reserva.html) |
| `disponibilidad-pistas` | [04-home](docs/ux/mockups/04-home.html), [08-pistas](docs/ux/mockups/08-pistas.html), [09-reservar](docs/ux/mockups/09-reservar.html) |
| `notificaciones` | [17-notificaciones](docs/ux/mockups/17-notificaciones.html) |
| `auditoria` | [06-dashboard-club](docs/ux/mockups/06-dashboard-club.html) |
| `exportaciones-rgpd` | [22-mis-datos](docs/ux/mockups/22-mis-datos.html), [23-exportar-datos](docs/ux/mockups/23-exportar-datos.html), [24-eliminar-cuenta](docs/ux/mockups/24-eliminar-cuenta.html) |
| `administracion-club` | [06-dashboard-club](docs/ux/mockups/06-dashboard-club.html) |

## Issues vinculados

- Branch: `feat/openspec-ux-link`
- OpenSpec change: `openspec/specs/` (14 capabilities actualizadas)
- UX docs: `docs/ux/README.md`

## Commits incluidos

- `9d10d84` — docs(openspec): añadir sección Mockups asociados a cada spec
- `f27dc25` — docs(ux): añadir tabla de cruce con OpenSpec en README

## Plan de validación

- [ ] Verificar que los 25 links relativos entre specs y mockups son navegables
- [ ] Confirmar que la tabla de cruce en README.md es consistente con las secciones en cada spec
- [ ] Revisar formato Markdown en los 14 specs
- [ ] Aprobar PR

🤖 Generado con Claude Code (orchestrator agent)