### PR TITLE
feat(openspec): change bootstrap-mvp · andamiaje + auth-local

### DIFF
--- a/docs/ux/README.md
+++ b/docs/ux/README.md
@@ -306,3 +306,26 @@ Las siguientes diferencias se encontraron entre la tabla de tareas proporcionada
 | Admin sidebar (pantallas 17–19) | Nav items | Variable | Pantalla 17 incluye item "Política" en sidebar; pantallas 18–19 no lo incluyen |
 
 Ninguna discrepancia afecta a capability, endpoint principal o permisos de forma material.
+
+---
+
+## Cruce con OpenSpec
+
+Tabla inversa: cada capability de `openspec/specs/` con sus pantallas UX asociadas. Mantenida sincronizada con las secciones `## Mockups asociados` de cada spec.
+
+| Capability | Spec | Pantallas |
+|---|---|---|
+| `auth-local` | [`openspec/specs/auth-local/spec.md`](../openspec/specs/auth-local/spec.md) | 01, 02, 03, 04, 05 |
+| `usuarios` | [`openspec/specs/usuarios/spec.md`](../openspec/specs/usuarios/spec.md) | 03, 13 |
+| `auth-otp-telegram` | [`openspec/specs/auth-otp-telegram/spec.md`](../openspec/specs/auth-otp-telegram/spec.md) | 13, 14, 15 |
+| `reservas` | [`openspec/specs/reservas/spec.md`](../openspec/specs/reservas/spec.md) | 06, 08, 10, 11, 12, 22, 23 |
+| `disponibilidad-pistas` | [`openspec/specs/disponibilidad-pistas/spec.md`](../openspec/specs/disponibilidad-pistas/spec.md) | 06, 07, 22 |
+| `pagos-redsys` | [`openspec/specs/pagos-redsys/spec.md`](../openspec/specs/pagos-redsys/spec.md) | 08, 09, 10, 18, 23 |
+| `notificaciones` | [`openspec/specs/notificaciones/spec.md`](../openspec/specs/notificaciones/spec.md) | 10 |
+| `partidas` | [`openspec/specs/partidas/spec.md`](../openspec/specs/partidas/spec.md) | 16, 17, 18 |
+| `exportaciones-rgpd` | [`openspec/specs/exportaciones-rgpd/spec.md`](../openspec/specs/exportaciones-rgpd/spec.md) | 19, 20 |
+| `auditoria` | [`openspec/specs/auditoria/spec.md`](../openspec/specs/auditoria/spec.md) | 20 |
+| `administracion-club` | [`openspec/specs/administracion-club/spec.md`](../openspec/specs/administracion-club/spec.md) | 21 |
+| `pistas` | [`openspec/specs/pistas/spec.md`](../openspec/specs/pistas/spec.md) | 24 |
+| `roles-permisos` | [`openspec/specs/roles-permisos/spec.md`](../openspec/specs/roles-permisos/spec.md) | — (transversal) |
+| `configuracion-club` | [`openspec/specs/configuracion-club/spec.md`](../openspec/specs/configuracion-club/spec.md) | — (backend) |

--- a/openspec/changes/bootstrap-mvp/design.md
+++ b/openspec/changes/bootstrap-mvp/design.md
@@ -60,10 +60,11 @@
 }
 ```
 
-**Regla:** Los endpoints `POST /api/auth/login` y `POST /api/auth/register` **nunca** revelan si el email ya existe en el sistema. El mensaje de error es idéntico para:
+**Regla:** Los endpoints `POST /api/auth/login` y `POST /api/auth/register` aplican anti-enumeración para credenciales incorrectas. La respuesta es idéntica para:
 - Email no registrado + contraseña cualquiera → 401
 - Email registrado + contraseña incorrecta → 401
-- Cuenta desactivada → 401 (mismo mensaje; no revelar estado de cuenta)
+
+**Excepción de estado de cuenta:** Las cuentas en estado `PENDING` o `INACTIVE` devuelven **403 Forbidden** (no 401). Esto es coherente con el contrato `docs/openapi.yaml` y permite al usuario saber que su cuenta existe pero no está activa — el ADMIN debe aprobarla con `PATCH /api/admin/usuarios/{id}/aprobar`. No viola la anti-enumeración porque el 403 ocurre solo cuando las credenciales son correctas.
 
 **Excepción justificada:** El registro (`POST /api/auth/register`) devuelve 409 Conflict si el email ya existe, porque el usuario *debe* saber que ya tiene cuenta para no crear un duplicado. Sin embargo, el cuerpo del 409 solo dice `"error": "EMAIL_ALREADY_REGISTERED"` sin confirmar si la cuenta está activa o desactivada.
 
@@ -102,12 +103,12 @@ Este diseño cumple con RN-RGPD-03 (las respuestas no exponen datos de otros usu
 | `last_name` | `VARCHAR(100)` | NOT NULL | Requerido en registro. |
 | `email` | `VARCHAR(255)` | UNIQUE NOT NULL | Igual que `login` en v1.0; separado para facilitar migración futura. |
 | `role` | `ENUM('ADMIN','USER')` | NOT NULL DEFAULT 'USER' | Solo dos roles en v1.0. |
-| `status` | `ENUM('PENDING','ACTIVE','INACTIVE')` | NOT NULL DEFAULT 'ACTIVE' | `PENDING` si se requiere verificación (change futuro). |
+| `status` | `ENUM('PENDING','ACTIVE','INACTIVE')` | NOT NULL DEFAULT 'PENDING' | Cambia a `ACTIVE` cuando ADMIN aprueba con `PATCH /api/admin/usuarios/{id}/aprobar`. |
 | `registered_at` | `TIMESTAMPTZ` | NOT NULL DEFAULT NOW() | Inmutable. |
 | `updated_at` | `TIMESTAMPTZ` | NOT NULL DEFAULT NOW() | Actualizado por trigger. |
 | `last_login_at` | `TIMESTAMPTZ` | NULLABLE | Actualizado en cada login exitoso. |
 
-**Nota de diseño:** `status = 'PENDING'` existe en el schema para el change de verificación de email, pero en `bootstrap-mvp` todos los registros nacen como `ACTIVE`. El campo se incluye ahora para evitar migraciones rupturistas más adelante.
+**Nota de diseño:** En `bootstrap-mvp` los registros nacen como `PENDING` (contrato `docs/openapi.yaml`). El campo cambia a `ACTIVE` cuando el ADMIN aprueba al usuario. El campo `INACTIVE` se usa para desactivar cuentas existentes (change `usuarios`).
 
 **Tabla `refresh_tokens`** (Flyway V2 — ver `docs/data-model.md`):
 

--- a/openspec/changes/bootstrap-mvp/design.md
+++ b/openspec/changes/bootstrap-mvp/design.md
@@ -83,13 +83,7 @@ Este diseño cumple con RN-RGPD-03 (las respuestas no exponen datos de otros usu
 | Longitud máxima | 128 caracteres | RN-AUTH-08 |
 | Mayúscula requerida | Sí (≥1) | RN-AUTH-08 |
 | Número requerido | Sí (≥1) | RN-AUTH-08 |
-| Símbolo requerido | **No especificado en fuente autoritativa** | Ver nota |
-
-<!-- DECISION-PENDING: el brief de diseño mencionó "una mayúscula, un número, un símbolo" como política.
-     Sin embargo, RN-AUTH-08 (fuente autoritativa: docs/openapi.yaml > docs/security-design.md) solo especifica
-     "mínimo 8 caracteres + 1 mayúscula + 1 número". No hay referencia a símbolo requerido.
-     La pantalla 10-nueva-password.html (pantalla de reset, change futuro) deberá mostrar la política vigente.
-     Se adopta RN-AUTH-08 sin el símbolo. Requiere validación de lcasadov antes de pasar el change a "approved". -->
+| Símbolo requerido | **No** — validado con `lcasadov` el 2026-05-23 | RN-AUTH-08; símbolo descartado |
 
 **Implementación:** Regex de validación en el servicio de dominio (no en el controlador). La validación es responsabilidad del backend; el frontend puede replicarla para UX pero el backend es la única fuente de verdad.
 

--- a/openspec/changes/bootstrap-mvp/design.md
+++ b/openspec/changes/bootstrap-mvp/design.md
@@ -1,0 +1,162 @@
+# Design: Bootstrap MVP — auth-local
+
+**Change slug:** `bootstrap-mvp`
+**Capability:** `auth-local`
+**Estado:** proposed
+**Fuente autoritativa de referencia:** `docs/security-design.md`, `docs/openapi.yaml`, `docs/data-model.md`
+
+---
+
+## Decisión 1 — Algoritmo de hashing de contraseñas
+
+**Decisión:** BCrypt con factor de coste 12.
+
+**Justificación:**
+- RN-AUTH-08 lo especifica explícitamente: *"hash BCrypt cost 12"*.
+- BCrypt está recomendado por OWASP ASVS v4 §2.4 como opción adecuada cuando el hardware es predecible (instalaciones On-Premise de gama media).
+- Cost 12 produce ~300 ms de hash en hardware moderno de servidor, suficiente para ralentizar ataques de fuerza bruta sin impactar UX (el usuario percibe el login como inmediato).
+
+**Alternativa documentada:** Argon2id (OWASP ASVS §2.4 lo prefiere en hardware moderno). Si el equipo decide migrar, el campo `password_hash` es opaco para la API; el cambio es interno al servicio de autenticación y no rompe el contrato.
+
+**Implementación en Spring Boot:**
+- Dependencia: `spring-security-crypto` (incluida en `spring-boot-starter-security`).
+- Bean: `BCryptPasswordEncoder(12)`.
+- Nunca registrar en logs el valor plano ni el hash (RN-RGPD-04).
+
+---
+
+## Decisión 2 — Formato del token de sesión
+
+**Decisión:** JWT firmado con HS256 (HMAC-SHA256), doble token (access + refresh).
+
+| Parámetro | Valor | Fuente |
+|---|---|---|
+| Algoritmo de firma | HS256 | `docs/security-design.md §2.2` |
+| Duración access token | 15 minutos | RN-AUTH-09 / `security-design.md §2.3` |
+| Duración refresh token | 7 días | RN-AUTH-09 |
+| Almacenamiento access | Memoria JavaScript (no localStorage, no sessionStorage) | RN-AUTH-09 |
+| Almacenamiento refresh | Cookie httpOnly, SameSite=Strict, Secure | RN-AUTH-09 |
+| Claims del access token | `sub` (user_id), `role`, `iat`, `exp` | `openapi.yaml` — securitySchemes `bearerAuth` |
+| Claims del refresh token | `sub` (user_id), `jti` (UUID v4), `iat`, `exp` | Decisión interna |
+
+**Por qué HS256 y no RS256:**
+- PadelPro es una instalación On-Premise monolítica. No hay múltiples servicios que necesiten verificar tokens con una clave pública distribuida.
+- HS256 es más simple de gestionar en un entorno Docker Compose donde el secreto puede almacenarse como variable de entorno.
+- RS256 se justifica cuando hay microservicios o terceros que necesitan verificar tokens sin acceso al secreto. No es el caso en v1.0.
+
+**Nota de conflicto documentado:** `README.md §3.7` indica 8 horas para el access token. La fuente autoritativa es `docs/security-design.md §2.3` (15 minutos). Se usa 15 minutos. Seguimiento: `openspec/AGENTS.md §6`.
+
+---
+
+## Decisión 3 — Formato de respuesta de error en endpoints de auth
+
+**Decisión:** Respuesta genérica anti-enumeración.
+
+```json
+{
+  "error": "AUTH_INVALID_CREDENTIALS",
+  "message": "Credenciales inválidas",
+  "timestamp": "2026-05-23T10:00:00Z"
+}
+```
+
+**Regla:** Los endpoints `POST /api/auth/login` y `POST /api/auth/register` **nunca** revelan si el email ya existe en el sistema. El mensaje de error es idéntico para:
+- Email no registrado + contraseña cualquiera → 401
+- Email registrado + contraseña incorrecta → 401
+- Cuenta desactivada → 401 (mismo mensaje; no revelar estado de cuenta)
+
+**Excepción justificada:** El registro (`POST /api/auth/register`) devuelve 409 Conflict si el email ya existe, porque el usuario *debe* saber que ya tiene cuenta para no crear un duplicado. Sin embargo, el cuerpo del 409 solo dice `"error": "EMAIL_ALREADY_REGISTERED"` sin confirmar si la cuenta está activa o desactivada.
+
+Este diseño cumple con RN-RGPD-03 (las respuestas no exponen datos de otros usuarios) y la regla anti-enumeración de OWASP API Security Top 10 (API3:2023).
+
+**Escenario UX:** La pantalla `01-login.html` muestra un único mensaje de error genérico. La pantalla `08-crear-cuenta.html` muestra un mensaje diferente si el email ya existe (409), lo que es aceptable porque es el flujo de registro propio del usuario.
+
+---
+
+## Decisión 4 — Política de contraseñas mínima
+
+**Decisión** (propuesta inicial — requiere validación humana):
+
+| Criterio | Valor | Fuente |
+|---|---|---|
+| Longitud mínima | 8 caracteres | RN-AUTH-08 |
+| Longitud máxima | 128 caracteres | RN-AUTH-08 |
+| Mayúscula requerida | Sí (≥1) | RN-AUTH-08 |
+| Número requerido | Sí (≥1) | RN-AUTH-08 |
+| Símbolo requerido | **No especificado en fuente autoritativa** | Ver nota |
+
+<!-- DECISION-PENDING: el brief de diseño mencionó "una mayúscula, un número, un símbolo" como política.
+     Sin embargo, RN-AUTH-08 (fuente autoritativa: docs/openapi.yaml > docs/security-design.md) solo especifica
+     "mínimo 8 caracteres + 1 mayúscula + 1 número". No hay referencia a símbolo requerido.
+     La pantalla 10-nueva-password.html (pantalla de reset, change futuro) deberá mostrar la política vigente.
+     Se adopta RN-AUTH-08 sin el símbolo. Requiere validación de lcasadov antes de pasar el change a "approved". -->
+
+**Implementación:** Regex de validación en el servicio de dominio (no en el controlador). La validación es responsabilidad del backend; el frontend puede replicarla para UX pero el backend es la única fuente de verdad.
+
+---
+
+## Decisión 5 — Persistencia en base de datos
+
+**Tabla `users`** (Flyway V1 — ver `docs/data-model.md` para DDL completo):
+
+| Columna | Tipo | Restricción | Notas |
+|---|---|---|---|
+| `id` | `BIGSERIAL` | PK | Clave interna. No expuesta en JWT (se usa en `sub` como string). |
+| `login` | `VARCHAR(100)` | UNIQUE NOT NULL | Alias de email. Lowercase enforced. |
+| `password_hash` | `VARCHAR(255)` | NOT NULL | BCrypt cost 12. Nunca en logs. |
+| `first_name` | `VARCHAR(100)` | NOT NULL | Requerido en registro (UX `08-crear-cuenta`). |
+| `last_name` | `VARCHAR(100)` | NOT NULL | Requerido en registro. |
+| `email` | `VARCHAR(255)` | UNIQUE NOT NULL | Igual que `login` en v1.0; separado para facilitar migración futura. |
+| `role` | `ENUM('ADMIN','USER')` | NOT NULL DEFAULT 'USER' | Solo dos roles en v1.0. |
+| `status` | `ENUM('PENDING','ACTIVE','INACTIVE')` | NOT NULL DEFAULT 'ACTIVE' | `PENDING` si se requiere verificación (change futuro). |
+| `registered_at` | `TIMESTAMPTZ` | NOT NULL DEFAULT NOW() | Inmutable. |
+| `updated_at` | `TIMESTAMPTZ` | NOT NULL DEFAULT NOW() | Actualizado por trigger. |
+| `last_login_at` | `TIMESTAMPTZ` | NULLABLE | Actualizado en cada login exitoso. |
+
+**Nota de diseño:** `status = 'PENDING'` existe en el schema para el change de verificación de email, pero en `bootstrap-mvp` todos los registros nacen como `ACTIVE`. El campo se incluye ahora para evitar migraciones rupturistas más adelante.
+
+**Tabla `refresh_tokens`** (Flyway V2 — ver `docs/data-model.md`):
+
+| Columna | Tipo | Notas |
+|---|---|---|
+| `id` | `BIGSERIAL` | PK |
+| `user_id` | `BIGINT` | FK → `users.id` ON DELETE CASCADE |
+| `token_hash` | `VARCHAR(64)` | SHA-256 del refresh token. Nunca almacenar el token plano. |
+| `expires_at` | `TIMESTAMPTZ` | NOT NULL |
+| `revoked` | `BOOLEAN` | DEFAULT FALSE. Permite revocar sesiones. |
+| `ip_address` | `INET` | Para auditoría. |
+| `created_at` | `TIMESTAMPTZ` | NOT NULL DEFAULT NOW() |
+
+---
+
+## Decisión 6 — Rate limiting de endpoints públicos
+
+**Decisión:** Throttle por IP implementado en la capa de Spring Security o mediante un filtro Servlet.
+
+| Endpoint | Límite | Fuente |
+|---|---|---|
+| `POST /api/auth/login` | 5 requests/min/IP | RN-SEC-01 |
+| `POST /api/auth/register` | 3 requests/min/IP | RN-SEC-01 |
+| `POST /api/auth/password/solicitar-reset` | 3 requests/min/IP | RN-SEC-01 (change futuro) |
+
+**Respuesta al superar el límite:** HTTP 429 Too Many Requests con cabecera `Retry-After: <segundos>`.
+
+**Implementación recomendada:** Bucket4j (biblioteca Java compatible con Spring Boot 3.x) con almacenamiento en memoria para v1.0. Si hay múltiples instancias (Fase 3), migrar a Redis. En v1.0 (Docker Compose, instancia única) la memoria es suficiente.
+
+**Nota:** El bloqueo de cuenta por fallos repetidos (RN-AUTH-06: 10 fallos en 10 min → 15 min de bloqueo) es distinto del rate limiting por IP y se declara en el change `auth-lockout`. No forma parte de este change.
+
+---
+
+## Decisiones aplazadas
+
+Las siguientes decisiones se cierran en changes posteriores:
+
+| Decisión | Change responsable |
+|---|---|
+| Flujo de recuperación de contraseña (endpoint, OTP, expiración) | `auth-password-reset` |
+| Verificación de email al registrarse (¿obligatoria en v1.0?) | `auth-email-verification` |
+| Bloqueo de cuenta tras N fallos consecutivos (RN-AUTH-06) | `auth-lockout` |
+| Política de sesiones simultáneas (¿cuántos refresh tokens activos por usuario?) | `auth-session-management` |
+| Expiración por inactividad (distinta de la expiración absoluta del token) | `auth-session-management` |
+| Vinculación con Telegram y OTP para operaciones críticas | `auth-otp-telegram` |
+| Rotación del secreto JWT (¿cómo se invalidan tokens existentes?) | `auth-session-management` |

--- a/openspec/changes/bootstrap-mvp/proposal.md
+++ b/openspec/changes/bootstrap-mvp/proposal.md
@@ -1,0 +1,88 @@
+# Proposal: Bootstrap MVP
+
+**Change slug:** `bootstrap-mvp`
+**Estado:** proposed
+**Issue GitHub:** #76
+**Épica:** EP-01 Acceso e Identidad
+**Milestone:** EP-01 Acceso e Identidad
+
+---
+
+## Contexto
+
+PadelPro tiene ya documentados su modelo de datos (`docs/data-model.md`), su diseño de seguridad (`docs/security-design.md`), su contrato REST (`docs/openapi.yaml`) y su estrategia de testing (`docs/TESTING-STRATEGY.md`). La documentación UX está completa en `docs/ux/`. Sin embargo, no existe todavía ningún change OpenSpec ejecutable que un agente pueda tomar para iniciar la implementación.
+
+Este change resuelve ese bloqueo de dos maneras:
+
+1. **Andamiaje**: consolida el esqueleto OpenSpec (`openspec/project.md`, `openspec/AGENTS.md`) como punto de entrada canónico para todos los agentes futuros.
+2. **Primera capability ejecutable**: declara `auth-local` mínima — registro e inicio de sesión con email y contraseña, emisión de JWT, rate limiting y auditoría de intentos — como la unidad mínima sobre la que se puede construir todo lo demás.
+
+Sin una identidad de usuario autenticada, ninguna otra capability puede operar: las reservas necesitan un `owner_id`, los pagos necesitan un titular, las notificaciones necesitan un `telegram_chat_id`. Este change crea ese prerrequisito.
+
+---
+
+## Alcance dentro del change
+
+- Verificación y referenciación de `openspec/project.md` y `openspec/AGENTS.md` (ya existen; no se modifican).
+- Capability `auth-local` mínima viable, que cubre:
+  - Registro de usuario con email único y contraseña (validación de política).
+  - Login con credenciales (email + contraseña) → devuelve access token JWT (HS256).
+  - Emisión y validación de tokens JWT (access 15 min en memoria JS, refresh 7 días en cookie httpOnly).
+  - Rate limiting en endpoints públicos de auth (login 5/min/IP, registro 3/min/IP).
+  - Registro de auditoría de cada intento de login (éxito y fallo) en `audit_log`.
+- Trazabilidad completa a mockups UX: `07-splash`, `01-login`, `08-crear-cuenta`.
+
+---
+
+## Alcance fuera del change
+
+Los siguientes aspectos de `auth-local` **no** forman parte de este change y se declaran en changes posteriores:
+
+| Capacidad excluida | Change futuro |
+|---|---|
+| Recuperación de contraseña (OTP por Telegram) | `auth-password-reset` |
+| Verificación de email al registrarse | `auth-email-verification` |
+| Vinculación de cuenta con Telegram | `auth-otp-telegram` |
+| Refresco de token y logout | `auth-session-management` |
+| Perfil del usuario (nombre, teléfono) | `usuarios` |
+| Gestión de usuarios por ADMIN | `usuarios` |
+| Bloqueo de cuenta tras fallos repetidos (RN-AUTH-06) | `auth-lockout` |
+
+---
+
+## Criterios de aceptación
+
+1. Los artefactos `openspec/project.md` y `openspec/AGENTS.md` existen y son referenciados desde este change.
+2. El spec de `auth-local` en este change declara los requirements mínimos (R-1 a R-5) con scenarios Given/When/Then sin ambigüedad: un agente de backend puede convertirlos en tests sin necesidad de interpretar.
+3. Existe trazabilidad explícita a los mockups UX `07-splash.html`, `01-login.html` y `08-crear-cuenta.html` en `docs/ux/mockups/`.
+4. Las decisiones de diseño en `design.md` son consistentes con las reglas de negocio autoritativas: RN-AUTH-08 (contraseña), RN-AUTH-09 (tokens), RN-SEC-01 (rate limiting), y con el algoritmo HS256 documentado en `docs/security-design.md`.
+5. La lista de tareas en `tasks.md` es ejecutable sin ambigüedad: un agente `backend-architect` puede tomar el bloque BACKEND y empezar sin preguntar.
+
+---
+
+## Riesgos
+
+| Riesgo | Probabilidad | Mitigación |
+|---|---|---|
+| Ambigüedad en la política de contraseñas (el prompt de diseño mencionó "símbolo" como requisito adicional, pero RN-AUTH-08 solo exige mayúscula + número) | Media | `design.md` sigue la fuente autoritativa (RN-AUTH-08). Se documenta el conflicto. Requiere validación humana. |
+| Elección entre BCrypt y Argon2id | Baja | `design.md` recomienda BCrypt cost 12 (ya especificado en RN-AUTH-08). Argon2id documentado como alternativa. |
+| Incompatibilidad de H2 con constraints PostgreSQL en tests | Alta | `docs/TESTING-STRATEGY.md` ya lo documenta. Testcontainers obligatorio para tests de integración. |
+| Solapamiento con el change `auth-otp-telegram` | Media | Este change solo declara JWT/contraseña. Ningún scenario menciona Telegram. La frontera es clara. |
+
+---
+
+## Impacto en otros changes
+
+Este change es el cimiento de todos los changes de Fase 1:
+
+| Change futuro | Dependencia de `bootstrap-mvp` |
+|---|---|
+| `auth-otp-telegram` | Extiende la identity creada aquí con `telegram_chat_id`. |
+| `usuarios` | Consume el modelo `User` (id, email, role) definido en este change. |
+| `reservas` | Requiere `owner_id` (FK a `users.id`) establecida aquí. |
+| `pagos-redsys` | Requiere un titular autenticado (USER role). |
+| `roles-permisos` | La matriz RBAC opera sobre los roles ADMIN/USER definidos en `users.role`. |
+| `auditoria` | El registro de intentos de login (R-5 de este change) es la primera entrada en `audit_log`. |
+| `exportaciones-rgpd` | El derecho de anonimización opera sobre el `users.id` establecido aquí. |
+
+**Sin este change aprobado y ejecutado, ningún otro change de Fase 1 puede entrar en `in-progress`.**

--- a/openspec/changes/bootstrap-mvp/specs/auth-local/spec.md
+++ b/openspec/changes/bootstrap-mvp/specs/auth-local/spec.md
@@ -1,0 +1,289 @@
+# Capability: auth-local — Change bootstrap-mvp
+
+> **Tipo de artefacto:** spec de change (delta sobre `openspec/specs/auth-local/spec.md`).
+> Todos los requirements de este fichero están marcados `[AÑADIDO]` porque son la primera implementación de la capability.
+> Al archivar este change (`/opsx:archive bootstrap-mvp`), estos requirements se fusionan con el spec base.
+
+**Change slug:** `bootstrap-mvp`
+**Capability:** `auth-local`
+**Issue GitHub:** #76
+
+---
+
+## Propósito
+
+Permite a un usuario crear una cuenta y autenticarse con email y contraseña, obteniendo un token JWT (HS256) para llamadas posteriores a la API. Es la capability mínima que habilita el resto de la Fase 1.
+
+---
+
+## Roles que consumen esta capability
+
+| Rol | Operación permitida |
+|---|---|
+| `USER` (jugador registrado) | Puede hacer login, obtener token y acceder a recursos propios. |
+| No autenticado (antes del registro) | Puede registrarse (`POST /api/auth/register`) y hacer login (`POST /api/auth/login`). Tras el registro, el usuario obtiene rol `USER`. |
+
+> Los roles `ADMIN` y `USER` son los únicos roles válidos en v1.0 (AGENTS.md §4 regla 3). El concepto de "usuario no autenticado" no es un rol del sistema; es el estado previo al registro.
+
+---
+
+## Reglas de negocio implicadas
+
+| Código | Descripción |
+|---|---|
+| **RN-AUTH-08** | Contraseña: mínimo 8 caracteres + 1 mayúscula + 1 número; máximo 128 caracteres; hash BCrypt cost 12. |
+| **RN-AUTH-09** | Access token 15 min almacenado en memoria JS; refresh token 7 días en cookie httpOnly. |
+| **RN-RGPD-03** | Las respuestas de error no exponen datos de otros usuarios (anti-enumeración). |
+| **RN-RGPD-04** | Los logs no contienen contraseñas, tokens JWT, códigos OTP ni datos de tarjeta. |
+| **RN-SEC-01** | Rate limiting: login 5/min/IP, registro 3/min/IP. |
+
+---
+
+## Endpoints cubiertos por este change
+
+| Método | Path | Autenticación |
+|---|---|---|
+| `POST` | `/api/auth/register` | Pública |
+| `POST` | `/api/auth/login` | Pública |
+
+> Los endpoints `/api/auth/refresh`, `/api/auth/logout` y `/api/auth/password/*` se declaran en changes posteriores (`auth-session-management`, `auth-password-reset`).
+
+---
+
+## Requirements
+
+### R-1 — Registro de usuario con email único `[AÑADIDO]`
+
+Un usuario no autenticado puede crear una cuenta proporcionando su nombre, apellido, email y contraseña. El email debe ser único en el sistema. La contraseña debe cumplir la política mínima (RN-AUTH-08). El sistema crea la cuenta con rol `USER` y estado `ACTIVE`.
+
+#### Scenarios
+
+**Scenario R-1.1 — Registro válido**
+```
+GIVEN un usuario no autenticado
+  AND los campos {first_name, last_name, email, password} son válidos
+  AND el email no existe en el sistema
+WHEN el usuario envía POST /api/auth/register con esos campos
+THEN el sistema responde 201 Created
+  AND el body contiene {id, email, role: "USER"}
+  AND el usuario queda persistido en la tabla users con status=ACTIVE
+  AND se genera una entrada en audit_log con action=USER_REGISTERED
+```
+
+**Scenario R-1.2 — Email ya registrado**
+```
+GIVEN un usuario no autenticado
+  AND el email proporcionado ya existe en la tabla users
+WHEN el usuario envía POST /api/auth/register
+THEN el sistema responde 409 Conflict
+  AND el body contiene {error: "EMAIL_ALREADY_REGISTERED"}
+  AND no se crea ningún registro nuevo en users
+  AND la respuesta no indica si la cuenta existente está activa o inactiva
+```
+
+**Scenario R-1.3 — Contraseña no cumple política mínima**
+```
+GIVEN un usuario no autenticado
+  AND la contraseña tiene menos de 8 caracteres
+    OR no contiene al menos una mayúscula
+    OR no contiene al menos un número
+WHEN el usuario envía POST /api/auth/register
+THEN el sistema responde 400 Bad Request
+  AND el body contiene {error: "INVALID_PASSWORD", details: ["<criterio_fallido>"]}
+  AND no se crea ningún registro en users
+```
+
+**Scenario R-1.4 — Campo obligatorio ausente**
+```
+GIVEN un usuario no autenticado
+  AND el body de la petición omite al menos uno de {first_name, last_name, email, password}
+WHEN el usuario envía POST /api/auth/register
+THEN el sistema responde 400 Bad Request
+  AND el body identifica el campo faltante
+  AND no se crea ningún registro en users
+```
+
+---
+
+### R-2 — Login con credenciales válidas `[AÑADIDO]`
+
+Un usuario registrado puede autenticarse con su email y contraseña. Si las credenciales son correctas, el sistema emite un access token JWT (en el body de la respuesta) y un refresh token (en cookie httpOnly). Si las credenciales son incorrectas o el email no existe, el sistema responde con el mismo error genérico para evitar enumeración de usuarios (RN-RGPD-03).
+
+#### Scenarios
+
+**Scenario R-2.1 — Login con credenciales válidas**
+```
+GIVEN un usuario con email=user@example.com existe en el sistema con status=ACTIVE
+  AND la contraseña proporcionada es correcta
+WHEN el usuario envía POST /api/auth/login con {email, password}
+THEN el sistema responde 200 OK
+  AND el body contiene {access_token: "<JWT>", token_type: "Bearer", expires_in: 900}
+  AND la respuesta incluye el header Set-Cookie con refresh_token; HttpOnly; SameSite=Strict; Secure; Max-Age=604800
+  AND se actualiza users.last_login_at con el timestamp actual
+```
+
+**Scenario R-2.2 — Email no registrado (anti-enumeración)**
+```
+GIVEN el email proporcionado no existe en la tabla users
+WHEN el usuario envía POST /api/auth/login con {email, password}
+THEN el sistema responde 401 Unauthorized
+  AND el body contiene {error: "AUTH_INVALID_CREDENTIALS", message: "Credenciales inválidas"}
+  AND la respuesta es indistinguible del Scenario R-2.3
+  AND no se genera ninguna entrada en audit_log con datos del email (para no exponer si existe)
+```
+
+**Scenario R-2.3 — Contraseña incorrecta**
+```
+GIVEN un usuario con email=user@example.com existe en el sistema con status=ACTIVE
+  AND la contraseña proporcionada es incorrecta
+WHEN el usuario envía POST /api/auth/login con {email, password}
+THEN el sistema responde 401 Unauthorized
+  AND el body contiene {error: "AUTH_INVALID_CREDENTIALS", message: "Credenciales inválidas"}
+  AND el tiempo de respuesta no revela si el email existe (se ejecuta el hash BCrypt igualmente)
+  AND se genera una entrada en audit_log con action=LOGIN_FAILURE, user_id=<id del usuario>, ip_address=<IP>
+```
+
+---
+
+### R-3 — Emisión y validación de JWT `[AÑADIDO]`
+
+El sistema emite access tokens JWT firmados con HS256. El token es válido durante 15 minutos. El sistema rechaza tokens expirados o manipulados.
+
+#### Scenarios
+
+**Scenario R-3.1 — Token recién emitido es válido**
+```
+GIVEN un access token JWT emitido en el login del Scenario R-2.1
+  AND el token tiene menos de 15 minutos de antigüedad
+WHEN el cliente envía el token en el header Authorization: Bearer <token> a cualquier endpoint protegido
+THEN el sistema acepta el token
+  AND procesa la petición con el rol extraído del claim "role"
+```
+
+**Scenario R-3.2 — Token expirado se rechaza**
+```
+GIVEN un access token JWT cuyo campo exp es anterior al momento actual
+WHEN el cliente envía ese token en el header Authorization: Bearer <token>
+THEN el sistema responde 401 Unauthorized
+  AND el body contiene {error: "TOKEN_EXPIRED"}
+  AND no se procesa la operación solicitada
+```
+
+**Scenario R-3.3 — Token con firma manipulada se rechaza**
+```
+GIVEN un access token JWT cuya firma ha sido alterada (payload modificado o firma cambiada)
+WHEN el cliente envía ese token en el header Authorization: Bearer <token>
+THEN el sistema responde 401 Unauthorized
+  AND el body contiene {error: "TOKEN_INVALID"}
+  AND no se procesa la operación solicitada
+  AND se genera una entrada en audit_log con action=TOKEN_TAMPERED, ip_address=<IP>
+```
+
+---
+
+### R-4 — Rate limiting de endpoints públicos de auth `[AÑADIDO]`
+
+Los endpoints públicos `POST /api/auth/login` y `POST /api/auth/register` están sujetos a throttling por IP para prevenir ataques de fuerza bruta (RN-SEC-01).
+
+#### Scenarios
+
+**Scenario R-4.1 — Peticiones por debajo del umbral se procesan**
+```
+GIVEN una IP que ha enviado 4 peticiones a POST /api/auth/login en el último minuto
+WHEN esa IP envía una 5ª petición a POST /api/auth/login
+THEN el sistema procesa la petición normalmente (200 o 401 según las credenciales)
+  AND no se devuelve ningún código de error relacionado con el límite
+```
+
+**Scenario R-4.2 — Al superar el umbral se devuelve 429**
+```
+GIVEN una IP que ha enviado 5 peticiones a POST /api/auth/login en el último minuto
+WHEN esa IP envía una 6ª petición a POST /api/auth/login
+THEN el sistema responde 429 Too Many Requests
+  AND la respuesta incluye el header Retry-After con los segundos hasta que se libera el cupo
+  AND el body contiene {error: "RATE_LIMIT_EXCEEDED"}
+  AND no se procesa la autenticación
+```
+
+**Scenario R-4.3 — Rate limiting de registro**
+```
+GIVEN una IP que ha enviado 3 peticiones a POST /api/auth/register en el último minuto
+WHEN esa IP envía una 4ª petición a POST /api/auth/register
+THEN el sistema responde 429 Too Many Requests con Retry-After
+```
+
+---
+
+### R-5 — Auditoría de intentos de login `[AÑADIDO]`
+
+Cada intento de login (exitoso o fallido) genera una entrada en la tabla `audit_log` con timestamp, dirección IP y resultado. La contraseña nunca se registra ni se insinúa en los logs (RN-RGPD-04).
+
+#### Scenarios
+
+**Scenario R-5.1 — Login exitoso genera entrada de auditoría**
+```
+GIVEN un usuario autentica correctamente (Scenario R-2.1)
+THEN el sistema registra en audit_log:
+  - action = 'LOGIN_SUCCESS'
+  - user_id = <id del usuario autenticado>
+  - ip_address = <IP del cliente>
+  - created_at = <timestamp actual>
+  - details = NULL (no se almacena token ni contraseña)
+```
+
+**Scenario R-5.2 — Login fallido con usuario existente genera entrada de auditoría**
+```
+GIVEN un usuario envía credenciales incorrectas para un email que existe (Scenario R-2.3)
+THEN el sistema registra en audit_log:
+  - action = 'LOGIN_FAILURE'
+  - user_id = <id del usuario cuyo email se intentó>
+  - ip_address = <IP del cliente>
+  - created_at = <timestamp actual>
+  - details = NULL (sin contraseña, sin token)
+```
+
+**Scenario R-5.3 — Login fallido con email inexistente NO expone el email en audit_log**
+```
+GIVEN un usuario envía credenciales con un email que no existe en el sistema (Scenario R-2.2)
+THEN el sistema registra en audit_log:
+  - action = 'LOGIN_FAILURE'
+  - user_id = NULL
+  - ip_address = <IP del cliente>
+  - created_at = <timestamp actual>
+  - details = NULL
+  AND el email enviado NO se almacena en audit_log (para no acumular datos de personas no registradas)
+```
+
+---
+
+## Mockups asociados
+
+Los siguientes mockups ilustran la experiencia de usuario para este change. Todos los links son relativos desde `openspec/changes/bootstrap-mvp/specs/auth-local/spec.md`.
+
+### Pantallas
+
+| Pantalla | Fichero | Permisos | Momento en el flujo |
+|---|---|---|---|
+| Splash / Bienvenida | [`07-splash.html`](../../../../../docs/ux/mockups/07-splash.html) | Pública | Primer punto de entrada. CTAs "Iniciar sesión" y "Crear cuenta". |
+| Login | [`01-login.html`](../../../../../docs/ux/mockups/01-login.html) | Pública | Campos email + contraseña. Mensaje de error genérico en 401 (R-2.2 y R-2.3). |
+| Crear cuenta (registro) | [`08-crear-cuenta.html`](../../../../../docs/ux/mockups/08-crear-cuenta.html) | Pública | Campos nombre, apellido, email, contraseña. Feedback de política de contraseñas (R-1.3). |
+
+### Flujos relacionados
+
+- **Flujo 1 · Onboarding y autenticación** → [`docs/ux/flujos.md`](../../../../../docs/ux/flujos.md)
+
+El flujo muestra:
+```
+07-splash → ¿Tiene cuenta? → Sí → 01-login → OK → 02-home-jugador
+                            → No → 08-crear-cuenta → POST /auth/register 201 → 02-home-jugador
+```
+
+Índice completo de pantallas: [`docs/ux/README.md`](../../../../../docs/ux/README.md)
+
+### Notas de UX derivadas de los requirements
+
+> **Anti-enumeración (R-2.2 / R-2.3):** La pantalla `01-login.html` muestra un único mensaje de error genérico ("Credenciales inválidas") tanto si el email no existe como si la contraseña es incorrecta. El frontend no puede diferenciar los casos porque el backend devuelve el mismo 401 en ambos.
+
+> **Política de contraseñas (R-1.3):** La pantalla `08-crear-cuenta.html` puede mostrar un indicador de fortaleza en tiempo real. Sin embargo, la validación autoritativa ocurre en el backend; si el frontend la omite, el 400 debe ser legible (campo `details` con criterio fallido).
+
+> **Cookie httpOnly (R-2.1):** El refresh token no es accesible desde JavaScript. El frontend no necesita gestionarlo explícitamente; el navegador lo envía automáticamente en las peticiones a `/api/auth/refresh`. El access token sí debe gestionarse en memoria JS (T-029).

--- a/openspec/changes/bootstrap-mvp/specs/auth-local/spec.md
+++ b/openspec/changes/bootstrap-mvp/specs/auth-local/spec.md
@@ -66,7 +66,7 @@ GIVEN un usuario no autenticado
 WHEN el usuario envía POST /api/auth/register con esos campos
 THEN el sistema responde 201 Created
   AND el body contiene {id, email, role: "USER"}
-  AND el usuario queda persistido en la tabla users con status=ACTIVE
+  AND el usuario queda persistido en la tabla users con status=PENDING
   AND se genera una entrada en audit_log con action=USER_REGISTERED
 ```
 
@@ -81,15 +81,36 @@ THEN el sistema responde 409 Conflict
   AND la respuesta no indica si la cuenta existente está activa o inactiva
 ```
 
-**Scenario R-1.3 — Contraseña no cumple política mínima**
+**Scenario R-1.3a — Contraseña demasiado corta**
 ```
 GIVEN un usuario no autenticado
   AND la contraseña tiene menos de 8 caracteres
-    OR no contiene al menos una mayúscula
-    OR no contiene al menos un número
 WHEN el usuario envía POST /api/auth/register
 THEN el sistema responde 400 Bad Request
-  AND el body contiene {error: "INVALID_PASSWORD", details: ["<criterio_fallido>"]}
+  AND el body contiene {error: "INVALID_PASSWORD", details: ["MIN_LENGTH_8"]}
+  AND no se crea ningún registro en users
+```
+
+**Scenario R-1.3b — Contraseña sin mayúscula**
+```
+GIVEN un usuario no autenticado
+  AND la contraseña tiene 8 o más caracteres
+  AND la contraseña no contiene ninguna letra mayúscula
+WHEN el usuario envía POST /api/auth/register
+THEN el sistema responde 400 Bad Request
+  AND el body contiene {error: "INVALID_PASSWORD", details: ["REQUIRES_UPPERCASE"]}
+  AND no se crea ningún registro en users
+```
+
+**Scenario R-1.3c — Contraseña sin número**
+```
+GIVEN un usuario no autenticado
+  AND la contraseña tiene 8 o más caracteres
+  AND la contraseña contiene al menos una letra mayúscula
+  AND la contraseña no contiene ningún dígito numérico
+WHEN el usuario envía POST /api/auth/register
+THEN el sistema responde 400 Bad Request
+  AND el body contiene {error: "INVALID_PASSWORD", details: ["REQUIRES_NUMBER"]}
   AND no se crea ningún registro en users
 ```
 
@@ -107,7 +128,7 @@ THEN el sistema responde 400 Bad Request
 
 ### R-2 — Login con credenciales válidas `[AÑADIDO]`
 
-Un usuario registrado puede autenticarse con su email y contraseña. Si las credenciales son correctas, el sistema emite un access token JWT (en el body de la respuesta) y un refresh token (en cookie httpOnly). Si las credenciales son incorrectas o el email no existe, el sistema responde con el mismo error genérico para evitar enumeración de usuarios (RN-RGPD-03).
+Un usuario registrado puede autenticarse con su email y contraseña. Si las credenciales son correctas y la cuenta está `ACTIVE`, el sistema emite un access token JWT y un refresh token (cookie httpOnly). Si las credenciales son incorrectas o el email no existe, el sistema responde 401 con el mismo mensaje genérico (anti-enumeración, RN-RGPD-03). Si las credenciales son correctas pero la cuenta está en estado `PENDING` o `INACTIVE`, el sistema responde 403.
 
 #### Scenarios
 
@@ -140,6 +161,18 @@ WHEN el usuario envía POST /api/auth/login con {email, password}
 THEN el sistema responde 401 Unauthorized
   AND el body contiene {error: "AUTH_INVALID_CREDENTIALS", message: "Credenciales inválidas"}
   AND el tiempo de respuesta no revela si el email existe (se ejecuta el hash BCrypt igualmente)
+  AND se genera una entrada en audit_log con action=LOGIN_FAILURE, user_id=<id del usuario>, ip_address=<IP>
+```
+
+**Scenario R-2.4 — Cuenta en estado PENDING o INACTIVE `[AÑADIDO]`**
+```
+GIVEN un usuario con email=user@example.com existe en el sistema
+  AND la contraseña proporcionada es correcta
+  AND el status del usuario es PENDING o INACTIVE
+WHEN el usuario envía POST /api/auth/login con {email, password}
+THEN el sistema responde 403 Forbidden
+  AND el body contiene {error: "ACCOUNT_NOT_ACTIVE", message: "Tu cuenta aún no está activada. Contacta con el administrador."}
+  AND no se emite ningún token JWT
   AND se genera una entrada en audit_log con action=LOGIN_FAILURE, user_id=<id del usuario>, ip_address=<IP>
 ```
 
@@ -275,7 +308,7 @@ Los siguientes mockups ilustran la experiencia de usuario para este change. Todo
 El flujo muestra:
 ```
 07-splash → ¿Tiene cuenta? → Sí → 01-login → OK → 02-home-jugador
-                            → No → 08-crear-cuenta → POST /auth/register 201 → 02-home-jugador
+                            → No → 08-crear-cuenta → POST /api/auth/register 201 → pantalla de confirmación (cuenta pendiente de aprobación)
 ```
 
 Índice completo de pantallas: [`docs/ux/README.md`](../../../../../docs/ux/README.md)

--- a/openspec/changes/bootstrap-mvp/tasks.md
+++ b/openspec/changes/bootstrap-mvp/tasks.md
@@ -39,7 +39,7 @@ Agente responsable: **`backend-architect`**. Lee `docs/openapi.yaml`, `docs/data
 
 ### Servicios de aplicación
 
-- [ ] **T-012** — Implementar `RegistrationService.register(RegisterCommand cmd)`: validar política de contraseñas (RN-AUTH-08), verificar unicidad de email (409 si ya existe), hash BCrypt cost 12, persistir `User` con `status=ACTIVE`, publicar evento `UserRegistered`. Módulo: `application/`.
+- [ ] **T-012** — Implementar `RegistrationService.register(RegisterCommand cmd)`: validar política de contraseñas (RN-AUTH-08), verificar unicidad de email (409 si ya existe), hash BCrypt cost 12, persistir `User` con `status=PENDING` (el ADMIN activa con `PATCH /api/admin/usuarios/{id}/aprobar`), publicar evento `UserRegistered`. Módulo: `application/`.
 - [ ] **T-013** — Implementar `AuthService.login(LoginCommand cmd)`: cargar usuario por email, verificar `BCryptPasswordEncoder.matches()`, generar access token JWT HS256 (claims: `sub`, `role`, `iat`, `exp`), generar refresh token (UUID v4), persistir hash SHA-256 del refresh token en `refresh_tokens`, actualizar `last_login_at`. Módulo: `application/`.
 - [ ] **T-014** — Implementar `JwtService.generateAccessToken(User user)` y `JwtService.validateToken(String token)`. Algoritmo HS256, duración 15 min (RN-AUTH-09). Módulo: `application/` o `infrastructure/`.
 

--- a/openspec/changes/bootstrap-mvp/tasks.md
+++ b/openspec/changes/bootstrap-mvp/tasks.md
@@ -1,0 +1,96 @@
+# Tasks: Bootstrap MVP
+
+**Change slug:** `bootstrap-mvp`
+**Issue GitHub:** #76
+**Rama de trabajo:** `feat/openspec-bootstrap-mvp`
+**Agentes responsables:** `openspec-curator` (DOCS), `backend-architect` (BACKEND), `frontend-engineer` (FRONTEND)
+
+> Cada tarea lleva un identificador `T-NNN` para ser referenciada en commits (`T-001`) y en comentarios de PR (`Closes T-001`).
+> El agente que ejecuta la tarea marca el checkbox `[x]` cuando termina.
+
+---
+
+## Bloque DOCS
+
+Ejecutar antes que BACKEND y FRONTEND. Valida que el andamiaje OpenSpec está completo.
+
+- [x] **T-001** — Verificar que `openspec/project.md` existe y es coherente con el stack y roles actuales (ADMIN/USER en v1.0). Sin modificaciones si ya es correcto.
+- [x] **T-002** — Verificar que `openspec/AGENTS.md` existe, contiene el orden de lectura obligatorio y las reglas para agentes. Sin modificaciones si ya es correcto.
+- [x] **T-003** — Crear `openspec/changes/bootstrap-mvp/proposal.md` con motivación, alcance, criterios de aceptación, riesgos e impacto en otros changes.
+- [x] **T-004** — Crear `openspec/changes/bootstrap-mvp/design.md` con las 6 decisiones de diseño (hashing, JWT, errores, política de contraseñas, persistencia, rate limiting) y la sección "Decisiones aplazadas".
+- [x] **T-005** — Crear `openspec/changes/bootstrap-mvp/tasks.md` (este fichero).
+- [x] **T-006** — Crear `openspec/changes/bootstrap-mvp/specs/auth-local/spec.md` con requirements R-1 a R-5, todos marcados `[AÑADIDO]`, con scenarios Given/When/Then y sección `## Mockups asociados`.
+- [x] **T-007** — Validar que los 3 enlaces relativos en el spec hacia `docs/ux/mockups/` resuelven a ficheros existentes: `01-login.html`, `07-splash.html`, `08-crear-cuenta.html`.
+- [ ] **T-008** — Crear el Issue GitHub #76 (ya creado) y añadirlo al Project v2 (`lcasadov/projects/1`) con status `In Review`.
+
+---
+
+## Bloque BACKEND
+
+Ejecutar en la rama `feature/<N>-auth-local` una vez que el change pase a `approved`. Requiere que T-001 a T-007 estén completos.
+
+Agente responsable: **`backend-architect`**. Lee `docs/openapi.yaml`, `docs/data-model.md`, `docs/security-design.md` y este `tasks.md` antes de empezar.
+
+### Modelo de dominio
+
+- [ ] **T-009** — Crear entidad JPA `User` con todos los campos del diseño (ver `design.md §Decisión 5`). Módulo: `domain/`.
+- [ ] **T-010** — Crear repositorio `UserRepository` (Spring Data JPA) con método `findByEmail(String email)`. Módulo: `infrastructure/`.
+- [ ] **T-011** — Crear entidad JPA `RefreshToken` y repositorio `RefreshTokenRepository` con métodos `findByTokenHash`, `revokeAll(Long userId)`. Módulo: `infrastructure/`.
+
+### Servicios de aplicación
+
+- [ ] **T-012** — Implementar `RegistrationService.register(RegisterCommand cmd)`: validar política de contraseñas (RN-AUTH-08), verificar unicidad de email (409 si ya existe), hash BCrypt cost 12, persistir `User` con `status=ACTIVE`, publicar evento `UserRegistered`. Módulo: `application/`.
+- [ ] **T-013** — Implementar `AuthService.login(LoginCommand cmd)`: cargar usuario por email, verificar `BCryptPasswordEncoder.matches()`, generar access token JWT HS256 (claims: `sub`, `role`, `iat`, `exp`), generar refresh token (UUID v4), persistir hash SHA-256 del refresh token en `refresh_tokens`, actualizar `last_login_at`. Módulo: `application/`.
+- [ ] **T-014** — Implementar `JwtService.generateAccessToken(User user)` y `JwtService.validateToken(String token)`. Algoritmo HS256, duración 15 min (RN-AUTH-09). Módulo: `application/` o `infrastructure/`.
+
+### API REST
+
+- [ ] **T-015** — Implementar `AuthController` con dos endpoints (ver `docs/openapi.yaml` para contrato exacto):
+  - `POST /api/auth/register` → 201 con body `{id, email, role}` o 409 si email duplicado o 400 si política de contraseñas fallida.
+  - `POST /api/auth/login` → 200 con access token en body + refresh token en cookie httpOnly `Set-Cookie: refresh_token=...; HttpOnly; SameSite=Strict; Secure; Max-Age=604800` o 401 genérico.
+- [ ] **T-016** — Configurar Spring Security: endpoints `/api/auth/**` públicos (sin JWT requerido). Todos los demás endpoints requieren JWT válido.
+
+### Persistencia y migraciones
+
+- [ ] **T-017** — Crear migración Flyway `V1__create_users_table.sql` con DDL de la tabla `users` (ver `docs/data-model.md` y `design.md §Decisión 5`). Incluir `CREATE EXTENSION IF NOT EXISTS btree_gist` si no está ya en V1.
+- [ ] **T-018** — Crear migración Flyway `V2__create_refresh_tokens_table.sql` con DDL de `refresh_tokens` (FK, índices).
+
+### Rate limiting
+
+- [ ] **T-019** — Añadir dependencia Bucket4j al POM. Implementar filtro de rate limiting para `POST /api/auth/login` (5/min/IP) y `POST /api/auth/register` (3/min/IP). Respuesta 429 con header `Retry-After`. (RN-SEC-01)
+
+### Auditoría
+
+- [ ] **T-020** — Registrar en `audit_log` cada intento de login (exitoso o fallido): `action='LOGIN_SUCCESS'` o `action='LOGIN_FAILURE'`, `user_id` (si el email existe, sino NULL), `ip_address`, `timestamp`. Sin exponer contraseña ni token. (RN-RGPD-04)
+
+### Testing
+
+- [ ] **T-021** — Tests unitarios de `RegistrationService`: contraseña válida, contraseña inválida (política), email duplicado. Mockear `UserRepository`.
+- [ ] **T-022** — Tests unitarios de `AuthService`: login válido, email inexistente (mismo error 401), contraseña incorrecta (mismo error 401). Mockear `UserRepository`.
+- [ ] **T-023** — Tests unitarios de `JwtService`: token recién emitido es válido, token expirado lanza excepción, token con firma manipulada lanza excepción.
+- [ ] **T-024** — Tests de integración con Testcontainers (`@SpringBootTest` + PostgreSQL container) para `POST /api/auth/register` y `POST /api/auth/login`. Verificar: 201, 400, 401, 409, cookie httpOnly presente en login exitoso.
+- [ ] **T-025** — Test de integración de rate limiting: 6 peticiones en 1 min a `POST /api/auth/login` → la 6ª devuelve 429 con `Retry-After`.
+
+---
+
+## Bloque FRONTEND
+
+Ejecutar en paralelo con BACKEND una vez que el contrato REST esté acordado (T-015 definido). Puede empezar con MSW mock del endpoint.
+
+Agente responsable: **`frontend-engineer`**. Lee `docs/openapi.yaml` y `docs/ux/mockups/` antes de empezar.
+
+### Pantallas
+
+- [ ] **T-026** — Implementar pantalla `07-splash` (splash screen con CTA "Iniciar sesión" y "Crear cuenta") alineada con el mockup `docs/ux/mockups/07-splash.html`. Rutas: `/` → redirige a `/login` si no hay token.
+- [ ] **T-027** — Implementar formulario de login alineado con mockup `docs/ux/mockups/01-login.html`. Campos: email, contraseña. Conectar a `POST /api/auth/login`. Mostrar error genérico en 401 (no revelar si el email existe).
+- [ ] **T-028** — Implementar formulario de registro alineado con mockup `docs/ux/mockups/08-crear-cuenta.html`. Campos: nombre, apellido, email, contraseña (con indicador de fortaleza). Conectar a `POST /api/auth/register`. Mostrar 409 si email duplicado, 400 si política de contraseñas fallida.
+
+### Gestión de sesión
+
+- [ ] **T-029** — Persistir el access token JWT en memoria JavaScript (variable de módulo o contexto React). Nunca en localStorage ni sessionStorage.
+- [ ] **T-030** — Implementar guard de rutas privadas: redirige a `/login` si no hay access token en memoria.
+
+### Testing
+
+- [ ] **T-031** — Tests unitarios Vitest para los formularios de login y registro (validación de campos, manejo de errores 401/409/400).
+- [ ] **T-032** — Tests de integración con MSW: mock de `POST /api/auth/login` y `POST /api/auth/register` con respuestas 200, 201, 400, 401, 409. Verificar que la UI reacciona correctamente.

--- a/openspec/specs/administracion-club/spec.md
+++ b/openspec/specs/administracion-club/spec.md
@@ -96,3 +96,19 @@ En Fase 2 (target behavior):
 - **`pagos-redsys`**: fuente de datos de ingresos. En v1.0, el frontend usa `GET /api/admin/pagos?status=PAID` con filtros de fecha.
 - **`auditoria`**: las consultas de dashboard por ADMIN generan entradas `ADMIN_USER_DATA_ACCESS` en `audit_log` para trazabilidad de acceso a datos agregados.
 - **`exportaciones-rgpd`**: los informes CSV deben respetar las restricciones RGPD sobre exposición de datos personales (RN-RGPD-04); la capability de exportaciones-rgpd define qué campos están sujetos a protección.
+
+## Mockups asociados
+
+Los siguientes mockups en alta fidelidad ilustran la experiencia de usuario para esta capability. La fuente única de verdad UX es [`docs/ux/README.md`](../../../docs/ux/README.md).
+
+### Pantallas
+
+| # | Pantalla | Dispositivo | Permisos | Mockup |
+|---|----------|-------------|----------|--------|
+| 21 | Dashboard club | Desktop | ADMIN | [`06-dashboard-club.html`](../../../docs/ux/mockups/06-dashboard-club.html) |
+
+### Flujos relacionados
+
+Esta capability participa en los siguientes flujos (ver [`docs/ux/flujos.md`](../../../docs/ux/flujos.md)):
+
+- **Flujo admin — gestión del club** — el dashboard (pantalla 21) es la pantalla principal del flujo admin; muestra KPIs de reservas, ingresos, ocupación y cancelaciones que en v1.0 el frontend agrega a partir de los endpoints existentes de `reservas` y `pagos-redsys`.

--- a/openspec/specs/auditoria/spec.md
+++ b/openspec/specs/auditoria/spec.md
@@ -123,3 +123,19 @@ Sin endpoint REST directo en v1.0 — las entradas se generan internamente.
 - **`exportaciones-rgpd`**: genera eventos USER_ANONYMIZED.
 - **`notificaciones`**: el fallo de webhook Telegram (secret inválido) genera TELEGRAM_WEBHOOK_INVALID_SECRET a través del adaptador de entrada del bot.
 - **`administracion-club`** (Fase 2): leerá `audit_log` para mostrar historial de actividad administrativa.
+
+## Mockups asociados
+
+Los siguientes mockups en alta fidelidad ilustran la experiencia de usuario para esta capability. La fuente única de verdad UX es [`docs/ux/README.md`](../../../docs/ux/README.md).
+
+### Pantallas
+
+| # | Pantalla | Dispositivo | Permisos | Mockup |
+|---|----------|-------------|----------|--------|
+| 20 | Confirmar eliminación | Mobile | USER | [`24-eliminar-cuenta.html`](../../../docs/ux/mockups/24-eliminar-cuenta.html) |
+
+### Flujos relacionados
+
+Esta capability participa en los siguientes flujos (ver [`docs/ux/flujos.md`](../../../docs/ux/flujos.md)):
+
+- **Flujo RGPD — derecho al olvido** — la anonimización de cuenta (pantalla 20) genera la entrada `USER_ANONYMIZED` en `audit_log`; esta entrada es el rastro inmutable que acredita el cumplimiento del Art. 17 RGPD.

--- a/openspec/specs/auth-local/spec.md
+++ b/openspec/specs/auth-local/spec.md
@@ -204,3 +204,30 @@ Todos los endpoints de esta capability tienen `security: []` (no requieren JWT s
 - **`usuarios`**: el registro crea un usuario en la tabla `users`; la aprobación de cuenta es responsabilidad de la capability `usuarios` (endpoint `PATCH /api/admin/usuarios/{id}/aprobar`).
 - **`auditoria`**: cada evento de autenticación (login exitoso/fallido, logout, reset) genera una entrada en `audit_log`.
 - **`roles-permisos`**: los endpoints admin requieren que la capa de seguridad valide el rol `ADMIN` antes de permitir el acceso.
+
+## Mockups asociados
+
+Los siguientes mockups en alta fidelidad ilustran la experiencia de usuario para esta capability. La fuente única de verdad UX es [`docs/ux/README.md`](../../../docs/ux/README.md).
+
+### Pantallas
+
+| # | Pantalla | Dispositivo | Permisos | Mockup |
+|---|----------|-------------|----------|--------|
+| 01 | Splash & bienvenida | Mobile | público | [`07-splash.html`](../../../docs/ux/mockups/07-splash.html) |
+| 02 | Login | Mobile | público | [`01-login.html`](../../../docs/ux/mockups/01-login.html) |
+| 03 | Crear cuenta | Mobile | público | [`08-crear-cuenta.html`](../../../docs/ux/mockups/08-crear-cuenta.html) |
+| 04 | Recuperar contraseña | Mobile | público | [`09-recuperar-password.html`](../../../docs/ux/mockups/09-recuperar-password.html) |
+| 05 | Nueva contraseña | Mobile | Token reset | [`10-nueva-password.html`](../../../docs/ux/mockups/10-nueva-password.html) |
+
+### Flujos relacionados
+
+Esta capability participa en los siguientes flujos (ver [`docs/ux/flujos.md`](../../../docs/ux/flujos.md)):
+
+- **Flujo de onboarding y autenticación** — cubre splash, login, creación de cuenta, recuperación de contraseña y establecimiento de nueva contraseña; es el flujo completo que gestiona esta capability.
+
+### Notas de UX
+
+> - El mensaje de error de login no debe revelar si el email o login existe en el sistema (anti-enumeración, derivado de RN-AUTH-06 y del scenario "Login fallido con contraseña incorrecta").
+> - Tras 10 intentos fallidos la cuenta se bloquea 15 minutos; la pantalla de login debe mostrar el tiempo de espera restante.
+> - La contraseña debe tener mínimo 8 caracteres, 1 mayúscula y 1 número; la pantalla de nueva contraseña incluye barra de fortaleza y lista de requisitos visuales (RN-AUTH-08).
+> - El OTP de reset de contraseña caduca a los 10 minutos; si el usuario intenta confirmar con un código expirado debe recibir un mensaje claro sin información adicional (RN-AUTH-07).

--- a/openspec/specs/auth-local/spec.md
+++ b/openspec/specs/auth-local/spec.md
@@ -227,7 +227,7 @@ Esta capability participa en los siguientes flujos (ver [`docs/ux/flujos.md`](..
 
 ### Notas de UX
 
-> - El mensaje de error de login no debe revelar si el email o login existe en el sistema (anti-enumeración, derivado de RN-AUTH-06 y del scenario "Login fallido con contraseña incorrecta").
+> - El mensaje de error de login no debe revelar si el email o login existe en el sistema (anti-enumeración, RN-RGPD-03 y del scenario "Login fallido con contraseña incorrecta").
 > - Tras 10 intentos fallidos la cuenta se bloquea 15 minutos; la pantalla de login debe mostrar el tiempo de espera restante.
 > - La contraseña debe tener mínimo 8 caracteres, 1 mayúscula y 1 número; la pantalla de nueva contraseña incluye barra de fortaleza y lista de requisitos visuales (RN-AUTH-08).
 > - El OTP de reset de contraseña caduca a los 10 minutos; si el usuario intenta confirmar con un código expirado debe recibir un mensaje claro sin información adicional (RN-AUTH-07).

--- a/openspec/specs/auth-otp-telegram/spec.md
+++ b/openspec/specs/auth-otp-telegram/spec.md
@@ -209,4 +209,4 @@ Esta capability participa en los siguientes flujos (ver [`docs/ux/flujos.md`](..
 
 > - El OTP caduca a los 10 minutos; la pantalla de introducción de OTP (pantalla 15) debe mostrar un contador de tiempo restante en monospace (RN-AUTH-07).
 > - Tras 3 intentos fallidos el OTP se invalida automáticamente; la pantalla debe indicar que el código ha sido invalidado y ofrecer la opción de solicitar uno nuevo (RN-AUTH-07).
-> - El OTP nunca aparece en claro en la pantalla de vinculación; el usuario lo recibe directamente en Telegram y lo introduce manualmente.
+> - El OTP nunca aparece en claro en la pantalla de vinculación; el usuario lo recibe directamente en Telegram y lo introduce manualmente (RN-AUTH-07).

--- a/openspec/specs/auth-otp-telegram/spec.md
+++ b/openspec/specs/auth-otp-telegram/spec.md
@@ -186,3 +186,27 @@ Fase 1
 - **`usuarios`**: la vinculación se refleja en el campo `telegram_chat_id` de la tabla `users`.
 - **`notificaciones`**: una vez vinculada la cuenta, el módulo de notificaciones puede usar el `telegram_chat_id` para enviar mensajes directos.
 - **`auditoria`**: todos los eventos OTP (generación, validación exitosa, fallo, invalidación) se registran en `audit_log`.
+
+## Mockups asociados
+
+Los siguientes mockups en alta fidelidad ilustran la experiencia de usuario para esta capability. La fuente única de verdad UX es [`docs/ux/README.md`](../../../docs/ux/README.md).
+
+### Pantallas
+
+| # | Pantalla | Dispositivo | Permisos | Mockup |
+|---|----------|-------------|----------|--------|
+| 13 | Mi perfil | Mobile | USER | [`14-mi-perfil.html`](../../../docs/ux/mockups/14-mi-perfil.html) |
+| 14 | Vincular Telegram | Mobile | USER | [`15-vincular-telegram.html`](../../../docs/ux/mockups/15-vincular-telegram.html) |
+| 15 | Introducir OTP | Mobile | USER | [`16-otp-telegram.html`](../../../docs/ux/mockups/16-otp-telegram.html) |
+
+### Flujos relacionados
+
+Esta capability participa en los siguientes flujos (ver [`docs/ux/flujos.md`](../../../docs/ux/flujos.md)):
+
+- **Flujo de vinculación Telegram** — cubre el flujo completo: desde Mi perfil (pantalla 13) donde el usuario inicia la vinculación, pasando por las instrucciones del bot (pantalla 14), hasta la introducción del OTP de 6 dígitos (pantalla 15).
+
+### Notas de UX
+
+> - El OTP caduca a los 10 minutos; la pantalla de introducción de OTP (pantalla 15) debe mostrar un contador de tiempo restante en monospace (RN-AUTH-07).
+> - Tras 3 intentos fallidos el OTP se invalida automáticamente; la pantalla debe indicar que el código ha sido invalidado y ofrecer la opción de solicitar uno nuevo (RN-AUTH-07).
+> - El OTP nunca aparece en claro en la pantalla de vinculación; el usuario lo recibe directamente en Telegram y lo introduce manualmente.

--- a/openspec/specs/configuracion-club/spec.md
+++ b/openspec/specs/configuracion-club/spec.md
@@ -137,3 +137,13 @@ Fase 1
 - **`notificaciones`**: las notificaciones por email usan la configuración SMTP de `system_config`.
 - **`auditoria`**: toda actualización de `system_config` genera una entrada en `audit_log`.
 - **`roles-permisos`**: ambos endpoints de esta capability requieren `role=ADMIN`.
+
+## Mockups asociados
+
+Esta capability es **transversal o puramente backend**. No tiene pantallas de usuario directas en el sistema actual.
+
+Está implícita en los siguientes mockups donde el concepto aparece de forma indirecta:
+
+- **`configuracion-club`**: los valores de `system_config` (`max_participants`, horario de apertura, `price_per_hour`) condicionan la disponibilidad mostrada en `07 · Buscar disponibilidad` → [`03-buscar-disponibilidad.html`](../../../docs/ux/mockups/03-buscar-disponibilidad.html) y el importe mostrado en `08 · Confirmar reserva` → [`04-confirmar-reserva.html`](../../../docs/ux/mockups/04-confirmar-reserva.html). El estado de mantenimiento de la pista (también en `system_config`) vacía el resultado de disponibilidad en esas mismas pantallas. Los parámetros de cancelación (`cancellation_deadline_hours`) determinan si el botón de cancelación está activo en `12 · Detalle de reserva` → [`13-detalle-reserva.html`](../../../docs/ux/mockups/13-detalle-reserva.html).
+
+Si se evoluciona esta capability hacia una UI dedicada de configuración para el ADMIN, añadir el flujo correspondiente en [`docs/ux/flujos.md`](../../../docs/ux/flujos.md) antes de generar mockups.

--- a/openspec/specs/disponibilidad-pistas/spec.md
+++ b/openspec/specs/disponibilidad-pistas/spec.md
@@ -99,3 +99,27 @@ Consulta de franjas horarias libres de la pista para una fecha concreta. Permite
 - **reservas**: La disponibilidad se calcula a partir de las reservas activas; cada creación o cancelación de reserva invalida la caché de `available-slots` para la fecha afectada.
 - **partidas**: La vista de partidas joinables se basa en la misma consulta de disponibilidad, filtrando los tramos con `plazasLibres > 0` asociados a reservas existentes con huecos.
 - **pistas**: El estado operativo de la pista (MANTENIMIENTO) afecta directamente al resultado de disponibilidad; se lee de `system_config`.
+
+## Mockups asociados
+
+Los siguientes mockups en alta fidelidad ilustran la experiencia de usuario para esta capability. La fuente única de verdad UX es [`docs/ux/README.md`](../../../docs/ux/README.md).
+
+### Pantallas
+
+| # | Pantalla | Dispositivo | Permisos | Mockup |
+|---|----------|-------------|----------|--------|
+| 06 | Home jugador | Mobile | USER | [`02-home-jugador.html`](../../../docs/ux/mockups/02-home-jugador.html) |
+| 07 | Buscar disponibilidad | Mobile | USER | [`03-buscar-disponibilidad.html`](../../../docs/ux/mockups/03-buscar-disponibilidad.html) |
+| 22 | Calendario semanal | Desktop | ADMIN | [`18-calendario-semanal.html`](../../../docs/ux/mockups/18-calendario-semanal.html) |
+
+### Flujos relacionados
+
+Esta capability participa en los siguientes flujos (ver [`docs/ux/flujos.md`](../../../docs/ux/flujos.md)):
+
+- **Flujo de reserva de pista con pago Redsys** — la pantalla de búsqueda de disponibilidad (pantalla 07) es la puerta de entrada al flujo de reserva; el resultado de disponibilidad determina qué franjas horarias puede seleccionar el usuario.
+- **Flujo admin — gestión del club** — el calendario semanal (pantalla 22) visualiza la ocupación de las franjas horarias, construida sobre la misma lógica de disponibilidad.
+
+### Notas de UX
+
+> - Cuando la pista está en mantenimiento, la pantalla de búsqueda de disponibilidad (pantalla 07) debe mostrar lista vacía sin revelar el motivo (RN-RES-04); el mensaje genérico es suficiente.
+> - El parámetro `fecha` debe validarse en formato YYYY-MM-DD; un formato incorrecto muestra error 400 antes de renderizar resultados.

--- a/openspec/specs/exportaciones-rgpd/spec.md
+++ b/openspec/specs/exportaciones-rgpd/spec.md
@@ -118,3 +118,26 @@ de la AEPD. La anonimización es irreversible y no elimina registros contables n
 - **`notificaciones`**: tras la anonimización, el usuario no puede recibir notificaciones porque `email` y `telegram_chat_id` han sido nullificados; `MensajeriaPort` debe manejar esta condición sin lanzar excepción.
 - **`reservas`**: las reservas históricas del usuario permanecen intactas con `owner_id` apuntando al usuario anonimizado (que sigue existiendo en la tabla).
 - **`pagos-redsys`**: los pagos históricos permanecen intactos; `registered_by_id` pasa a NULL por FK SET NULL si el usuario anonimizado era el admin que registró pagos en efectivo.
+
+## Mockups asociados
+
+Los siguientes mockups en alta fidelidad ilustran la experiencia de usuario para esta capability. La fuente única de verdad UX es [`docs/ux/README.md`](../../../docs/ux/README.md).
+
+### Pantallas
+
+| # | Pantalla | Dispositivo | Permisos | Mockup |
+|---|----------|-------------|----------|--------|
+| 19 | Mis datos y privacidad | Mobile | USER | [`23-mis-datos.html`](../../../docs/ux/mockups/23-mis-datos.html) |
+| 20 | Confirmar eliminación | Mobile | USER | [`24-eliminar-cuenta.html`](../../../docs/ux/mockups/24-eliminar-cuenta.html) |
+
+### Flujos relacionados
+
+Esta capability participa en los siguientes flujos (ver [`docs/ux/flujos.md`](../../../docs/ux/flujos.md)):
+
+- **Flujo RGPD — derecho al olvido** — cubre el flujo completo: desde la pantalla de mis datos y privacidad (pantalla 19) con referencias a los artículos RGPD, hasta la pantalla de confirmación de eliminación de cuenta (pantalla 20) con la advertencia de irreversibilidad.
+
+### Notas de UX
+
+> - La pantalla de confirmar eliminación (pantalla 20) debe requerir que el usuario escriba literalmente "ELIMINAR" (o su nombre) para confirmar la acción destructiva; el botón permanece deshabilitado hasta que el campo de confirmación coincide.
+> - La anonimización es irreversible; la pantalla 20 debe listar explícitamente las consecuencias (pérdida de acceso, datos anonimizados, historial preservado por obligación fiscal) antes de permitir continuar (RN-RGPD-01, RN-RGPD-02).
+> - La pantalla de mis datos (pantalla 19) debe mostrar referencia al artículo legal aplicable (Art. 15, 16, 17 RGPD) para cada acción disponible.

--- a/openspec/specs/notificaciones/spec.md
+++ b/openspec/specs/notificaciones/spec.md
@@ -111,3 +111,24 @@ a través del puerto de salida `MensajeriaPort`. El job de recordatorios usa `@S
 - **`pagos-redsys`**: el evento `PAYMENT_CONFIRMED` dispara el recibo de pago.
 - **`autenticacion`**: el flujo de reset de contraseña usa `MensajeriaPort` para enviar el OTP por Telegram.
 - **`auditoria`**: los fallos de envío Telegram con secret inválido generan entradas en `audit_log` con `action=TELEGRAM_WEBHOOK_INVALID_SECRET`.
+
+## Mockups asociados
+
+Los siguientes mockups en alta fidelidad ilustran la experiencia de usuario para esta capability. La fuente única de verdad UX es [`docs/ux/README.md`](../../../docs/ux/README.md).
+
+### Pantallas
+
+| # | Pantalla | Dispositivo | Permisos | Mockup |
+|---|----------|-------------|----------|--------|
+| 10 | Pago confirmado | Mobile | USER | [`12-pago-confirmado.html`](../../../docs/ux/mockups/12-pago-confirmado.html) |
+
+### Flujos relacionados
+
+Esta capability participa en los siguientes flujos (ver [`docs/ux/flujos.md`](../../../docs/ux/flujos.md)):
+
+- **Flujo de reserva de pista con pago Redsys** — la pantalla de pago confirmado (pantalla 10) incluye el aviso de que el usuario recibirá una notificación por Telegram si tiene la cuenta vinculada.
+
+### Notas de UX
+
+> - La pantalla de pago confirmado (pantalla 10) debe indicar que se ha enviado una notificación por Telegram solo si el usuario tiene `telegram_chat_id` vinculado (RN-TEL-03); si no está vinculado, omitir el aviso.
+> - Un fallo en el envío de notificación no debe impedir que la pantalla de confirmación se muestre al usuario; el flujo principal no se bloquea (RN-NOT-01).

--- a/openspec/specs/pagos-redsys/spec.md
+++ b/openspec/specs/pagos-redsys/spec.md
@@ -162,3 +162,31 @@ Gestión del ciclo de pago online mediante la pasarela Redsys (HMAC SHA-256) y d
 ## Dependencias con otras capabilities
 - **reservas**: Cada pago está asociado a una reserva (FK UNIQUE); la reserva se crea atómicamente con el pago en `status=PENDING`. El estado de la reserva puede actualizarse tras la confirmación del pago (ej. `PENDING_CONFIRMATION → CONFIRMED`).
 - **pistas**: La configuración del sistema (incluidas las credenciales Redsys) se gestiona desde la capability `pistas` via `system_config`.
+
+## Mockups asociados
+
+Los siguientes mockups en alta fidelidad ilustran la experiencia de usuario para esta capability. La fuente única de verdad UX es [`docs/ux/README.md`](../../../docs/ux/README.md).
+
+### Pantallas
+
+| # | Pantalla | Dispositivo | Permisos | Mockup |
+|---|----------|-------------|----------|--------|
+| 08 | Confirmar reserva | Mobile | USER | [`04-confirmar-reserva.html`](../../../docs/ux/mockups/04-confirmar-reserva.html) |
+| 09 | Checkout Redsys | Mobile | USER | [`11-checkout-redsys.html`](../../../docs/ux/mockups/11-checkout-redsys.html) |
+| 10 | Pago confirmado | Mobile | USER | [`12-pago-confirmado.html`](../../../docs/ux/mockups/12-pago-confirmado.html) |
+| 18 | Confirmar unión | Mobile | USER | [`22-confirmar-union.html`](../../../docs/ux/mockups/22-confirmar-union.html) |
+| 23 | Reservas del club | Desktop | ADMIN | [`19-reservas-club.html`](../../../docs/ux/mockups/19-reservas-club.html) |
+
+### Flujos relacionados
+
+Esta capability participa en los siguientes flujos (ver [`docs/ux/flujos.md`](../../../docs/ux/flujos.md)):
+
+- **Flujo de reserva de pista con pago Redsys** — esta capability gestiona el checkout (pantalla 09) y la confirmación de pago (pantalla 10); el importe mostrado en pantalla 08 proviene del cálculo backend.
+- **Flujo de partida pública** — la confirmación de unión (pantalla 18) puede requerir pago cuando la reserva tiene pago compartido.
+- **Flujo admin — gestión del club** — la tabla de reservas del club (pantalla 23) incluye el estado e importe de cada pago asociado a las reservas.
+
+### Notas de UX
+
+> - Los datos de tarjeta (PAN, CVV, fecha) nunca pasan por el frontend de PadelPro; la pantalla de checkout (pantalla 09) muestra solo previsualización de tarjeta guardada y redirige al TPV de Redsys (RN-PAY-03).
+> - El importe mostrado en todas las pantallas de pago proviene exclusivamente del backend; el usuario no puede modificarlo (RN-RES-03).
+> - La pantalla de pago confirmado (pantalla 10) debe mostrar el código de reserva y la referencia Redsys para que el usuario pueda reclamar en caso de incidencia.

--- a/openspec/specs/partidas/spec.md
+++ b/openspec/specs/partidas/spec.md
@@ -133,4 +133,4 @@ Esta capability participa en los siguientes flujos (ver [`docs/ux/flujos.md`](..
 
 > - La pantalla de partidas abiertas (pantalla 16) solo muestra reservas con plazas libres (`participants_count < max_participants`); las partidas completas no aparecen.
 > - Si el usuario ya es participante de una reserva e intenta unirse de nuevo, el sistema responde 409; la pantalla debe mostrar un mensaje claro sin redirigir al checkout (RN-AUTH-03).
-> - La pantalla de confirmar unión (pantalla 18) debe mostrar la política de cancelación automática y el importe que corresponde al usuario antes de confirmar.
+> - La pantalla de confirmar unión (pantalla 18) debe mostrar la política de cancelación automática y el importe que corresponde al usuario antes de confirmar (RN-RES-04, RN-RES-02).

--- a/openspec/specs/partidas/spec.md
+++ b/openspec/specs/partidas/spec.md
@@ -110,3 +110,27 @@ Permite a los usuarios ver las reservas con plazas libres (partidas abiertas) y 
 ## Dependencias con otras capabilities
 - **reservas**: Las partidas son un subconjunto de reservas. La lógica de creación, estado y cancelación de la reserva base pertenece a la capability `reservas`.
 - **disponibilidad-pistas**: La consulta de disponibilidad (`GET /api/reservas/disponibles`) alimenta también la vista de partidas joinables.
+
+## Mockups asociados
+
+Los siguientes mockups en alta fidelidad ilustran la experiencia de usuario para esta capability. La fuente única de verdad UX es [`docs/ux/README.md`](../../../docs/ux/README.md).
+
+### Pantallas
+
+| # | Pantalla | Dispositivo | Permisos | Mockup |
+|---|----------|-------------|----------|--------|
+| 16 | Partidas abiertas | Mobile | USER | [`21-partidas-abiertas.html`](../../../docs/ux/mockups/21-partidas-abiertas.html) |
+| 17 | Crear partida pública | Mobile | USER | [`20-crear-partida.html`](../../../docs/ux/mockups/20-crear-partida.html) |
+| 18 | Confirmar unión | Mobile | USER | [`22-confirmar-union.html`](../../../docs/ux/mockups/22-confirmar-union.html) |
+
+### Flujos relacionados
+
+Esta capability participa en los siguientes flujos (ver [`docs/ux/flujos.md`](../../../docs/ux/flujos.md)):
+
+- **Flujo de partida pública** — cubre el ciclo completo de una partida pública: listado de partidas abiertas (pantalla 16), creación de nueva partida (pantalla 17) y confirmación de unión a una partida existente (pantalla 18).
+
+### Notas de UX
+
+> - La pantalla de partidas abiertas (pantalla 16) solo muestra reservas con plazas libres (`participants_count < max_participants`); las partidas completas no aparecen.
+> - Si el usuario ya es participante de una reserva e intenta unirse de nuevo, el sistema responde 409; la pantalla debe mostrar un mensaje claro sin redirigir al checkout (RN-AUTH-03).
+> - La pantalla de confirmar unión (pantalla 18) debe mostrar la política de cancelación automática y el importe que corresponde al usuario antes de confirmar.

--- a/openspec/specs/pistas/spec.md
+++ b/openspec/specs/pistas/spec.md
@@ -108,3 +108,24 @@ Gestión del catálogo de pistas (courts) del club. Permite al ADMIN crear, cons
 ## Dependencias con otras capabilities
 - **reservas**: La disponibilidad de la pista es prerrequisito para crear reservas. La capability `reservas` consume los tramos devueltos por `/api/reservas/disponibles`.
 - **disponibilidad-pistas**: Esta capability es la vista de consulta de disponibilidad; `pistas` es el plano de configuración que la controla.
+
+## Mockups asociados
+
+Los siguientes mockups en alta fidelidad ilustran la experiencia de usuario para esta capability. La fuente única de verdad UX es [`docs/ux/README.md`](../../../docs/ux/README.md).
+
+### Pantallas
+
+| # | Pantalla | Dispositivo | Permisos | Mockup |
+|---|----------|-------------|----------|--------|
+| 24 | Gestión de pistas | Desktop | ADMIN | [`17-gestion-pistas.html`](../../../docs/ux/mockups/17-gestion-pistas.html) |
+
+### Flujos relacionados
+
+Esta capability participa en los siguientes flujos (ver [`docs/ux/flujos.md`](../../../docs/ux/flujos.md)):
+
+- **Flujo admin — gestión del club** — la pantalla de gestión de pistas (pantalla 24) permite al ADMIN ver el estado operativo (Activa / Mantenimiento) y las métricas de ocupación y tarifa de cada pista; desde aquí se controla si la pista acepta nuevas reservas.
+
+### Notas de UX
+
+> - Cuando la pista pasa a estado MANTENIMIENTO, la pantalla debe advertir que las reservas existentes no se cancelan automáticamente; solo se bloquean nuevas reservas (RN-RES-04).
+> - Los campos sensibles de `system_config` (claves Redsys, token Telegram, contraseña SMTP) nunca se muestran en claro en la pantalla de configuración (RN-SEC-02).

--- a/openspec/specs/pistas/spec.md
+++ b/openspec/specs/pistas/spec.md
@@ -123,7 +123,7 @@ Los siguientes mockups en alta fidelidad ilustran la experiencia de usuario para
 
 Esta capability participa en los siguientes flujos (ver [`docs/ux/flujos.md`](../../../docs/ux/flujos.md)):
 
-- **Flujo admin — gestión del club** — la pantalla de gestión de pistas (pantalla 24) permite al ADMIN ver el estado operativo (Activa / Mantenimiento) y las métricas de ocupación y tarifa de cada pista; desde aquí se controla si la pista acepta nuevas reservas.
+- **Flujo admin — gestión del club** — la pantalla de gestión de pistas (pantalla 24) permite al ADMIN ver el estado operativo (Activa / Mantenimiento) y las métricas de ocupación y tarifa de la pista; desde aquí se controla si la pista acepta nuevas reservas.
 
 ### Notas de UX
 

--- a/openspec/specs/reservas/spec.md
+++ b/openspec/specs/reservas/spec.md
@@ -170,3 +170,32 @@ Gestión del ciclo de vida completo de una reserva de pista: creación, consulta
 - **disponibilidad-pistas**: La disponibilidad se calcula a partir de las reservas activas en `reservations`.
 - **partidas**: Las reservas con plazas libres y status `CONFIRMED` o `PENDING_CONFIRMATION` son joinables desde la capability `partidas`.
 - **pagos-redsys**: Cada reserva crea atómicamente un registro de pago; el flujo de pago Redsys referencia el `payments.id` y el `reservations.id`.
+
+## Mockups asociados
+
+Los siguientes mockups en alta fidelidad ilustran la experiencia de usuario para esta capability. La fuente única de verdad UX es [`docs/ux/README.md`](../../../docs/ux/README.md).
+
+### Pantallas
+
+| # | Pantalla | Dispositivo | Permisos | Mockup |
+|---|----------|-------------|----------|--------|
+| 06 | Home jugador | Mobile | USER | [`02-home-jugador.html`](../../../docs/ux/mockups/02-home-jugador.html) |
+| 08 | Confirmar reserva | Mobile | USER | [`04-confirmar-reserva.html`](../../../docs/ux/mockups/04-confirmar-reserva.html) |
+| 10 | Pago confirmado | Mobile | USER | [`12-pago-confirmado.html`](../../../docs/ux/mockups/12-pago-confirmado.html) |
+| 11 | Mis reservas | Mobile | USER | [`05-mis-reservas.html`](../../../docs/ux/mockups/05-mis-reservas.html) |
+| 12 | Detalle de reserva | Mobile | USER | [`13-detalle-reserva.html`](../../../docs/ux/mockups/13-detalle-reserva.html) |
+| 22 | Calendario semanal | Desktop | ADMIN | [`18-calendario-semanal.html`](../../../docs/ux/mockups/18-calendario-semanal.html) |
+| 23 | Reservas del club | Desktop | ADMIN | [`19-reservas-club.html`](../../../docs/ux/mockups/19-reservas-club.html) |
+
+### Flujos relacionados
+
+Esta capability participa en los siguientes flujos (ver [`docs/ux/flujos.md`](../../../docs/ux/flujos.md)):
+
+- **Flujo de reserva de pista con pago Redsys** — es la capability central del flujo: cubre la confirmación de la reserva (pantalla 08), la pantalla de pago confirmado (pantalla 10) y el detalle posterior de la reserva (pantalla 12).
+- **Flujo admin — gestión del club** — el calendario semanal (pantalla 22) y la tabla de reservas del club (pantalla 23) permiten al ADMIN supervisar y gestionar el estado de todas las reservas.
+
+### Notas de UX
+
+> - El importe mostrado en la pantalla de confirmar reserva (pantalla 08) proviene siempre del backend; el cliente no puede modificarlo (RN-RES-03).
+> - Un USER solo ve en Mis reservas (pantalla 11) las reservas de las que es owner o participante (RN-AUTH-01).
+> - La pantalla de detalle de reserva (pantalla 12) debe mostrar el botón de cancelación solo si el usuario es el owner y la reserva está en un estado cancelable; fuera del plazo de cancelación debe indicar visualmente que no aplica reembolso (RN-RES-04).

--- a/openspec/specs/roles-permisos/spec.md
+++ b/openspec/specs/roles-permisos/spec.md
@@ -182,3 +182,13 @@ Los endpoints de esta capability no tienen rutas propias; la protección se apli
 - **`auth-local`**: proporciona el JWT que contiene los claims `userId` y `role` usados por la verificación de acceso.
 - **`usuarios`**: la asignación de rol se implementa en la capability `usuarios` (endpoint `PATCH /api/admin/usuarios/{id}`).
 - **`auditoria`**: los accesos denegados (403) se registran en `audit_log`.
+
+## Mockups asociados
+
+Esta capability es **transversal o puramente backend**. No tiene pantallas de usuario directas en el sistema actual.
+
+Está implícita en los siguientes mockups donde el concepto aparece de forma indirecta:
+
+- **`roles-permisos`**: implícita en todas las pantallas protegidas (roles ADMIN/USER controlan la navegación). El pill de rol del usuario aparece en `13 · Mi perfil` → [`14-mi-perfil.html`](../../../docs/ux/mockups/14-mi-perfil.html). La redirección por rol no autorizado (403) se manifiesta en todas las pantallas de admin cuando un USER intenta acceder. Las pantallas admin (`21 · Dashboard club`, `22 · Calendario semanal`, `23 · Reservas del club`, `24 · Gestión de pistas`) solo son accesibles para usuarios con rol ADMIN.
+
+Si se evoluciona esta capability hacia una UI dedicada (ej. panel de gestión de roles en Fase 2), añadir el flujo correspondiente en [`docs/ux/flujos.md`](../../../docs/ux/flujos.md) antes de generar mockups.

--- a/openspec/specs/usuarios/spec.md
+++ b/openspec/specs/usuarios/spec.md
@@ -161,7 +161,7 @@ Los siguientes mockups en alta fidelidad ilustran la experiencia de usuario para
 
 | # | Pantalla | Dispositivo | Permisos | Mockup |
 |---|----------|-------------|----------|--------|
-| 03 | Crear cuenta | Mobile | público | [`08-crear-cuenta.html`](../../../docs/ux/mockups/08-crear-cuenta.html) |
+| 03 | Crear cuenta | Mobile | No autenticado | [`08-crear-cuenta.html`](../../../docs/ux/mockups/08-crear-cuenta.html) |
 | 13 | Mi perfil | Mobile | USER | [`14-mi-perfil.html`](../../../docs/ux/mockups/14-mi-perfil.html) |
 
 ### Flujos relacionados

--- a/openspec/specs/usuarios/spec.md
+++ b/openspec/specs/usuarios/spec.md
@@ -152,3 +152,26 @@ Fase 1
 - **`roles-permisos`**: los endpoints `/api/admin/usuarios/**` están protegidos por la capa RBAC que verifica `role=ADMIN`.
 - **`auditoria`**: cada operación administrativa (creación, aprobación, desactivación, cambio de rol) genera una entrada en `audit_log`.
 - **`exportaciones-rgpd`**: la anonimización completa de datos personales (derecho de supresión RGPD) se implementa como extensión del endpoint `DELETE /api/admin/usuarios/{id}`.
+
+## Mockups asociados
+
+Los siguientes mockups en alta fidelidad ilustran la experiencia de usuario para esta capability. La fuente única de verdad UX es [`docs/ux/README.md`](../../../docs/ux/README.md).
+
+### Pantallas
+
+| # | Pantalla | Dispositivo | Permisos | Mockup |
+|---|----------|-------------|----------|--------|
+| 03 | Crear cuenta | Mobile | público | [`08-crear-cuenta.html`](../../../docs/ux/mockups/08-crear-cuenta.html) |
+| 13 | Mi perfil | Mobile | USER | [`14-mi-perfil.html`](../../../docs/ux/mockups/14-mi-perfil.html) |
+
+### Flujos relacionados
+
+Esta capability participa en los siguientes flujos (ver [`docs/ux/flujos.md`](../../../docs/ux/flujos.md)):
+
+- **Flujo de onboarding y autenticación** — el formulario de creación de cuenta (pantalla 03) recoge los datos del nuevo usuario que esta capability persiste en estado PENDING.
+- **Flujo de vinculación Telegram** — la pantalla de Mi perfil (pantalla 13) es el punto de entrada al flujo de vinculación, y también donde el usuario actualiza sus datos de perfil.
+
+### Notas de UX
+
+> - El mensaje de error al actualizar email duplicado no debe revelar datos del otro usuario (RN-RGPD-03); la pantalla debe indicar solo que el email ya está en uso.
+> - Los campos `role` y `status` no son editables por el propio usuario desde Mi perfil; el formulario no debe mostrar controles para modificarlos.


### PR DESCRIPTION
## Resumen

Este PR introduce el primer change ejecutable del proyecto OpenSpec: `bootstrap-mvp`. Establece la capability `auth-local` mínima viable (registro + login + JWT) como prerrequisito de todos los changes de Fase 1.

---

## proposal.md (completo)

**Change slug:** `bootstrap-mvp` · **Issue:** #76 · **Épica:** EP-01 Acceso e Identidad

### Contexto

PadelPro tiene ya documentados su modelo de datos, diseño de seguridad, contrato REST y estrategia de testing. La documentación UX está completa en `docs/ux/`. Sin embargo, no existe ningún change OpenSpec ejecutable que un agente pueda tomar para iniciar la implementación. Este change resuelve ese bloqueo.

### Alcance dentro

- Capability `auth-local` mínima: registro, login, JWT HS256, rate limiting, auditoría.
- Trazabilidad a mockups UX: `07-splash`, `01-login`, `08-crear-cuenta`.
- `openspec/project.md` y `openspec/AGENTS.md` verificados (ya existían; no modificados).

### Alcance fuera

Recuperación de contraseña · verificación de email · OTP Telegram · refresh/logout · bloqueo de cuenta · sesiones simultáneas — todos en changes posteriores.

### Decisión pendiente de validación humana

`[DECISION-PENDING]` La política de contraseñas: RN-AUTH-08 especifica solo mayúscula + número (sin símbolo). El brief mencionó "símbolo". Se usa RN-AUTH-08 como fuente autoritativa. **Requiere confirmación de `lcasadov` antes de pasar el change a `approved`.**

---

## Tasks checklist (T-001 … T-032)

### Bloque DOCS (completado en este PR)
- [x] T-001 — Verificar `openspec/project.md`
- [x] T-002 — Verificar `openspec/AGENTS.md`
- [x] T-003 — Crear `proposal.md`
- [x] T-004 — Crear `design.md`
- [x] T-005 — Crear `tasks.md`
- [x] T-006 — Crear `specs/auth-local/spec.md`
- [x] T-007 — Validar 3 links UX → ✅ 01-login, 07-splash, 08-crear-cuenta

### Bloque BACKEND (pendiente — change en `approved`)
- [ ] T-009 — Entidad JPA `User`
- [ ] T-010 — `UserRepository`
- [ ] T-011 — Entidad JPA `RefreshToken` + `RefreshTokenRepository`
- [ ] T-012 — `RegistrationService`
- [ ] T-013 — `AuthService` (login + JWT)
- [ ] T-014 — `JwtService` (HS256, 15 min)
- [ ] T-015 — `AuthController` (POST /api/auth/register + POST /api/auth/login)
- [ ] T-016 — Spring Security config (endpoints públicos vs protegidos)
- [ ] T-017 — Flyway V1 tabla `users`
- [ ] T-018 — Flyway V2 tabla `refresh_tokens`
- [ ] T-019 — Rate limiting Bucket4j (5/min login, 3/min registro)
- [ ] T-020 — Auditoría en `audit_log`
- [ ] T-021 a T-025 — Tests unitarios + integración con Testcontainers

### Bloque FRONTEND (pendiente — change en `approved`)
- [ ] T-026 — Pantalla splash (07-splash)
- [ ] T-027 — Formulario login (01-login)
- [ ] T-028 — Formulario registro (08-crear-cuenta)
- [ ] T-029 — Token JWT en memoria JS
- [ ] T-030 — Guard de rutas privadas
- [ ] T-031 a T-032 — Tests Vitest + MSW

---

## Scenarios contractuales de auth-local

| Req | Scenario | Input | Output esperado |
|---|---|---|---|
| R-1 | Registro válido | email único + pwd OK | 201 + {id, email, role} |
| R-1 | Email duplicado | email ya existe | 409 EMAIL_ALREADY_REGISTERED |
| R-1 | Contraseña inválida | pwd < 8 chars o sin mayúscula/número | 400 INVALID_PASSWORD |
| R-2 | Login OK | credenciales correctas | 200 + access_token + cookie refresh |
| R-2 | Email inexistente | email no existe | 401 AUTH_INVALID_CREDENTIALS |
| R-2 | Contraseña incorrecta | pwd errónea | 401 AUTH_INVALID_CREDENTIALS (indistinguible) |
| R-3 | Token válido | JWT < 15 min | endpoint procesa |
| R-3 | Token expirado | JWT exp < ahora | 401 TOKEN_EXPIRED |
| R-3 | Firma manipulada | JWT alterado | 401 TOKEN_INVALID |
| R-4 | Bajo umbral | 5 peticiones/min/IP | procesadas |
| R-4 | Sobre umbral login | 6ª petición/min/IP | 429 + Retry-After |
| R-4 | Sobre umbral registro | 4ª petición/min/IP | 429 + Retry-After |
| R-5 | Auditoría login OK | login exitoso | audit_log LOGIN_SUCCESS |
| R-5 | Auditoría login KO | login fallido (email existe) | audit_log LOGIN_FAILURE con user_id |
| R-5 | Auditoría email inexistente | email no existe | audit_log LOGIN_FAILURE user_id=NULL, sin email |

---

## OpenSpec · Estructura creada

```
openspec/changes/bootstrap-mvp/
├── proposal.md   (motivación, alcance, riesgos, impacto)
├── design.md     (6 decisiones + [DECISION-PENDING] política contraseñas)
├── tasks.md      (T-001..T-032: DOCS ✅ · BACKEND ⏳ · FRONTEND ⏳)
└── specs/
    └── auth-local/
        └── spec.md  (R-1..R-5, 13 scenarios [AÑADIDO], mockups asociados)
```

## Issues vinculados

- Closes #76 (una vez que el change pase a `done`)
- Project: https://github.com/users/lcasadov/projects/1

## Plan de validación

- [ ] Revisar `design.md` — confirmar política de contraseñas (con o sin símbolo)
- [ ] Revisar que los 13 scenarios de `spec.md` son convertibles en tests sin ambigüedad
- [ ] Confirmar que `proposal.md` tiene todos los cambios futuros correctamente diferidos
- [ ] Aprobar PR → merge a `develop`

🤖 Generado con Claude Code (openspec-curator · orchestrator agent)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added detailed authentication design specifications including password policies, JWT token management, and rate limiting rules.
  * Added cross-reference mapping between capabilities and corresponding specification documents.
  * Added mockup associations and UX notes to all capability specifications for consistency and user experience guidance.
  * Created Bootstrap MVP proposal and task tracker documenting authentication feature implementation roadmap.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lcasadov/PadelPro/pull/77?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->