### PR TITLE
feat(usuarios): perfil propio + administración de usuarios (#144)

### DIFF
--- a/backend/src/main/java/com/padelpro/auth/domain/model/User.java
+++ b/backend/src/main/java/com/padelpro/auth/domain/model/User.java
@@ -52,6 +52,15 @@ public class User {
     @Column(name = "last_login_at")
     private OffsetDateTime lastLoginAt;
 
+    @Column(length = 20)
+    private String phone;
+
+    @Column(name = "telegram_chat_id", length = 50)
+    private String telegramChatId;
+
+    @Column(name = "telegram_linked_at")
+    private OffsetDateTime telegramLinkedAt;
+
     // -------------------------------------------------------------------------
     // Constructors
     // -------------------------------------------------------------------------
@@ -109,4 +118,13 @@ public class User {
 
     public OffsetDateTime getLastLoginAt() { return lastLoginAt; }
     public void setLastLoginAt(OffsetDateTime lastLoginAt) { this.lastLoginAt = lastLoginAt; }
+
+    public String getPhone() { return phone; }
+    public void setPhone(String phone) { this.phone = phone; }
+
+    public String getTelegramChatId() { return telegramChatId; }
+    public void setTelegramChatId(String telegramChatId) { this.telegramChatId = telegramChatId; }
+
+    public OffsetDateTime getTelegramLinkedAt() { return telegramLinkedAt; }
+    public void setTelegramLinkedAt(OffsetDateTime telegramLinkedAt) { this.telegramLinkedAt = telegramLinkedAt; }
 }

--- a/backend/src/main/java/com/padelpro/auth/domain/port/out/UserRepositoryPort.java
+++ b/backend/src/main/java/com/padelpro/auth/domain/port/out/UserRepositoryPort.java
@@ -1,6 +1,9 @@
 package com.padelpro.auth.domain.port.out;
 
 import com.padelpro.auth.domain.model.User;
+import com.padelpro.auth.domain.model.UserStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 
@@ -39,4 +42,30 @@ public interface UserRepositoryPort {
      * @return the persisted entity (may have {@code id} populated after insert)
      */
     User save(User user);
+
+    /**
+     * Find a user by their primary key.
+     */
+    Optional<User> findById(Long id);
+
+    /**
+     * Check if another user (different id) already uses this email.
+     * Used to detect email conflicts on profile updates.
+     */
+    boolean existsByEmailAndIdNot(String email, Long id);
+
+    /**
+     * Check whether a user with the given login already exists.
+     */
+    boolean existsByLogin(String login);
+
+    /**
+     * Return a page of users filtered by status.
+     */
+    Page<User> findByStatus(UserStatus status, Pageable pageable);
+
+    /**
+     * Return a page of all users (no status filter).
+     */
+    Page<User> findAll(Pageable pageable);
 }

--- a/backend/src/main/java/com/padelpro/auth/infrastructure/config/SecurityConfig.java
+++ b/backend/src/main/java/com/padelpro/auth/infrastructure/config/SecurityConfig.java
@@ -23,6 +23,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
  */
 @Configuration
 @EnableWebSecurity
+@org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 public class SecurityConfig {
 
     @Bean
@@ -34,6 +35,8 @@ public class SecurityConfig {
                         sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                        .requestMatchers("/api/usuarios/me").authenticated()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)

--- a/backend/src/main/java/com/padelpro/auth/infrastructure/persistence/UserRepository.java
+++ b/backend/src/main/java/com/padelpro/auth/infrastructure/persistence/UserRepository.java
@@ -1,7 +1,10 @@
 package com.padelpro.auth.infrastructure.persistence;
 
 import com.padelpro.auth.domain.model.User;
+import com.padelpro.auth.domain.model.UserStatus;
 import com.padelpro.auth.domain.port.out.UserRepositoryPort;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -36,6 +39,21 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
      * Check whether a user with the given email already exists.
      */
     boolean existsByEmail(String email);
+
+    /**
+     * Check if another user (different id) already uses this email.
+     */
+    boolean existsByEmailAndIdNot(String email, Long id);
+
+    /**
+     * Check whether a user with the given login already exists.
+     */
+    boolean existsByLogin(String login);
+
+    /**
+     * Return a page of users filtered by status.
+     */
+    Page<User> findByStatus(UserStatus status, Pageable pageable);
 
     /**
      * Resolves the ambiguity between {@link UserRepositoryPort#save(User)} and the

--- a/backend/src/main/java/com/padelpro/auth/infrastructure/persistence/UserRepository.java
+++ b/backend/src/main/java/com/padelpro/auth/infrastructure/persistence/UserRepository.java
@@ -56,6 +56,16 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
     Page<User> findByStatus(UserStatus status, Pageable pageable);
 
     /**
+     * Resolves the ambiguity between {@link UserRepositoryPort#findById(Long)} and
+     * the generic {@code findById(ID)} inherited from {@link JpaRepository}.
+     */
+    @Override
+    default java.util.Optional<User> findById(Long id) {
+        throw new UnsupportedOperationException(
+                "Spring Data proxy must override this method");
+    }
+
+    /**
      * Resolves the ambiguity between {@link UserRepositoryPort#save(User)} and the
      * generic {@code <S>save(S)} inherited from {@link JpaRepository}.
      * This explicit {@code default} override makes {@code save(User)} unambiguous

--- a/backend/src/main/java/com/padelpro/auth/infrastructure/web/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/padelpro/auth/infrastructure/web/GlobalExceptionHandler.java
@@ -7,6 +7,10 @@ import com.padelpro.auth.domain.exception.InvalidPasswordException;
 import com.padelpro.auth.domain.exception.TokenExpiredException;
 import com.padelpro.auth.domain.exception.TokenInvalidException;
 import com.padelpro.auth.infrastructure.web.dto.ErrorResponse;
+import com.padelpro.usuarios.domain.exception.AdminSelfDeactivationException;
+import com.padelpro.usuarios.domain.exception.EmailConflictException;
+import com.padelpro.usuarios.domain.exception.UserNotFoundException;
+import com.padelpro.usuarios.domain.exception.UserNotPendingException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -82,5 +86,37 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.UNAUTHORIZED)
                 .body(new ErrorResponse("TOKEN_INVALID", "Access token is invalid"));
+    }
+
+    // -------------------------------------------------------------------------
+    // usuarios capability
+    // -------------------------------------------------------------------------
+
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleUserNotFound(UserNotFoundException ex) {
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(new ErrorResponse("USUARIO_NOT_FOUND", ex.getMessage()));
+    }
+
+    @ExceptionHandler(UserNotPendingException.class)
+    public ResponseEntity<ErrorResponse> handleUserNotPending(UserNotPendingException ex) {
+        return ResponseEntity
+                .status(HttpStatus.UNPROCESSABLE_ENTITY)
+                .body(new ErrorResponse("USUARIO_NOT_PENDING", ex.getMessage()));
+    }
+
+    @ExceptionHandler(AdminSelfDeactivationException.class)
+    public ResponseEntity<ErrorResponse> handleAdminSelfDeactivation(AdminSelfDeactivationException ex) {
+        return ResponseEntity
+                .status(HttpStatus.UNPROCESSABLE_ENTITY)
+                .body(new ErrorResponse("ADMIN_SELF_DEACTIVATION", ex.getMessage()));
+    }
+
+    @ExceptionHandler(EmailConflictException.class)
+    public ResponseEntity<ErrorResponse> handleEmailConflict(EmailConflictException ex) {
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT)
+                .body(new ErrorResponse("USUARIOS_EMAIL_CONFLICT", ex.getMessage()));
     }
 }

--- a/backend/src/main/java/com/padelpro/usuarios/application/dto/CreateUserAdminCommand.java
+++ b/backend/src/main/java/com/padelpro/usuarios/application/dto/CreateUserAdminCommand.java
@@ -1,0 +1,20 @@
+package com.padelpro.usuarios.application.dto;
+
+/**
+ * Command for admin-created user accounts (POST /api/admin/usuarios).
+ *
+ * <p>Admin-created users are set to {@code status=ACTIVE} immediately — no
+ * approval step required (spec Requirement 2, scenario 1).
+ * Password policy RN-AUTH-08 is enforced in the service layer.
+ *
+ * @param role optional — defaults to USER if null
+ */
+public record CreateUserAdminCommand(
+        String login,
+        String firstName,
+        String lastName,
+        String email,
+        String password,
+        String phone,
+        String role
+) {}

--- a/backend/src/main/java/com/padelpro/usuarios/application/dto/PagedUsersResponse.java
+++ b/backend/src/main/java/com/padelpro/usuarios/application/dto/PagedUsersResponse.java
@@ -1,0 +1,14 @@
+package com.padelpro.usuarios.application.dto;
+
+import java.util.List;
+
+/**
+ * Paged response for admin user listings (GET /api/admin/usuarios).
+ */
+public record PagedUsersResponse(
+        List<UserAdminResponse> content,
+        long totalElements,
+        int totalPages,
+        int page,
+        int size
+) {}

--- a/backend/src/main/java/com/padelpro/usuarios/application/dto/UpdateMyProfileCommand.java
+++ b/backend/src/main/java/com/padelpro/usuarios/application/dto/UpdateMyProfileCommand.java
@@ -1,0 +1,15 @@
+package com.padelpro.usuarios.application.dto;
+
+/**
+ * Command for updating the authenticated user's own profile (PATCH /api/usuarios/me).
+ *
+ * <p>All fields are nullable — only non-null values are applied (partial update semantics).
+ * {@code role} and {@code status} are intentionally absent: users cannot modify their own
+ * role or status (spec Requirement 1, scenario 3).
+ */
+public record UpdateMyProfileCommand(
+        String firstName,
+        String lastName,
+        String email,
+        String phone
+) {}

--- a/backend/src/main/java/com/padelpro/usuarios/application/dto/UpdateUserAdminCommand.java
+++ b/backend/src/main/java/com/padelpro/usuarios/application/dto/UpdateUserAdminCommand.java
@@ -1,0 +1,16 @@
+package com.padelpro.usuarios.application.dto;
+
+/**
+ * Command for admin updates to any user account (PATCH /api/admin/usuarios/{id}).
+ *
+ * <p>All fields are nullable — only non-null values are applied.
+ * {@code login} is intentionally absent: login is immutable post-creation.
+ */
+public record UpdateUserAdminCommand(
+        String firstName,
+        String lastName,
+        String email,
+        String phone,
+        String role,
+        String status
+) {}

--- a/backend/src/main/java/com/padelpro/usuarios/application/dto/UserAdminResponse.java
+++ b/backend/src/main/java/com/padelpro/usuarios/application/dto/UserAdminResponse.java
@@ -1,0 +1,23 @@
+package com.padelpro.usuarios.application.dto;
+
+import java.time.OffsetDateTime;
+
+/**
+ * Response DTO returned by admin endpoints (full view of a user).
+ *
+ * <p>Includes {@code registeredAt} and {@code updatedAt} fields not present in
+ * the self-profile view, giving the admin a complete picture of account lifecycle.
+ */
+public record UserAdminResponse(
+        Long id,
+        String login,
+        String firstName,
+        String lastName,
+        String email,
+        String phone,
+        String status,
+        String role,
+        boolean telegramLinked,
+        OffsetDateTime registeredAt,
+        OffsetDateTime updatedAt
+) {}

--- a/backend/src/main/java/com/padelpro/usuarios/application/dto/UserProfileResponse.java
+++ b/backend/src/main/java/com/padelpro/usuarios/application/dto/UserProfileResponse.java
@@ -1,0 +1,19 @@
+package com.padelpro.usuarios.application.dto;
+
+/**
+ * Response DTO for the authenticated user's own profile (GET /api/usuarios/me).
+ *
+ * <p>{@code telegramLinked} is a computed boolean: {@code telegramChatId != null}.
+ * Password hash and telegram_chat_id are never included in responses (RN-RGPD-03).
+ */
+public record UserProfileResponse(
+        Long id,
+        String login,
+        String firstName,
+        String lastName,
+        String email,
+        String phone,
+        String status,
+        String role,
+        boolean telegramLinked
+) {}

--- a/backend/src/main/java/com/padelpro/usuarios/application/service/UserAdminService.java
+++ b/backend/src/main/java/com/padelpro/usuarios/application/service/UserAdminService.java
@@ -1,0 +1,241 @@
+package com.padelpro.usuarios.application.service;
+
+import com.padelpro.auth.domain.model.AuditLog;
+import com.padelpro.auth.domain.model.User;
+import com.padelpro.auth.domain.model.UserRole;
+import com.padelpro.auth.domain.model.UserStatus;
+import com.padelpro.auth.domain.port.out.AuditLogRepositoryPort;
+import com.padelpro.auth.domain.port.out.UserRepositoryPort;
+import com.padelpro.usuarios.application.dto.CreateUserAdminCommand;
+import com.padelpro.usuarios.application.dto.PagedUsersResponse;
+import com.padelpro.usuarios.application.dto.UpdateUserAdminCommand;
+import com.padelpro.usuarios.application.dto.UserAdminResponse;
+import com.padelpro.usuarios.domain.audit.AuditActions;
+import com.padelpro.usuarios.domain.exception.AdminSelfDeactivationException;
+import com.padelpro.usuarios.domain.exception.EmailConflictException;
+import com.padelpro.usuarios.domain.exception.UserNotFoundException;
+import com.padelpro.usuarios.domain.exception.UserNotPendingException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+/**
+ * Application service for admin user-management operations.
+ *
+ * <p>All mutating operations produce an {@link AuditLog} entry.
+ * IP address is null for admin operations (not originating from a user-facing HTTP request).
+ */
+@Service
+public class UserAdminService {
+
+    private final UserRepositoryPort userRepositoryPort;
+    private final AuditLogRepositoryPort auditLogRepositoryPort;
+    private final BCryptPasswordEncoder passwordEncoder;
+
+    public UserAdminService(UserRepositoryPort userRepositoryPort,
+                            AuditLogRepositoryPort auditLogRepositoryPort,
+                            BCryptPasswordEncoder passwordEncoder) {
+        this.userRepositoryPort   = userRepositoryPort;
+        this.auditLogRepositoryPort = auditLogRepositoryPort;
+        this.passwordEncoder      = passwordEncoder;
+    }
+
+    /**
+     * Create a user directly as ACTIVE (no approval step required for admin-created accounts).
+     *
+     * @throws EmailConflictException if email is already in use
+     * @throws IllegalArgumentException if login is already in use
+     */
+    @Transactional
+    public UserAdminResponse createUser(CreateUserAdminCommand cmd) {
+        if (userRepositoryPort.existsByEmail(cmd.email())) {
+            throw new EmailConflictException();
+        }
+        if (userRepositoryPort.existsByLogin(cmd.login())) {
+            throw new IllegalArgumentException("Login already exists: " + cmd.login());
+        }
+
+        UserRole role = (cmd.role() != null)
+                ? UserRole.valueOf(cmd.role().toUpperCase())
+                : UserRole.USER;
+
+        OffsetDateTime now = OffsetDateTime.now();
+        User user = new User(
+                cmd.login(),
+                passwordEncoder.encode(cmd.password()),
+                cmd.firstName(),
+                cmd.lastName(),
+                cmd.email(),
+                role,
+                UserStatus.ACTIVE,
+                now,
+                now
+        );
+        user.setPhone(cmd.phone());
+
+        User saved = userRepositoryPort.save(user);
+
+        auditLogRepositoryPort.save(new AuditLog(
+                AuditActions.USER_CREATED_BY_ADMIN, saved, null,
+                "login=" + cmd.login(), OffsetDateTime.now()));
+
+        return toAdminResponse(saved);
+    }
+
+    /**
+     * Approve a PENDING user, setting their status to ACTIVE.
+     *
+     * @throws UserNotFoundException  if no user with this id exists
+     * @throws UserNotPendingException if the user is not in PENDING status
+     */
+    @Transactional
+    public UserAdminResponse approveUser(Long targetId) {
+        User user = requireUser(targetId);
+        if (user.getStatus() != UserStatus.PENDING) {
+            throw new UserNotPendingException(targetId);
+        }
+        user.setStatus(UserStatus.ACTIVE);
+        User saved = userRepositoryPort.save(user);
+
+        auditLogRepositoryPort.save(new AuditLog(
+                AuditActions.USER_APPROVED, saved, null,
+                "userId=" + targetId, OffsetDateTime.now()));
+
+        return toAdminResponse(saved);
+    }
+
+    /**
+     * Return a paged list of users, optionally filtered by status.
+     * Page size is capped at 100 regardless of the caller's request.
+     */
+    @Transactional(readOnly = true)
+    public PagedUsersResponse listUsers(UserStatus status, Pageable pageable) {
+        int cappedSize = Math.min(pageable.getPageSize(), 100);
+        Pageable capped = PageRequest.of(pageable.getPageNumber(), cappedSize,
+                pageable.getSort());
+
+        Page<User> page = (status != null)
+                ? userRepositoryPort.findByStatus(status, capped)
+                : userRepositoryPort.findAll(capped);
+
+        List<UserAdminResponse> content = page.getContent().stream()
+                .map(UserAdminService::toAdminResponse)
+                .toList();
+
+        return new PagedUsersResponse(
+                content,
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.getNumber(),
+                page.getSize()
+        );
+    }
+
+    /**
+     * Return a single user by id.
+     *
+     * @throws UserNotFoundException if no user with this id exists
+     */
+    @Transactional(readOnly = true)
+    public UserAdminResponse getUser(Long id) {
+        return toAdminResponse(requireUser(id));
+    }
+
+    /**
+     * Apply a partial update to any user account.
+     * Audits a role change if the role field is present and different.
+     *
+     * @throws UserNotFoundException  if no user with this id exists
+     * @throws EmailConflictException if the new email is already used by another user
+     */
+    @Transactional
+    public UserAdminResponse updateUser(Long id, UpdateUserAdminCommand cmd) {
+        User user = requireUser(id);
+
+        if (cmd.email() != null && !cmd.email().equals(user.getEmail())) {
+            if (userRepositoryPort.existsByEmailAndIdNot(cmd.email(), id)) {
+                throw new EmailConflictException();
+            }
+            user.setEmail(cmd.email());
+        }
+        if (cmd.firstName() != null) user.setFirstName(cmd.firstName());
+        if (cmd.lastName()  != null) user.setLastName(cmd.lastName());
+        if (cmd.phone()     != null) user.setPhone(cmd.phone());
+
+        boolean roleChanged = false;
+        if (cmd.role() != null) {
+            UserRole newRole = UserRole.valueOf(cmd.role().toUpperCase());
+            if (newRole != user.getRole()) {
+                user.setRole(newRole);
+                roleChanged = true;
+            }
+        }
+        if (cmd.status() != null) {
+            user.setStatus(UserStatus.valueOf(cmd.status().toUpperCase()));
+        }
+
+        User saved = userRepositoryPort.save(user);
+
+        if (roleChanged) {
+            auditLogRepositoryPort.save(new AuditLog(
+                    AuditActions.USER_ROLE_CHANGED, saved, null,
+                    "userId=" + id + " newRole=" + cmd.role(), OffsetDateTime.now()));
+        }
+
+        return toAdminResponse(saved);
+    }
+
+    /**
+     * Deactivate a user (soft-delete via status=INACTIVE).
+     * An admin cannot deactivate their own account (RN-AUTH-05).
+     *
+     * @param targetId the id of the user to deactivate
+     * @param adminId  the id of the requesting admin
+     * @throws AdminSelfDeactivationException if targetId == adminId
+     * @throws UserNotFoundException          if the target user does not exist
+     */
+    @Transactional
+    public void deactivateUser(Long targetId, Long adminId) {
+        if (targetId.equals(adminId)) {
+            throw new AdminSelfDeactivationException();
+        }
+        User user = requireUser(targetId);
+        user.setStatus(UserStatus.INACTIVE);
+        User saved = userRepositoryPort.save(user);
+
+        auditLogRepositoryPort.save(new AuditLog(
+                AuditActions.USER_DEACTIVATED, saved, null,
+                "deactivatedBy=" + adminId, OffsetDateTime.now()));
+    }
+
+    // -------------------------------------------------------------------------
+    // helpers
+    // -------------------------------------------------------------------------
+
+    private User requireUser(Long id) {
+        return userRepositoryPort.findById(id)
+                .orElseThrow(() -> new UserNotFoundException(id));
+    }
+
+    static UserAdminResponse toAdminResponse(User user) {
+        return new UserAdminResponse(
+                user.getId(),
+                user.getLogin(),
+                user.getFirstName(),
+                user.getLastName(),
+                user.getEmail(),
+                user.getPhone(),
+                user.getStatus().name(),
+                user.getRole().name(),
+                user.getTelegramChatId() != null,
+                user.getRegisteredAt(),
+                user.getUpdatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/padelpro/usuarios/application/service/UserProfileService.java
+++ b/backend/src/main/java/com/padelpro/usuarios/application/service/UserProfileService.java
@@ -1,0 +1,90 @@
+package com.padelpro.usuarios.application.service;
+
+import com.padelpro.auth.domain.model.User;
+import com.padelpro.auth.domain.port.out.UserRepositoryPort;
+import com.padelpro.usuarios.application.dto.UpdateMyProfileCommand;
+import com.padelpro.usuarios.application.dto.UserProfileResponse;
+import com.padelpro.usuarios.domain.exception.EmailConflictException;
+import com.padelpro.usuarios.domain.exception.UserNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Application service for self-profile operations (GET/PATCH /api/usuarios/me).
+ *
+ * <p>Users may update firstName, lastName, email, and phone.
+ * Role and status are read-only from the user's perspective.
+ */
+@Service
+public class UserProfileService {
+
+    private final UserRepositoryPort userRepositoryPort;
+
+    public UserProfileService(UserRepositoryPort userRepositoryPort) {
+        this.userRepositoryPort = userRepositoryPort;
+    }
+
+    /**
+     * Return the profile of the authenticated user.
+     *
+     * @param userId the id extracted from the JWT
+     * @throws UserNotFoundException if no user with this id exists
+     */
+    @Transactional(readOnly = true)
+    public UserProfileResponse getMyProfile(Long userId) {
+        User user = requireUser(userId);
+        return toProfileResponse(user);
+    }
+
+    /**
+     * Apply a partial update to the authenticated user's own profile.
+     *
+     * <p>Only non-null fields in the command are applied.
+     * Role and status cannot be changed via this operation.
+     *
+     * @param userId the id extracted from the JWT
+     * @param cmd    the partial update command
+     * @throws UserNotFoundException  if no user with this id exists
+     * @throws EmailConflictException if the requested email is already used by another user
+     */
+    @Transactional
+    public UserProfileResponse updateMyProfile(Long userId, UpdateMyProfileCommand cmd) {
+        User user = requireUser(userId);
+
+        if (cmd.email() != null && !cmd.email().equals(user.getEmail())) {
+            if (userRepositoryPort.existsByEmailAndIdNot(cmd.email(), userId)) {
+                throw new EmailConflictException();
+            }
+            user.setEmail(cmd.email());
+        }
+        if (cmd.firstName() != null) user.setFirstName(cmd.firstName());
+        if (cmd.lastName()  != null) user.setLastName(cmd.lastName());
+        if (cmd.phone()     != null) user.setPhone(cmd.phone());
+
+        User saved = userRepositoryPort.save(user);
+        return toProfileResponse(saved);
+    }
+
+    // -------------------------------------------------------------------------
+    // helpers
+    // -------------------------------------------------------------------------
+
+    private User requireUser(Long userId) {
+        return userRepositoryPort.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(userId));
+    }
+
+    static UserProfileResponse toProfileResponse(User user) {
+        return new UserProfileResponse(
+                user.getId(),
+                user.getLogin(),
+                user.getFirstName(),
+                user.getLastName(),
+                user.getEmail(),
+                user.getPhone(),
+                user.getStatus().name(),
+                user.getRole().name(),
+                user.getTelegramChatId() != null
+        );
+    }
+}

--- a/backend/src/main/java/com/padelpro/usuarios/domain/audit/AuditActions.java
+++ b/backend/src/main/java/com/padelpro/usuarios/domain/audit/AuditActions.java
@@ -1,0 +1,19 @@
+package com.padelpro.usuarios.domain.audit;
+
+/**
+ * Audit action constants for the usuarios capability.
+ *
+ * <p>Known actions from auth-local: USER_REGISTERED, LOGIN_SUCCESS, LOGIN_FAILURE, TOKEN_TAMPERED.
+ * This class adds the admin-management actions introduced in the usuarios change.
+ */
+public final class AuditActions {
+
+    public static final String USER_CREATED_BY_ADMIN = "USER_CREATED_BY_ADMIN";
+    public static final String USER_APPROVED         = "USER_APPROVED";
+    public static final String USER_DEACTIVATED      = "USER_DEACTIVATED";
+    public static final String USER_ROLE_CHANGED     = "USER_ROLE_CHANGED";
+
+    private AuditActions() {
+        // Utility class — not instantiable
+    }
+}

--- a/backend/src/main/java/com/padelpro/usuarios/domain/exception/AdminSelfDeactivationException.java
+++ b/backend/src/main/java/com/padelpro/usuarios/domain/exception/AdminSelfDeactivationException.java
@@ -1,0 +1,11 @@
+package com.padelpro.usuarios.domain.exception;
+
+/**
+ * Thrown when an admin attempts to deactivate their own account (RN-AUTH-05).
+ */
+public class AdminSelfDeactivationException extends RuntimeException {
+
+    public AdminSelfDeactivationException() {
+        super("An admin cannot deactivate their own account");
+    }
+}

--- a/backend/src/main/java/com/padelpro/usuarios/domain/exception/EmailConflictException.java
+++ b/backend/src/main/java/com/padelpro/usuarios/domain/exception/EmailConflictException.java
@@ -1,0 +1,12 @@
+package com.padelpro.usuarios.domain.exception;
+
+/**
+ * Thrown when an email address is already in use by another user.
+ * Used during profile updates and admin user creation to signal a 409 conflict.
+ */
+public class EmailConflictException extends RuntimeException {
+
+    public EmailConflictException() {
+        super("Email address is already in use");
+    }
+}

--- a/backend/src/main/java/com/padelpro/usuarios/domain/exception/UserNotFoundException.java
+++ b/backend/src/main/java/com/padelpro/usuarios/domain/exception/UserNotFoundException.java
@@ -1,0 +1,11 @@
+package com.padelpro.usuarios.domain.exception;
+
+/**
+ * Thrown when a requested user does not exist in the system.
+ */
+public class UserNotFoundException extends RuntimeException {
+
+    public UserNotFoundException(Long id) {
+        super("User not found: " + id);
+    }
+}

--- a/backend/src/main/java/com/padelpro/usuarios/domain/exception/UserNotPendingException.java
+++ b/backend/src/main/java/com/padelpro/usuarios/domain/exception/UserNotPendingException.java
@@ -1,0 +1,11 @@
+package com.padelpro.usuarios.domain.exception;
+
+/**
+ * Thrown when an approval operation is attempted on a user whose status is not PENDING.
+ */
+public class UserNotPendingException extends RuntimeException {
+
+    public UserNotPendingException(Long id) {
+        super("User " + id + " is not in PENDING status");
+    }
+}

--- a/backend/src/main/java/com/padelpro/usuarios/infrastructure/web/AdminUsuariosController.java
+++ b/backend/src/main/java/com/padelpro/usuarios/infrastructure/web/AdminUsuariosController.java
@@ -1,0 +1,121 @@
+package com.padelpro.usuarios.infrastructure.web;
+
+import com.padelpro.auth.domain.model.UserStatus;
+import com.padelpro.usuarios.application.dto.CreateUserAdminCommand;
+import com.padelpro.usuarios.application.dto.PagedUsersResponse;
+import com.padelpro.usuarios.application.dto.UpdateUserAdminCommand;
+import com.padelpro.usuarios.application.dto.UserAdminResponse;
+import com.padelpro.usuarios.application.service.UserAdminService;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST controller for ADMIN user-management operations.
+ *
+ * <p>All endpoints require {@code ROLE_ADMIN} — enforced at the method level via
+ * {@code @PreAuthorize} (requires {@code @EnableMethodSecurity} on {@link
+ * com.padelpro.auth.infrastructure.config.SecurityConfig}).
+ */
+@RestController
+@RequestMapping("/api/admin/usuarios")
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminUsuariosController {
+
+    private final UserAdminService userAdminService;
+
+    public AdminUsuariosController(UserAdminService userAdminService) {
+        this.userAdminService = userAdminService;
+    }
+
+    /**
+     * GET /api/admin/usuarios?status=&page=&size=
+     * Lists users, optionally filtered by status. Page size is capped at 100.
+     */
+    @GetMapping
+    public ResponseEntity<PagedUsersResponse> listUsers(
+            @RequestParam(required = false) String status,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+
+        UserStatus statusFilter = (status != null && !status.isBlank())
+                ? UserStatus.valueOf(status.toUpperCase())
+                : null;
+        Pageable pageable = PageRequest.of(page, size);
+        return ResponseEntity.ok(userAdminService.listUsers(statusFilter, pageable));
+    }
+
+    /**
+     * POST /api/admin/usuarios
+     * Creates a new user directly with status=ACTIVE.
+     */
+    @PostMapping
+    public ResponseEntity<UserAdminResponse> createUser(
+            @RequestBody CreateUserAdminCommand command) {
+        UserAdminResponse created = userAdminService.createUser(command);
+        return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    }
+
+    /**
+     * GET /api/admin/usuarios/{id}
+     * Returns the full profile of a specific user.
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<UserAdminResponse> getUser(@PathVariable Long id) {
+        return ResponseEntity.ok(userAdminService.getUser(id));
+    }
+
+    /**
+     * PATCH /api/admin/usuarios/{id}
+     * Partially updates any user (including role and status).
+     */
+    @PatchMapping("/{id}")
+    public ResponseEntity<UserAdminResponse> updateUser(
+            @PathVariable Long id,
+            @RequestBody UpdateUserAdminCommand command) {
+        return ResponseEntity.ok(userAdminService.updateUser(id, command));
+    }
+
+    /**
+     * PATCH /api/admin/usuarios/{id}/aprobar
+     * Approves a PENDING user, setting their status to ACTIVE.
+     */
+    @PatchMapping("/{id}/aprobar")
+    public ResponseEntity<UserAdminResponse> approveUser(@PathVariable Long id) {
+        return ResponseEntity.ok(userAdminService.approveUser(id));
+    }
+
+    /**
+     * DELETE /api/admin/usuarios/{id}
+     * Deactivates a user (soft-delete: status=INACTIVE).
+     * An admin cannot deactivate their own account (RN-AUTH-05).
+     */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deactivateUser(@PathVariable Long id) {
+        Long adminId = resolveAdminId();
+        userAdminService.deactivateUser(id, adminId);
+        return ResponseEntity.noContent().build();
+    }
+
+    // -------------------------------------------------------------------------
+    // helpers
+    // -------------------------------------------------------------------------
+
+    private Long resolveAdminId() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        return Long.parseLong((String) auth.getPrincipal());
+    }
+}

--- a/backend/src/main/java/com/padelpro/usuarios/infrastructure/web/UsuariosMeController.java
+++ b/backend/src/main/java/com/padelpro/usuarios/infrastructure/web/UsuariosMeController.java
@@ -1,0 +1,66 @@
+package com.padelpro.usuarios.infrastructure.web;
+
+import com.padelpro.usuarios.application.dto.UpdateMyProfileCommand;
+import com.padelpro.usuarios.application.dto.UserProfileResponse;
+import com.padelpro.usuarios.application.service.UserProfileService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST controller for the authenticated user's own profile.
+ *
+ * <p>GET  /api/usuarios/me  — read own profile.<br>
+ * PATCH /api/usuarios/me  — partial update of own profile (firstName, lastName, email, phone).
+ *
+ * <p>The JWT subject is the user id (Long as String), placed there by
+ * {@link com.padelpro.auth.application.service.JwtService} and validated by
+ * {@link com.padelpro.auth.infrastructure.web.filter.JwtAuthFilter}.
+ */
+@RestController
+@RequestMapping("/api/usuarios")
+public class UsuariosMeController {
+
+    private final UserProfileService userProfileService;
+
+    public UsuariosMeController(UserProfileService userProfileService) {
+        this.userProfileService = userProfileService;
+    }
+
+    /**
+     * GET /api/usuarios/me
+     * Returns the profile of the currently authenticated user.
+     */
+    @GetMapping("/me")
+    public ResponseEntity<UserProfileResponse> getMyProfile() {
+        Long userId = resolveUserId();
+        return ResponseEntity.ok(userProfileService.getMyProfile(userId));
+    }
+
+    /**
+     * PATCH /api/usuarios/me
+     * Partially updates the profile of the currently authenticated user.
+     * Fields {@code role} and {@code status} are intentionally absent from
+     * {@link UpdateMyProfileCommand} — they are silently ignored if sent in the body.
+     */
+    @PatchMapping("/me")
+    public ResponseEntity<UserProfileResponse> updateMyProfile(
+            @RequestBody UpdateMyProfileCommand command) {
+        Long userId = resolveUserId();
+        return ResponseEntity.ok(userProfileService.updateMyProfile(userId, command));
+    }
+
+    // -------------------------------------------------------------------------
+    // helpers
+    // -------------------------------------------------------------------------
+
+    private Long resolveUserId() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        return Long.parseLong((String) auth.getPrincipal());
+    }
+}

--- a/backend/src/main/resources/db/migration/V4__add_phone_telegram_to_users.sql
+++ b/backend/src/main/resources/db/migration/V4__add_phone_telegram_to_users.sql
@@ -1,0 +1,9 @@
+-- =============================================================================
+-- V4__add_phone_telegram_to_users.sql
+-- Añade campos phone y telegram a la tabla users — change: usuarios
+-- =============================================================================
+
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS phone              VARCHAR(20),
+    ADD COLUMN IF NOT EXISTS telegram_chat_id   VARCHAR(50),
+    ADD COLUMN IF NOT EXISTS telegram_linked_at TIMESTAMPTZ;

--- a/backend/src/test/java/com/padelpro/usuarios/application/service/UserAdminServiceTest.java
+++ b/backend/src/test/java/com/padelpro/usuarios/application/service/UserAdminServiceTest.java
@@ -1,0 +1,209 @@
+package com.padelpro.usuarios.application.service;
+
+import com.padelpro.auth.domain.model.AuditLog;
+import com.padelpro.auth.domain.model.User;
+import com.padelpro.auth.domain.model.UserRole;
+import com.padelpro.auth.domain.model.UserStatus;
+import com.padelpro.auth.domain.port.out.AuditLogRepositoryPort;
+import com.padelpro.auth.domain.port.out.UserRepositoryPort;
+import com.padelpro.usuarios.application.dto.CreateUserAdminCommand;
+import com.padelpro.usuarios.application.dto.PagedUsersResponse;
+import com.padelpro.usuarios.application.dto.UserAdminResponse;
+import com.padelpro.usuarios.domain.exception.AdminSelfDeactivationException;
+import com.padelpro.usuarios.domain.exception.EmailConflictException;
+import com.padelpro.usuarios.domain.exception.UserNotFoundException;
+import com.padelpro.usuarios.domain.exception.UserNotPendingException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserAdminService — unit tests")
+class UserAdminServiceTest {
+
+    @Mock
+    private UserRepositoryPort userRepositoryPort;
+
+    @Mock
+    private AuditLogRepositoryPort auditLogRepositoryPort;
+
+    @Mock
+    private BCryptPasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private UserAdminService userAdminService;
+
+    private User pendingUser;
+    private User activeUser;
+    private User adminUser;
+
+    @BeforeEach
+    void setUp() {
+        pendingUser = makeUser(1L, "pending.user", UserStatus.PENDING, UserRole.USER);
+        activeUser  = makeUser(2L, "active.user",  UserStatus.ACTIVE,  UserRole.USER);
+        adminUser   = makeUser(3L, "admin.user",   UserStatus.ACTIVE,  UserRole.ADMIN);
+    }
+
+    // -------------------------------------------------------------------------
+    // createUser
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("should_create_user_with_active_status_and_bcrypt_hash")
+    void should_create_user_with_active_status_and_bcrypt_hash() {
+        when(userRepositoryPort.existsByEmail("new@example.com")).thenReturn(false);
+        when(userRepositoryPort.existsByLogin("newlogin")).thenReturn(false);
+        when(passwordEncoder.encode("P@ssword1")).thenReturn("$2a$12$hashed");
+        when(userRepositoryPort.save(any(User.class))).thenAnswer(inv -> {
+            User u = inv.getArgument(0);
+            setId(u, 10L);
+            return u;
+        });
+        when(auditLogRepositoryPort.save(any(AuditLog.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        CreateUserAdminCommand cmd = new CreateUserAdminCommand(
+                "newlogin", "New", "User", "new@example.com", "P@ssword1", null, null);
+
+        UserAdminResponse response = userAdminService.createUser(cmd);
+
+        assertThat(response.status()).isEqualTo("ACTIVE");
+        assertThat(response.role()).isEqualTo("USER");
+        verify(passwordEncoder).encode("P@ssword1");
+        verify(auditLogRepositoryPort).save(any(AuditLog.class));
+    }
+
+    @Test
+    @DisplayName("should_throw_email_conflict_when_creating_duplicate_email")
+    void should_throw_email_conflict_when_creating_duplicate_email() {
+        when(userRepositoryPort.existsByEmail("dup@example.com")).thenReturn(true);
+
+        CreateUserAdminCommand cmd = new CreateUserAdminCommand(
+                "somelogin", "A", "B", "dup@example.com", "P@ssword1", null, null);
+
+        assertThatThrownBy(() -> userAdminService.createUser(cmd))
+                .isInstanceOf(EmailConflictException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // approveUser
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("should_approve_pending_user_and_audit")
+    void should_approve_pending_user_and_audit() {
+        when(userRepositoryPort.findById(1L)).thenReturn(Optional.of(pendingUser));
+        when(userRepositoryPort.save(any(User.class))).thenReturn(pendingUser);
+        when(auditLogRepositoryPort.save(any(AuditLog.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        UserAdminResponse response = userAdminService.approveUser(1L);
+
+        assertThat(response.status()).isEqualTo("ACTIVE");
+        verify(auditLogRepositoryPort).save(any(AuditLog.class));
+    }
+
+    @Test
+    @DisplayName("should_throw_when_approving_non_pending_user")
+    void should_throw_when_approving_non_pending_user() {
+        when(userRepositoryPort.findById(2L)).thenReturn(Optional.of(activeUser));
+
+        assertThatThrownBy(() -> userAdminService.approveUser(2L))
+                .isInstanceOf(UserNotPendingException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // listUsers
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("should_return_paged_users_with_max_size_100")
+    void should_return_paged_users_with_max_size_100() {
+        // Request with size=200 — service must cap it at 100
+        Pageable requested = PageRequest.of(0, 200);
+        Page<User> page = new PageImpl<>(List.of(activeUser), PageRequest.of(0, 100), 1);
+        when(userRepositoryPort.findAll(any(Pageable.class))).thenReturn(page);
+
+        PagedUsersResponse response = userAdminService.listUsers(null, requested);
+
+        assertThat(response.size()).isLessThanOrEqualTo(100);
+        assertThat(response.totalElements()).isEqualTo(1);
+    }
+
+    // -------------------------------------------------------------------------
+    // getUser
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("should_throw_not_found_when_user_does_not_exist")
+    void should_throw_not_found_when_user_does_not_exist() {
+        when(userRepositoryPort.findById(999L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userAdminService.getUser(999L))
+                .isInstanceOf(UserNotFoundException.class)
+                .hasMessageContaining("999");
+    }
+
+    // -------------------------------------------------------------------------
+    // deactivateUser
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("should_deactivate_user_and_audit")
+    void should_deactivate_user_and_audit() {
+        when(userRepositoryPort.findById(2L)).thenReturn(Optional.of(activeUser));
+        when(userRepositoryPort.save(any(User.class))).thenReturn(activeUser);
+        when(auditLogRepositoryPort.save(any(AuditLog.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        userAdminService.deactivateUser(2L, 3L);
+
+        assertThat(activeUser.getStatus()).isEqualTo(UserStatus.INACTIVE);
+        verify(auditLogRepositoryPort).save(any(AuditLog.class));
+    }
+
+    @Test
+    @DisplayName("should_throw_admin_self_deactivation_exception")
+    void should_throw_admin_self_deactivation_exception() {
+        assertThatThrownBy(() -> userAdminService.deactivateUser(3L, 3L))
+                .isInstanceOf(AdminSelfDeactivationException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // helpers
+    // -------------------------------------------------------------------------
+
+    private User makeUser(Long id, String login, UserStatus status, UserRole role) {
+        User u = new User(login, "$2a$12$hash", "First", "Last",
+                login + "@example.com", role, status,
+                OffsetDateTime.now().minusDays(5), OffsetDateTime.now().minusDays(1));
+        setId(u, id);
+        return u;
+    }
+
+    private void setId(User u, Long id) {
+        try {
+            var f = User.class.getDeclaredField("id");
+            f.setAccessible(true);
+            f.set(u, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/backend/src/test/java/com/padelpro/usuarios/application/service/UserProfileServiceTest.java
+++ b/backend/src/test/java/com/padelpro/usuarios/application/service/UserProfileServiceTest.java
@@ -1,0 +1,122 @@
+package com.padelpro.usuarios.application.service;
+
+import com.padelpro.auth.domain.model.User;
+import com.padelpro.auth.domain.model.UserRole;
+import com.padelpro.auth.domain.model.UserStatus;
+import com.padelpro.auth.domain.port.out.UserRepositoryPort;
+import com.padelpro.usuarios.application.dto.UpdateMyProfileCommand;
+import com.padelpro.usuarios.application.dto.UserProfileResponse;
+import com.padelpro.usuarios.domain.exception.EmailConflictException;
+import com.padelpro.usuarios.domain.exception.UserNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserProfileService — unit tests")
+class UserProfileServiceTest {
+
+    @Mock
+    private UserRepositoryPort userRepositoryPort;
+
+    @InjectMocks
+    private UserProfileService userProfileService;
+
+    private User existingUser;
+
+    @BeforeEach
+    void setUp() {
+        existingUser = new User(
+                "juan.garcia",
+                "$2a$12$hashedpassword",
+                "Juan",
+                "Garcia",
+                "juan@example.com",
+                UserRole.USER,
+                UserStatus.ACTIVE,
+                OffsetDateTime.now().minusDays(10),
+                OffsetDateTime.now().minusDays(1)
+        );
+        existingUser.setPhone("+34600000001");
+        // inject id via reflection since there's no public setter
+        try {
+            var idField = User.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(existingUser, 42L);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    @DisplayName("should_return_profile_when_user_exists")
+    void should_return_profile_when_user_exists() {
+        when(userRepositoryPort.findById(42L)).thenReturn(Optional.of(existingUser));
+
+        UserProfileResponse response = userProfileService.getMyProfile(42L);
+
+        assertThat(response.id()).isEqualTo(42L);
+        assertThat(response.login()).isEqualTo("juan.garcia");
+        assertThat(response.firstName()).isEqualTo("Juan");
+        assertThat(response.email()).isEqualTo("juan@example.com");
+        assertThat(response.phone()).isEqualTo("+34600000001");
+        assertThat(response.role()).isEqualTo("USER");
+        assertThat(response.status()).isEqualTo("ACTIVE");
+        assertThat(response.telegramLinked()).isFalse();
+    }
+
+    @Test
+    @DisplayName("should_throw_user_not_found_when_user_missing")
+    void should_throw_user_not_found_when_user_missing() {
+        when(userRepositoryPort.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userProfileService.getMyProfile(99L))
+                .isInstanceOf(UserNotFoundException.class)
+                .hasMessageContaining("99");
+    }
+
+    @Test
+    @DisplayName("should_update_profile_when_fields_are_valid")
+    void should_update_profile_when_fields_are_valid() {
+        when(userRepositoryPort.findById(42L)).thenReturn(Optional.of(existingUser));
+        when(userRepositoryPort.existsByEmailAndIdNot("new@example.com", 42L)).thenReturn(false);
+        when(userRepositoryPort.save(any(User.class))).thenReturn(existingUser);
+
+        UpdateMyProfileCommand cmd = new UpdateMyProfileCommand(
+                "NuevoNombre", "NuevoApellido", "new@example.com", "+34611111111");
+
+        UserProfileResponse response = userProfileService.updateMyProfile(42L, cmd);
+
+        assertThat(response).isNotNull();
+        verify(userRepositoryPort).save(existingUser);
+        assertThat(existingUser.getFirstName()).isEqualTo("NuevoNombre");
+        assertThat(existingUser.getLastName()).isEqualTo("NuevoApellido");
+        assertThat(existingUser.getEmail()).isEqualTo("new@example.com");
+        assertThat(existingUser.getPhone()).isEqualTo("+34611111111");
+    }
+
+    @Test
+    @DisplayName("should_throw_email_conflict_when_email_already_taken")
+    void should_throw_email_conflict_when_email_already_taken() {
+        when(userRepositoryPort.findById(42L)).thenReturn(Optional.of(existingUser));
+        when(userRepositoryPort.existsByEmailAndIdNot("taken@example.com", 42L)).thenReturn(true);
+
+        UpdateMyProfileCommand cmd = new UpdateMyProfileCommand(
+                null, null, "taken@example.com", null);
+
+        assertThatThrownBy(() -> userProfileService.updateMyProfile(42L, cmd))
+                .isInstanceOf(EmailConflictException.class);
+    }
+}

--- a/backend/src/test/java/com/padelpro/usuarios/infrastructure/web/AdminUsuariosControllerIntegrationTest.java
+++ b/backend/src/test/java/com/padelpro/usuarios/infrastructure/web/AdminUsuariosControllerIntegrationTest.java
@@ -1,0 +1,224 @@
+package com.padelpro.usuarios.infrastructure.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.padelpro.auth.application.service.JwtService;
+import com.padelpro.auth.domain.model.User;
+import com.padelpro.auth.domain.model.UserRole;
+import com.padelpro.auth.domain.model.UserStatus;
+import com.padelpro.auth.infrastructure.persistence.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Integration tests for AdminUsuariosController (/api/admin/usuarios).
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@Testcontainers
+@ActiveProfiles("it")
+@Sql(scripts = "/sql/cleanup.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+class AdminUsuariosControllerIntegrationTest {
+
+    @Container
+    static final PostgreSQLContainer<?> postgres =
+            new PostgreSQLContainer<>("postgres:15-alpine")
+                    .withDatabaseName("padelpro_test")
+                    .withUsername("padelpro_test")
+                    .withPassword("padelpro_test");
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private UserRepository userRepository;
+    @Autowired private BCryptPasswordEncoder passwordEncoder;
+    @Autowired private JwtService jwtService;
+
+    private User adminUser;
+    private User regularUser;
+    private User pendingUser;
+    private String adminToken;
+    private String userToken;
+
+    @BeforeEach
+    void setUp() {
+        OffsetDateTime now = OffsetDateTime.now();
+
+        adminUser = userRepository.saveAndFlush(new User(
+                "admin.user", passwordEncoder.encode("Password1"),
+                "Admin", "User", "admin@example.com",
+                UserRole.ADMIN, UserStatus.ACTIVE, now, now));
+
+        regularUser = userRepository.saveAndFlush(new User(
+                "regular.user", passwordEncoder.encode("Password1"),
+                "Regular", "User", "regular@example.com",
+                UserRole.USER, UserStatus.ACTIVE, now, now));
+
+        pendingUser = userRepository.saveAndFlush(new User(
+                "pending.user", passwordEncoder.encode("Password1"),
+                "Pending", "User", "pending@example.com",
+                UserRole.USER, UserStatus.PENDING, now, now));
+
+        adminToken = jwtService.generateAccessToken(adminUser);
+        userToken  = jwtService.generateAccessToken(regularUser);
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /api/admin/usuarios
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("POST /api/admin/usuarios valid → 201 status=ACTIVE")
+    void create_user_valid_returns_201_active() throws Exception {
+        Map<String, String> body = Map.of(
+                "login", "new.user",
+                "firstName", "New",
+                "lastName", "User",
+                "email", "newuser@example.com",
+                "password", "Password1"
+        );
+        mockMvc.perform(post("/api/admin/usuarios")
+                        .header("Authorization", "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status", is("ACTIVE")))
+                .andExpect(jsonPath("$.role", is("USER")))
+                .andExpect(jsonPath("$.login", is("new.user")));
+    }
+
+    @Test
+    @DisplayName("POST /api/admin/usuarios duplicate email → 409")
+    void create_user_duplicate_email_returns_409() throws Exception {
+        Map<String, String> body = Map.of(
+                "login", "another.login",
+                "firstName", "A",
+                "lastName", "B",
+                "email", "regular@example.com",   // already used by regularUser
+                "password", "Password1"
+        );
+        mockMvc.perform(post("/api/admin/usuarios")
+                        .header("Authorization", "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error", is("USUARIOS_EMAIL_CONFLICT")));
+    }
+
+    // -------------------------------------------------------------------------
+    // PATCH /api/admin/usuarios/{id}/aprobar
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("PATCH /api/admin/usuarios/{id}/aprobar on PENDING → 200 status=ACTIVE")
+    void approve_pending_user_returns_200_active() throws Exception {
+        mockMvc.perform(patch("/api/admin/usuarios/{id}/aprobar", pendingUser.getId())
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status", is("ACTIVE")));
+    }
+
+    @Test
+    @DisplayName("PATCH /api/admin/usuarios/{id}/aprobar on ACTIVE → 422")
+    void approve_active_user_returns_422() throws Exception {
+        mockMvc.perform(patch("/api/admin/usuarios/{id}/aprobar", regularUser.getId())
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.error", is("USUARIO_NOT_PENDING")));
+    }
+
+    // -------------------------------------------------------------------------
+    // GET /api/admin/usuarios?status=
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("GET /api/admin/usuarios?status=PENDING → 200 contains only PENDING users")
+    void list_users_filtered_by_pending() throws Exception {
+        mockMvc.perform(get("/api/admin/usuarios")
+                        .param("status", "PENDING")
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements", is(1)))
+                .andExpect(jsonPath("$.content[0].status", is("PENDING")));
+    }
+
+    // -------------------------------------------------------------------------
+    // DELETE /api/admin/usuarios/{id}
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("DELETE /api/admin/usuarios/{id} → 204 and user becomes INACTIVE")
+    void deactivate_user_returns_204() throws Exception {
+        mockMvc.perform(delete("/api/admin/usuarios/{id}", regularUser.getId())
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isNoContent());
+
+        // Verify in DB
+        User updated = userRepository.findByLogin(regularUser.getLogin()).orElseThrow();
+        assert updated.getStatus() == UserStatus.INACTIVE;
+    }
+
+    @Test
+    @DisplayName("DELETE /api/admin/usuarios/{self} → 422 (RN-AUTH-05)")
+    void deactivate_self_returns_422() throws Exception {
+        mockMvc.perform(delete("/api/admin/usuarios/{id}", adminUser.getId())
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.error", is("ADMIN_SELF_DEACTIVATION")));
+    }
+
+    // -------------------------------------------------------------------------
+    // Authorization checks
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("GET /api/admin/usuarios with role USER → 403")
+    void list_users_with_user_role_returns_403() throws Exception {
+        mockMvc.perform(get("/api/admin/usuarios")
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isForbidden());
+    }
+
+    // -------------------------------------------------------------------------
+    // GET /api/admin/usuarios/{id}
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("GET /api/admin/usuarios/{id} non-existent → 404")
+    void get_user_nonexistent_returns_404() throws Exception {
+        mockMvc.perform(get("/api/admin/usuarios/{id}", 999999L)
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error", is("USUARIO_NOT_FOUND")));
+    }
+}

--- a/backend/src/test/java/com/padelpro/usuarios/infrastructure/web/UsuariosMeControllerIntegrationTest.java
+++ b/backend/src/test/java/com/padelpro/usuarios/infrastructure/web/UsuariosMeControllerIntegrationTest.java
@@ -1,0 +1,173 @@
+package com.padelpro.usuarios.infrastructure.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.padelpro.auth.application.service.JwtService;
+import com.padelpro.auth.domain.model.User;
+import com.padelpro.auth.domain.model.UserRole;
+import com.padelpro.auth.domain.model.UserStatus;
+import com.padelpro.auth.infrastructure.persistence.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Integration tests for UsuariosMeController (GET/PATCH /api/usuarios/me).
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@Testcontainers
+@ActiveProfiles("it")
+@Sql(scripts = "/sql/cleanup.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+class UsuariosMeControllerIntegrationTest {
+
+    @Container
+    static final PostgreSQLContainer<?> postgres =
+            new PostgreSQLContainer<>("postgres:15-alpine")
+                    .withDatabaseName("padelpro_test")
+                    .withUsername("padelpro_test")
+                    .withPassword("padelpro_test");
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private BCryptPasswordEncoder passwordEncoder;
+
+    @Autowired
+    private JwtService jwtService;
+
+    private User testUser;
+    private String userToken;
+
+    @BeforeEach
+    void setUp() {
+        OffsetDateTime now = OffsetDateTime.now();
+        testUser = new User(
+                "me.user",
+                passwordEncoder.encode("Password1"),
+                "Me",
+                "User",
+                "me.user@example.com",
+                UserRole.USER,
+                UserStatus.ACTIVE,
+                now,
+                now
+        );
+        testUser = userRepository.saveAndFlush(testUser);
+        userToken = jwtService.generateAccessToken(testUser);
+    }
+
+    @Test
+    @DisplayName("GET /api/usuarios/me with valid JWT returns 200")
+    void get_me_with_valid_jwt_returns_200() throws Exception {
+        mockMvc.perform(get("/api/usuarios/me")
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.login", is("me.user")))
+                .andExpect(jsonPath("$.email", is("me.user@example.com")))
+                .andExpect(jsonPath("$.role", is("USER")))
+                .andExpect(jsonPath("$.status", is("ACTIVE")));
+    }
+
+    @Test
+    @DisplayName("GET /api/usuarios/me without JWT returns 401")
+    void get_me_without_jwt_returns_401() throws Exception {
+        mockMvc.perform(get("/api/usuarios/me"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("PATCH /api/usuarios/me with valid fields returns 200")
+    void patch_me_with_valid_fields_returns_200() throws Exception {
+        Map<String, String> body = Map.of(
+                "firstName", "Updated",
+                "lastName", "Name",
+                "phone", "+34611000001"
+        );
+        mockMvc.perform(patch("/api/usuarios/me")
+                        .header("Authorization", "Bearer " + userToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.firstName", is("Updated")))
+                .andExpect(jsonPath("$.lastName", is("Name")))
+                .andExpect(jsonPath("$.phone", is("+34611000001")));
+    }
+
+    @Test
+    @DisplayName("PATCH /api/usuarios/me with duplicate email returns 409")
+    void patch_me_with_duplicate_email_returns_409() throws Exception {
+        // Create a second user with a different email
+        OffsetDateTime now = OffsetDateTime.now();
+        User other = new User(
+                "other.user",
+                passwordEncoder.encode("Password1"),
+                "Other",
+                "User",
+                "other@example.com",
+                UserRole.USER,
+                UserStatus.ACTIVE,
+                now,
+                now
+        );
+        userRepository.saveAndFlush(other);
+
+        Map<String, String> body = Map.of("email", "other@example.com");
+        mockMvc.perform(patch("/api/usuarios/me")
+                        .header("Authorization", "Bearer " + userToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error", is("USUARIOS_EMAIL_CONFLICT")));
+    }
+
+    @Test
+    @DisplayName("PATCH /api/usuarios/me with role in body returns 200 but role does not change")
+    void patch_me_with_role_in_body_role_does_not_change() throws Exception {
+        // UpdateMyProfileCommand has no 'role' field — Jackson ignores unknown fields by default
+        String body = "{\"firstName\":\"RoleTest\",\"role\":\"ADMIN\"}";
+        mockMvc.perform(patch("/api/usuarios/me")
+                        .header("Authorization", "Bearer " + userToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.role", is("USER")))
+                .andExpect(jsonPath("$.firstName", is("RoleTest")));
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,8 @@ import { PrivateRoute } from './guards/PrivateRoute';
 import { SplashPage } from './pages/SplashPage';
 import { LoginPage } from './pages/LoginPage';
 import { RegisterPage } from './pages/RegisterPage';
+import { HomePage } from './pages/HomePage';
+import { MiPerfilPage } from './pages/MiPerfilPage';
 
 function App() {
   return (
@@ -15,9 +17,10 @@ function App() {
           <Route path="/login" element={<LoginPage />} />
           <Route path="/register" element={<RegisterPage />} />
 
-          {/* Rutas privadas — placeholder para Oleada 3 */}
+          {/* Rutas privadas */}
           <Route element={<PrivateRoute />}>
-            <Route path="/home" element={<div>Home (pendiente — Oleada 3)</div>} />
+            <Route path="/home" element={<HomePage />} />
+            <Route path="/perfil" element={<MiPerfilPage />} />
           </Route>
         </Routes>
       </BrowserRouter>

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -9,7 +9,7 @@ interface AuthContextValue {
   isAuthenticated: boolean;
 }
 
-const AuthContext = createContext<AuthContextValue | null>(null);
+export const AuthContext = createContext<AuthContextValue | null>(null);
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [accessToken, setAccessToken] = useState<string | null>(null);

--- a/frontend/src/pages/HomePage.module.css
+++ b/frontend/src/pages/HomePage.module.css
@@ -1,0 +1,138 @@
+/* HomePage — Ref visual: docs/ux/mockups/02-home-jugador.html */
+
+.homePage {
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  padding: 24px 24px 40px;
+  background: var(--cream);
+  max-width: 430px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+/* ── Top bar ── */
+.topBar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 32px;
+}
+
+.avatarBtn {
+  width: 40px;
+  height: 40px;
+  background: var(--olive);
+  color: var(--lime);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: opacity 0.15s ease;
+}
+
+.avatarBtn:hover {
+  opacity: 0.85;
+}
+
+/* ── Greeting ── */
+.greet {
+  margin-bottom: 32px;
+}
+
+.eyebrow {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--muted);
+  display: block;
+  margin-bottom: 8px;
+}
+
+.greet h1 {
+  font-family: var(--font-display);
+  font-size: 42px;
+  font-weight: 700;
+  line-height: 0.95;
+  letter-spacing: -0.04em;
+}
+
+.greet h1 em {
+  font-style: italic;
+  font-weight: 500;
+  color: var(--olive);
+}
+
+/* ── Quick actions grid ── */
+.actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  margin-bottom: 28px;
+}
+
+.action {
+  background: white;
+  border: 1px solid rgba(13, 13, 13, 0.1);
+  border-radius: 18px;
+  padding: 18px 16px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  text-decoration: none;
+  color: var(--ink);
+  display: block;
+}
+
+.action:hover {
+  border-color: rgba(13, 13, 13, 0.3);
+  transform: translateY(-1px);
+}
+
+.actionPrimary {
+  background: var(--lime);
+  border-color: var(--lime);
+}
+
+.actionPrimary:hover {
+  background: var(--lime-dark);
+  border-color: var(--lime-dark);
+}
+
+.actionIco {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 18px;
+}
+
+.actionIco svg {
+  width: 20px;
+  height: 20px;
+}
+
+.actionLabel {
+  font-family: var(--font-display);
+  font-size: 17px;
+  font-weight: 700;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+}
+
+.actionSub {
+  font-size: 11px;
+  color: var(--muted);
+  margin-top: 4px;
+}
+
+.actionPrimary .actionSub {
+  color: var(--olive);
+}
+
+/* ── Logout ── */
+.logoutBtn {
+  margin-top: auto;
+}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,0 +1,78 @@
+// T-144 — HomePage — pantalla principal post-login
+// Ref visual: docs/ux/mockups/02-home-jugador.html
+// Incluye enlace a /perfil (Mi perfil)
+import { Link } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+import './pages.css';
+import styles from './HomePage.module.css';
+
+export function HomePage() {
+  const { setAccessToken } = useAuth();
+
+  function handleLogout() {
+    setAccessToken(null);
+  }
+
+  return (
+    <div className={styles.homePage}>
+      {/* ── Top bar ── */}
+      <div className={styles.topBar}>
+        <div className="p-logo">
+          <span className="p-dot" />
+          PadelPro
+        </div>
+        <Link to="/perfil" className={styles.avatarBtn} aria-label="Mi perfil">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+            <circle cx="12" cy="8" r="4"/>
+            <path d="M4 21v-1a7 7 0 0114 0v1"/>
+          </svg>
+        </Link>
+      </div>
+
+      {/* ── Greeting ── */}
+      <div className={styles.greet}>
+        <span className={styles.eyebrow}>Bienvenido</span>
+        <h1>
+          Hola,<br />
+          <em>jugador.</em>
+        </h1>
+      </div>
+
+      {/* ── Quick actions ── */}
+      <div className={styles.actions}>
+        <div className={`${styles.action} ${styles.actionPrimary}`}>
+          <div className={styles.actionIco}>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <rect x="3" y="4" width="18" height="18" rx="2"/>
+              <line x1="16" y1="2" x2="16" y2="6"/>
+              <line x1="8" y1="2" x2="8" y2="6"/>
+              <line x1="3" y1="10" x2="21" y2="10"/>
+            </svg>
+          </div>
+          <div className={styles.actionLabel}>Reservar pista</div>
+          <div className={styles.actionSub}>Encuentra una franja libre</div>
+        </div>
+
+        <Link to="/perfil" className={styles.action}>
+          <div className={styles.actionIco}>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <circle cx="12" cy="8" r="4"/>
+              <path d="M4 21v-1a7 7 0 0114 0v1"/>
+            </svg>
+          </div>
+          <div className={styles.actionLabel}>Mi perfil</div>
+          <div className={styles.actionSub}>Datos y configuración</div>
+        </Link>
+      </div>
+
+      {/* ── Logout ── */}
+      <button
+        type="button"
+        className={`p-btn p-btn-outline ${styles.logoutBtn}`}
+        onClick={handleLogout}
+      >
+        Cerrar sesión
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/pages/MiPerfilPage.module.css
+++ b/frontend/src/pages/MiPerfilPage.module.css
@@ -1,0 +1,253 @@
+/* MiPerfilPage — Ref visual: docs/ux/mockups/14-mi-perfil.html */
+
+.perfilPage {
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  background: var(--cream);
+  max-width: 430px;
+  margin: 0 auto;
+  width: 100%;
+  padding-bottom: 32px;
+}
+
+/* ── Header ── */
+.header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 20px 24px 0;
+}
+
+.logo {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--lime);
+  flex-shrink: 0;
+}
+
+/* ── Avatar & identity block ── */
+.profileHead {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 24px 24px 20px;
+}
+
+.avatar {
+  width: 56px;
+  height: 56px;
+  background: var(--olive);
+  color: var(--lime);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 18px;
+  flex-shrink: 0;
+}
+
+.identityInfo h1 {
+  font-family: var(--font-display);
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  line-height: 1.1;
+}
+
+.loginHandle {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--muted);
+  letter-spacing: 0.04em;
+  text-transform: lowercase;
+  margin-top: 2px;
+}
+
+/* ── Read-only badges ── */
+.badgeRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 0 24px 20px;
+}
+
+.badge {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 4px 10px;
+  border-radius: 20px;
+  background: rgba(13, 13, 13, 0.06);
+  color: var(--muted);
+  border: 1px solid rgba(13, 13, 13, 0.1);
+}
+
+.badgeTelegram {
+  background: rgba(37, 99, 235, 0.08);
+  color: #2563eb;
+  border-color: rgba(37, 99, 235, 0.2);
+}
+
+/* ── Form sections ── */
+.section {
+  padding: 0 24px 8px;
+}
+
+.sectionTitle {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted-light);
+  margin-bottom: 16px;
+  padding-top: 8px;
+}
+
+.divider {
+  height: 1px;
+  background: rgba(13, 13, 13, 0.08);
+  margin: 4px 24px 0;
+}
+
+/* ── Form ── */
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  padding: 0 24px;
+}
+
+.fieldGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 20px;
+}
+
+.fieldLabel {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--muted);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.fieldInput {
+  background: transparent;
+  border: none;
+  border-bottom: 1.5px solid rgba(13, 13, 13, 0.2);
+  padding: 8px 0;
+  font-size: 15px;
+  color: var(--ink);
+  outline: none;
+  transition: border-color 0.2s ease;
+  width: 100%;
+  font-family: var(--font-body);
+}
+
+.fieldInput:focus {
+  border-bottom-color: var(--ink);
+}
+
+.fieldInput::placeholder {
+  color: var(--muted-light);
+}
+
+/* ── Success / error feedback ── */
+.successMsg {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  font-weight: 500;
+  color: #16a34a;
+  padding: 10px 14px;
+  background: rgba(22, 163, 74, 0.08);
+  border-radius: 8px;
+  border-left: 3px solid #16a34a;
+  margin-bottom: 16px;
+}
+
+.errorMsg {
+  font-size: 13px;
+  color: var(--error);
+  padding: 10px 14px;
+  background: rgba(221, 68, 68, 0.08);
+  border-radius: 8px;
+  border-left: 3px solid var(--error);
+  margin-bottom: 16px;
+}
+
+/* ── Submit button ── */
+.submitBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  padding: 14px 20px;
+  border-radius: 12px;
+  font-family: var(--font-body);
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  background: var(--lime);
+  color: var(--ink);
+  border: none;
+  cursor: pointer;
+  transition: transform 0.1s ease, opacity 0.1s ease, background 0.15s ease;
+  margin-top: 4px;
+}
+
+.submitBtn:hover {
+  background: var(--lime-dark);
+}
+
+.submitBtn:active {
+  transform: scale(0.98);
+}
+
+.submitBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ── Loading state ── */
+.loadingWrapper {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 200px;
+}
+
+.spinner {
+  width: 28px;
+  height: 28px;
+  border: 2.5px solid rgba(13, 13, 13, 0.12);
+  border-top-color: var(--lime);
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}

--- a/frontend/src/pages/MiPerfilPage.tsx
+++ b/frontend/src/pages/MiPerfilPage.tsx
@@ -1,0 +1,241 @@
+// T-144 — MiPerfilPage
+// Ref visual: docs/ux/mockups/14-mi-perfil.html
+// API: GET /api/usuarios/me, PATCH /api/usuarios/me
+import { useState, useEffect } from 'react';
+import { Navigate } from 'react-router-dom';
+import axios from 'axios';
+import { useAuth } from '../context/AuthContext';
+import { getMeApi, updateMeApi, UsuarioMe } from '../services/usuariosApi';
+import './pages.css';
+import styles from './MiPerfilPage.module.css';
+
+function getInitials(firstName: string, lastName: string): string {
+  return `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase();
+}
+
+export function MiPerfilPage() {
+  const { accessToken, isAuthenticated } = useAuth();
+
+  const [profile, setProfile] = useState<UsuarioMe | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+
+  // Form state — editable fields
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
+
+  // Feedback state
+  const [successMsg, setSuccessMsg] = useState<string | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  // Guard placed after all hooks — React rules require hooks to run unconditionally
+  // The early return happens below, after the hook declarations.
+
+  useEffect(() => {
+    if (!accessToken) return;
+    setLoading(true);
+    getMeApi(accessToken)
+      .then((data) => {
+        setProfile(data);
+        setFirstName(data.firstName);
+        setLastName(data.lastName);
+        setEmail(data.email);
+        setPhone(data.phone ?? '');
+      })
+      .catch(() => {
+        setErrorMsg('No se pudo cargar el perfil. Inténtalo de nuevo.');
+      })
+      .finally(() => setLoading(false));
+  }, [accessToken]);
+
+  // Guard: redirect unauthenticated users to /login (hooks already ran above)
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (!accessToken) return;
+
+    setSuccessMsg(null);
+    setErrorMsg(null);
+    setSubmitting(true);
+
+    try {
+      const updated = await updateMeApi(accessToken, {
+        firstName: firstName.trim(),
+        lastName: lastName.trim(),
+        email: email.trim(),
+        phone: phone.trim() || null,
+      });
+      setProfile(updated);
+      setFirstName(updated.firstName);
+      setLastName(updated.lastName);
+      setEmail(updated.email);
+      setPhone(updated.phone ?? '');
+      setSuccessMsg('Perfil actualizado');
+    } catch (err) {
+      if (axios.isAxiosError(err)) {
+        const status = err.response?.status;
+        const body = err.response?.data as { code?: string; message?: string } | undefined;
+        if (status === 409 && body?.code === 'USUARIOS_EMAIL_CONFLICT') {
+          setErrorMsg('El email ya está registrado');
+        } else if (status === 400) {
+          setErrorMsg('Los datos introducidos no son válidos. Revísalos e inténtalo de nuevo.');
+        } else {
+          setErrorMsg('Error inesperado. Inténtalo de nuevo.');
+        }
+      } else {
+        setErrorMsg('Error inesperado. Inténtalo de nuevo.');
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className={styles.perfilPage}>
+      {/* ── Header ── */}
+      <header className={styles.header}>
+        <div className={styles.logo}>
+          <span className={styles.dot} />
+          PadelPro
+        </div>
+      </header>
+
+      {loading ? (
+        <div className={styles.loadingWrapper}>
+          <div className={styles.spinner} role="status" aria-label="Cargando perfil" />
+        </div>
+      ) : (
+        <>
+          {/* ── Avatar / identity block ── */}
+          <div className={styles.profileHead}>
+            <div className={styles.avatar} aria-hidden="true">
+              {profile ? getInitials(profile.firstName, profile.lastName) : '??'}
+            </div>
+            <div className={styles.identityInfo}>
+              <h1>
+                {profile ? `${profile.firstName} ${profile.lastName}` : ''}
+              </h1>
+              {profile && (
+                <div className={styles.loginHandle}>@{profile.login}</div>
+              )}
+            </div>
+          </div>
+
+          {/* ── Read-only badges: role, status, telegram ── */}
+          {profile && (
+            <div className={styles.badgeRow}>
+              <span className={styles.badge}>{profile.role}</span>
+              <span className={styles.badge}>{profile.status}</span>
+              {profile.telegramLinked && (
+                <span className={`${styles.badge} ${styles.badgeTelegram}`}>
+                  Telegram vinculado
+                </span>
+              )}
+            </div>
+          )}
+
+          <div className={styles.divider} />
+
+          {/* ── Editable form ── */}
+          <form className={styles.form} onSubmit={handleSubmit} noValidate>
+            <p className={styles.sectionTitle}>Datos personales</p>
+
+            {successMsg && (
+              <p className={styles.successMsg}>{successMsg}</p>
+            )}
+
+            {errorMsg && (
+              <p className={styles.errorMsg} role="alert">{errorMsg}</p>
+            )}
+
+            <div className={styles.fieldGroup}>
+              <label className={styles.fieldLabel} htmlFor="perfil-firstName">
+                Nombre
+              </label>
+              <input
+                id="perfil-firstName"
+                className={styles.fieldInput}
+                type="text"
+                autoComplete="given-name"
+                value={firstName}
+                onChange={(e) => {
+                  setFirstName(e.target.value);
+                  setSuccessMsg(null);
+                }}
+                required
+              />
+            </div>
+
+            <div className={styles.fieldGroup}>
+              <label className={styles.fieldLabel} htmlFor="perfil-lastName">
+                Apellido
+              </label>
+              <input
+                id="perfil-lastName"
+                className={styles.fieldInput}
+                type="text"
+                autoComplete="family-name"
+                value={lastName}
+                onChange={(e) => {
+                  setLastName(e.target.value);
+                  setSuccessMsg(null);
+                }}
+                required
+              />
+            </div>
+
+            <div className={styles.fieldGroup}>
+              <label className={styles.fieldLabel} htmlFor="perfil-email">
+                Email
+              </label>
+              <input
+                id="perfil-email"
+                className={styles.fieldInput}
+                type="email"
+                autoComplete="email"
+                value={email}
+                onChange={(e) => {
+                  setEmail(e.target.value);
+                  setSuccessMsg(null);
+                  setErrorMsg(null);
+                }}
+                required
+              />
+            </div>
+
+            <div className={styles.fieldGroup}>
+              <label className={styles.fieldLabel} htmlFor="perfil-phone">
+                Teléfono <span style={{ fontWeight: 400, opacity: 0.6 }}>(opcional)</span>
+              </label>
+              <input
+                id="perfil-phone"
+                className={styles.fieldInput}
+                type="tel"
+                autoComplete="tel"
+                placeholder="+34 6XX XXX XXX"
+                value={phone}
+                onChange={(e) => {
+                  setPhone(e.target.value);
+                  setSuccessMsg(null);
+                }}
+              />
+            </div>
+
+            <button
+              type="submit"
+              className={styles.submitBtn}
+              disabled={submitting}
+            >
+              {submitting ? 'Guardando…' : 'Guardar cambios'}
+            </button>
+          </form>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/services/usuariosApi.ts
+++ b/frontend/src/services/usuariosApi.ts
@@ -1,0 +1,37 @@
+// T-144 — usuariosApi — GET/PATCH /api/usuarios/me
+import axios from 'axios';
+
+const api = axios.create({ baseURL: '/api', withCredentials: true });
+
+export interface UsuarioMe {
+  id: number;
+  login: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone: string | null;
+  status: string;
+  role: string;
+  telegramLinked: boolean;
+}
+
+export interface UpdateMeRequest {
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+  phone?: string | null;
+}
+
+export async function getMeApi(token: string): Promise<UsuarioMe> {
+  const { data } = await api.get<UsuarioMe>('/usuarios/me', {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return data;
+}
+
+export async function updateMeApi(token: string, req: UpdateMeRequest): Promise<UsuarioMe> {
+  const { data } = await api.patch<UsuarioMe>('/usuarios/me', req, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return data;
+}

--- a/frontend/src/test/MiPerfilPage.test.tsx
+++ b/frontend/src/test/MiPerfilPage.test.tsx
@@ -1,0 +1,186 @@
+// T-144 — MiPerfilPage integration tests (TDD — RED phase)
+// Tests describe the expected behavior before implementation.
+// Covers:
+//   P-1 — render profile data loaded from GET /api/usuarios/me
+//   P-2 — show success message after PATCH /api/usuarios/me → 200
+//   P-3 — show email conflict error on PATCH → 409 USUARIOS_EMAIL_CONFLICT
+//   P-4 — redirect to /login when not authenticated
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { http, HttpResponse } from 'msw';
+
+import { AuthProvider } from '../context/AuthContext';
+import { server } from './mocks/server';
+
+// ---------------------------------------------------------------------------
+// Lazy import so RED tests fail fast if the file does not exist yet
+// ---------------------------------------------------------------------------
+import { MiPerfilPage } from '../pages/MiPerfilPage';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+const mockProfile = {
+  id: 42,
+  login: 'lauracasado',
+  firstName: 'Laura',
+  lastName: 'Casado',
+  email: 'laura.casado@email.com',
+  phone: '+34612345678',
+  status: 'ACTIVO',
+  role: 'JUGADOR',
+  telegramLinked: true,
+};
+
+// ---------------------------------------------------------------------------
+// MSW handler helpers
+// ---------------------------------------------------------------------------
+function mockGetMe200() {
+  server.use(
+    http.get('/api/usuarios/me', () => HttpResponse.json(mockProfile, { status: 200 }))
+  );
+}
+
+function mockPatchMe200() {
+  server.use(
+    http.patch('/api/usuarios/me', async ({ request }) => {
+      const body = (await request.json()) as Record<string, unknown>;
+      return HttpResponse.json({ ...mockProfile, ...body }, { status: 200 });
+    })
+  );
+}
+
+function mockPatchMe409() {
+  server.use(
+    http.patch('/api/usuarios/me', () =>
+      HttpResponse.json(
+        { code: 'USUARIOS_EMAIL_CONFLICT', message: 'El email ya está registrado' },
+        { status: 409 }
+      )
+    )
+  );
+}
+
+function mockPatchMe400() {
+  server.use(
+    http.patch('/api/usuarios/me', () =>
+      HttpResponse.json({ code: 'VALIDATION_ERROR', message: 'Datos inválidos' }, { status: 400 })
+    )
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Render helpers
+// ---------------------------------------------------------------------------
+function renderWithAuth(authenticated: boolean) {
+  const Wrapper = () => {
+    return (
+      <AuthProvider>
+        <AuthSeeder authenticated={authenticated}>
+          <MemoryRouter initialEntries={['/perfil']}>
+            <Routes>
+              <Route path="/perfil" element={<MiPerfilPage />} />
+              <Route path="/login" element={<div>Login Page</div>} />
+            </Routes>
+          </MemoryRouter>
+        </AuthSeeder>
+      </AuthProvider>
+    );
+  };
+  return render(<Wrapper />);
+}
+
+// Component that injects a token into AuthContext
+import React from 'react';
+import { useAuth } from '../context/AuthContext';
+
+function AuthSeeder({
+  authenticated,
+  children,
+}: {
+  authenticated: boolean;
+  children: React.ReactNode;
+}) {
+  const { setAccessToken } = useAuth();
+  React.useEffect(() => {
+    if (authenticated) {
+      setAccessToken('test.jwt.token');
+    }
+  }, [authenticated, setAccessToken]);
+  return <>{children}</>;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('MiPerfilPage (T-144)', () => {
+  beforeEach(() => {
+    mockGetMe200();
+    mockPatchMe200();
+  });
+
+  it('P-1 — should render profile data loaded from API', async () => {
+    renderWithAuth(true);
+
+    // Should show a loading state initially or directly load data
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Laura')).toBeInTheDocument();
+    });
+
+    expect(screen.getByDisplayValue('Casado')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('laura.casado@email.com')).toBeInTheDocument();
+  });
+
+  it('P-2 — should show success message after update', async () => {
+    renderWithAuth(true);
+
+    // Wait for form to load
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Laura')).toBeInTheDocument();
+    });
+
+    // Change firstName
+    const firstNameInput = screen.getByLabelText(/nombre/i);
+    await userEvent.clear(firstNameInput);
+    await userEvent.type(firstNameInput, 'Laura Updated');
+
+    // Submit
+    await userEvent.click(screen.getByRole('button', { name: /guardar/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/perfil actualizado/i)).toBeInTheDocument();
+    });
+  });
+
+  it('P-3 — should show email conflict error on 409', async () => {
+    mockPatchMe409();
+    renderWithAuth(true);
+
+    // Wait for form to load
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('laura.casado@email.com')).toBeInTheDocument();
+    });
+
+    // Change email to something that conflicts
+    const emailInput = screen.getByLabelText(/email/i);
+    await userEvent.clear(emailInput);
+    await userEvent.type(emailInput, 'existing@email.com');
+
+    await userEvent.click(screen.getByRole('button', { name: /guardar/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('El email ya está registrado');
+    });
+  });
+
+  it('P-4 — should redirect to /login if not authenticated', async () => {
+    renderWithAuth(false);
+
+    await waitFor(() => {
+      expect(screen.getByText('Login Page')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/test/MiPerfilPage.test.tsx
+++ b/frontend/src/test/MiPerfilPage.test.tsx
@@ -1,24 +1,20 @@
-// T-144 — MiPerfilPage integration tests (TDD — RED phase)
-// Tests describe the expected behavior before implementation.
+// T-144 — MiPerfilPage integration tests (TDD — GREEN phase)
 // Covers:
 //   P-1 — render profile data loaded from GET /api/usuarios/me
 //   P-2 — show success message after PATCH /api/usuarios/me → 200
 //   P-3 — show email conflict error on PATCH → 409 USUARIOS_EMAIL_CONFLICT
 //   P-4 — redirect to /login when not authenticated
 
+import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { http, HttpResponse } from 'msw';
 
-import { AuthProvider } from '../context/AuthContext';
-import { server } from './mocks/server';
-
-// ---------------------------------------------------------------------------
-// Lazy import so RED tests fail fast if the file does not exist yet
-// ---------------------------------------------------------------------------
+import { AuthContext } from '../context/AuthContext';
 import { MiPerfilPage } from '../pages/MiPerfilPage';
+import { server } from './mocks/server';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -36,7 +32,7 @@ const mockProfile = {
 };
 
 // ---------------------------------------------------------------------------
-// MSW handler helpers
+// MSW handler helpers (called inside tests that need non-default behaviour)
 // ---------------------------------------------------------------------------
 function mockGetMe200() {
   server.use(
@@ -64,53 +60,32 @@ function mockPatchMe409() {
   );
 }
 
-function mockPatchMe400() {
-  server.use(
-    http.patch('/api/usuarios/me', () =>
-      HttpResponse.json({ code: 'VALIDATION_ERROR', message: 'Datos inválidos' }, { status: 400 })
-    )
-  );
-}
-
 // ---------------------------------------------------------------------------
 // Render helpers
 // ---------------------------------------------------------------------------
-function renderWithAuth(authenticated: boolean) {
-  const Wrapper = () => {
-    return (
-      <AuthProvider>
-        <AuthSeeder authenticated={authenticated}>
-          <MemoryRouter initialEntries={['/perfil']}>
-            <Routes>
-              <Route path="/perfil" element={<MiPerfilPage />} />
-              <Route path="/login" element={<div>Login Page</div>} />
-            </Routes>
-          </MemoryRouter>
-        </AuthSeeder>
-      </AuthProvider>
-    );
+
+/**
+ * Renders MiPerfilPage inside a controlled AuthContext with an optional token.
+ * Using a custom Provider value avoids the async-effect timing issue that arises
+ * when setting the token via useEffect inside an AuthSeeder child component.
+ */
+function renderWithToken(token: string | null) {
+  const ctxValue = {
+    accessToken: token,
+    setAccessToken: () => {},
+    isAuthenticated: !!token,
   };
-  return render(<Wrapper />);
-}
 
-// Component that injects a token into AuthContext
-import React from 'react';
-import { useAuth } from '../context/AuthContext';
-
-function AuthSeeder({
-  authenticated,
-  children,
-}: {
-  authenticated: boolean;
-  children: React.ReactNode;
-}) {
-  const { setAccessToken } = useAuth();
-  React.useEffect(() => {
-    if (authenticated) {
-      setAccessToken('test.jwt.token');
-    }
-  }, [authenticated, setAccessToken]);
-  return <>{children}</>;
+  return render(
+    <AuthContext.Provider value={ctxValue}>
+      <MemoryRouter initialEntries={['/perfil']}>
+        <Routes>
+          <Route path="/perfil" element={<MiPerfilPage />} />
+          <Route path="/login" element={<div>Login Page</div>} />
+        </Routes>
+      </MemoryRouter>
+    </AuthContext.Provider>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -123,9 +98,8 @@ describe('MiPerfilPage (T-144)', () => {
   });
 
   it('P-1 — should render profile data loaded from API', async () => {
-    renderWithAuth(true);
+    renderWithToken('test.jwt.token');
 
-    // Should show a loading state initially or directly load data
     await waitFor(() => {
       expect(screen.getByDisplayValue('Laura')).toBeInTheDocument();
     });
@@ -135,9 +109,8 @@ describe('MiPerfilPage (T-144)', () => {
   });
 
   it('P-2 — should show success message after update', async () => {
-    renderWithAuth(true);
+    renderWithToken('test.jwt.token');
 
-    // Wait for form to load
     await waitFor(() => {
       expect(screen.getByDisplayValue('Laura')).toBeInTheDocument();
     });
@@ -157,7 +130,7 @@ describe('MiPerfilPage (T-144)', () => {
 
   it('P-3 — should show email conflict error on 409', async () => {
     mockPatchMe409();
-    renderWithAuth(true);
+    renderWithToken('test.jwt.token');
 
     // Wait for form to load
     await waitFor(() => {
@@ -177,10 +150,9 @@ describe('MiPerfilPage (T-144)', () => {
   });
 
   it('P-4 — should redirect to /login if not authenticated', async () => {
-    renderWithAuth(false);
+    renderWithToken(null);
 
-    await waitFor(() => {
-      expect(screen.getByText('Login Page')).toBeInTheDocument();
-    });
+    // Synchronous redirect — no need to wait for async operations
+    expect(screen.getByText('Login Page')).toBeInTheDocument();
   });
 });

--- a/openspec/changes/usuarios/tasks.md
+++ b/openspec/changes/usuarios/tasks.md
@@ -1,0 +1,83 @@
+## 1. Setup y andamiaje
+
+- [x] 1.1 Crear GitHub Issue para el change `usuarios` (label `type:user-story`, Milestone `EP-01 Acceso e Identidad`, Sprint 1)
+- [x] 1.2 Crear rama `feat/usuarios` desde `develop`
+- [x] 1.3 Crear estructura de paquetes Maven hexagonal: `com.padelpro.usuarios.domain`, `com.padelpro.usuarios.application`, `com.padelpro.usuarios.infrastructure` (compilable, vacío)
+
+## 2. Backend — Dominio (DTOs, puertos, excepciones)
+
+- [x] 2.1 Crear `UserProfileResponse` (campos: id, login, firstName, lastName, email, phone, status, role, telegramLinked)
+- [x] 2.2 Crear `UpdateMyProfileCommand` (campos: firstName, lastName, email, phone — sin role ni status)
+- [x] 2.3 Crear `UserAdminResponse` (todos los campos del perfil incluyendo role, status, registeredAt, updatedAt)
+- [x] 2.4 Crear `CreateUserAdminCommand` (campos: login, firstName, lastName, email, password, phone, role opcional)
+- [x] 2.5 Crear `UpdateUserAdminCommand` (todos los campos modificables: firstName, lastName, email, phone, role, status — sin login)
+- [x] 2.6 Crear `PagedUsersResponse` (wrapper: content, totalElements, totalPages, page, size)
+- [x] 2.7 Crear excepciones de dominio: `UserNotFoundException` (→ 404), `UserNotPendingException` (→ 422), `AdminSelfDeactivationException` (→ 422), `EmailConflictException` (→ 409)
+- [x] 2.8 Añadir métodos al `UserRepositoryPort`: `findAll(status, pageable)`, `existsByEmailAndIdNot(email, id)`, `existsByLogin(login)`
+
+## 3. Backend — Servicios de aplicación
+
+- [x] 3.1 Implementar `UserProfileService.getMyProfile(userId)` → devuelve `UserProfileResponse`
+- [x] 3.2 Implementar `UserProfileService.updateMyProfile(userId, command)` → valida conflicto de email, actualiza, devuelve `UserProfileResponse`
+- [x] 3.3 Implementar `UserAdminService.createUser(command)` → crea con `status=ACTIVE`, hashea BCrypt cost 12, audita `USER_CREATED_BY_ADMIN`
+- [x] 3.4 Implementar `UserAdminService.approveUser(targetId)` → verifica `status=PENDING`, transiciona a `ACTIVE`, audita `USER_APPROVED`
+- [x] 3.5 Implementar `UserAdminService.listUsers(status, pageable)` → fuerza `size = min(size, 100)`, devuelve `PagedUsersResponse`
+- [x] 3.6 Implementar `UserAdminService.getUser(id)` → devuelve `UserAdminResponse` o lanza `UserNotFoundException`
+- [x] 3.7 Implementar `UserAdminService.updateUser(id, command)` → actualiza campos, audita `USER_ROLE_CHANGED` si role cambia
+- [x] 3.8 Implementar `UserAdminService.deactivateUser(targetId, adminId)` → verifica RN-AUTH-05, cambia a `status=INACTIVE`, audita `USER_DEACTIVATED`
+
+## 4. Backend — Infraestructura (controllers, seguridad, auditoría)
+
+- [x] 4.1 Añadir acciones al enum/constantes `AuditAction`: `USER_CREATED_BY_ADMIN`, `USER_APPROVED`, `USER_DEACTIVATED`, `USER_ROLE_CHANGED`
+- [x] 4.2 Implementar `UsuariosMeController`: `GET /api/usuarios/me` (200) y `PATCH /api/usuarios/me` (200/400/409)
+- [x] 4.3 Implementar `AdminUsuariosController`: `GET /api/admin/usuarios` (200), `POST /api/admin/usuarios` (201/409), `GET /api/admin/usuarios/{id}` (200/404), `PATCH /api/admin/usuarios/{id}` (200), `PATCH /api/admin/usuarios/{id}/aprobar` (200/422), `DELETE /api/admin/usuarios/{id}` (204/422)
+- [x] 4.4 Extender `SecurityFilterChain`: añadir `.requestMatchers("/api/admin/**").hasRole("ADMIN")` y `.requestMatchers("/api/usuarios/me").authenticated()`
+- [x] 4.5 Añadir handler en `GlobalExceptionHandler` para `UserNotFoundException` (404), `UserNotPendingException` (422), `AdminSelfDeactivationException` (422), `EmailConflictException` (409)
+
+## 5. Backend — Tests unitarios (TDD — escribir antes de implementar los servicios)
+
+- [x] 5.1 `UserProfileServiceTest`: `should_return_profile_when_user_exists` (R-1)
+- [x] 5.2 `UserProfileServiceTest`: `should_update_profile_when_fields_are_valid` (R-1)
+- [x] 5.3 `UserProfileServiceTest`: `should_throw_email_conflict_when_email_already_taken` (R-1)
+- [x] 5.4 `UserProfileServiceTest`: `should_ignore_role_and_status_fields_in_update_command` (R-1)
+- [x] 5.5 `UserAdminServiceTest`: `should_create_user_with_active_status_and_bcrypt_hash` (R-2)
+- [x] 5.6 `UserAdminServiceTest`: `should_throw_email_conflict_when_creating_duplicate_email` (R-2)
+- [x] 5.7 `UserAdminServiceTest`: `should_approve_pending_user_and_audit` (R-2)
+- [x] 5.8 `UserAdminServiceTest`: `should_throw_when_approving_non_pending_user` (R-2)
+- [x] 5.9 `UserAdminServiceTest`: `should_return_paged_users_with_max_size_100` (R-2)
+- [x] 5.10 `UserAdminServiceTest`: `should_throw_not_found_when_user_does_not_exist` (R-2)
+- [x] 5.11 `UserAdminServiceTest`: `should_deactivate_user_and_audit` (R-2 + R-3)
+- [x] 5.12 `UserAdminServiceTest`: `should_throw_admin_self_deactivation_exception` (R-3)
+
+## 6. Backend — Tests de integración (Testcontainers)
+
+- [x] 6.1 `UsuariosMeControllerIntegrationTest`: `GET /api/usuarios/me` con JWT válido → 200 con campos correctos
+- [x] 6.2 `UsuariosMeControllerIntegrationTest`: `GET /api/usuarios/me` sin JWT → 401
+- [x] 6.3 `UsuariosMeControllerIntegrationTest`: `PATCH /api/usuarios/me` campos válidos → 200
+- [x] 6.4 `UsuariosMeControllerIntegrationTest`: `PATCH /api/usuarios/me` email duplicado → 409
+- [x] 6.5 `UsuariosMeControllerIntegrationTest`: `PATCH /api/usuarios/me` con role/status en body → 200 pero campos no cambian
+- [x] 6.6 `AdminUsuariosControllerIntegrationTest`: `POST /api/admin/usuarios` válido → 201, `status=ACTIVE`
+- [x] 6.7 `AdminUsuariosControllerIntegrationTest`: `POST /api/admin/usuarios` email duplicado → 409
+- [x] 6.8 `AdminUsuariosControllerIntegrationTest`: `PATCH /api/admin/usuarios/{id}/aprobar` PENDING → 200, `status=ACTIVE`
+- [x] 6.9 `AdminUsuariosControllerIntegrationTest`: `PATCH /api/admin/usuarios/{id}/aprobar` ACTIVE → 422
+- [x] 6.10 `AdminUsuariosControllerIntegrationTest`: `GET /api/admin/usuarios?status=PENDING` → 200, solo PENDING
+- [x] 6.11 `AdminUsuariosControllerIntegrationTest`: `DELETE /api/admin/usuarios/{id}` → 204, `status=INACTIVE`
+- [x] 6.12 `AdminUsuariosControllerIntegrationTest`: `DELETE /api/admin/usuarios/{self}` → 422 (RN-AUTH-05)
+- [x] 6.13 `AdminUsuariosControllerIntegrationTest`: `GET /api/admin/usuarios` con `role=USER` → 403
+- [x] 6.14 `AdminUsuariosControllerIntegrationTest`: `GET /api/admin/usuarios/{id}` inexistente → 404
+- [x] 6.15 ArchUnit test: `com.padelpro.usuarios.domain` no importa nada de `com.padelpro.usuarios.infrastructure`
+
+## 7. Frontend — Mi Perfil
+
+- [x] 7.1 Crear `MiPerfilPage.tsx` con ruta `/perfil` protegida por `PrivateRoute`
+- [x] 7.2 Implementar fetch `GET /api/usuarios/me` al montar el componente; mostrar datos del perfil
+- [x] 7.3 Implementar formulario de edición con campos firstName, lastName, email, phone (sin role ni status)
+- [x] 7.4 Implementar submit `PATCH /api/usuarios/me`; manejar 200 (éxito), 400 (validación), 409 (email en conflicto)
+- [x] 7.5 Añadir enlace / botón de acceso a Mi Perfil desde la pantalla principal (post-login)
+
+## 8. Frontend — Tests (Vitest + React Testing Library + MSW)
+
+- [x] 8.1 `MiPerfilPage.test.tsx`: renderiza datos del perfil cargados desde mock `GET /api/usuarios/me`
+- [x] 8.2 `MiPerfilPage.test.tsx`: actualización exitosa muestra mensaje de confirmación
+- [x] 8.3 `MiPerfilPage.test.tsx`: error 409 muestra mensaje de email en conflicto
+- [x] 8.4 `MiPerfilPage.test.tsx`: sin JWT redirige a `/login` (PrivateRoute guard)


### PR DESCRIPTION
## Contexto

Implementación completa de la capability `usuarios`: perfil propio para usuarios autenticados y CRUD de administración para ADMIN. Cierra el hueco que dejaba `auth-local`: los usuarios en estado `PENDING` ya pueden ser activados por el ADMIN, y cualquier usuario puede consultar y actualizar su propio perfil.

Closes #144

---

## Endpoints implementados

| Método | Path | Rol | Código |
|---|---|---|---|
| GET | /api/usuarios/me | USER/ADMIN | 200 |
| PATCH | /api/usuarios/me | USER/ADMIN | 200/400/409 |
| GET | /api/admin/usuarios | ADMIN | 200 (paginado) |
| POST | /api/admin/usuarios | ADMIN | 201/409 |
| GET | /api/admin/usuarios/{id} | ADMIN | 200/404 |
| PATCH | /api/admin/usuarios/{id} | ADMIN | 200 |
| PATCH | /api/admin/usuarios/{id}/aprobar | ADMIN | 200/422 |
| DELETE | /api/admin/usuarios/{id} | ADMIN | 204/422 |

---

## Tareas completadas (44/44)

### Setup
- [x] 1.1 Issue #144 en GitHub Projects
- [x] 1.2 Rama feat/144-usuarios desde develop
- [x] 1.3 Estructura hexagonal com.padelpro.usuarios.*

### Backend — Dominio
- [x] 2.1-2.8 DTOs, excepciones, extensión UserRepositoryPort

### Backend — Servicios
- [x] 3.1-3.8 UserProfileService + UserAdminService

### Backend — Infraestructura
- [x] 4.1-4.5 Controllers, SecurityConfig, GlobalExceptionHandler

### Backend — Tests unitarios (12/12 GREEN)
- [x] 5.1-5.12 UserProfileServiceTest + UserAdminServiceTest

### Backend — Tests integración (14 scenarios, Testcontainers)
- [x] 6.1-6.15 UsuariosMeControllerIntegrationTest + AdminUsuariosControllerIntegrationTest + ArchUnit

### Frontend — Mi Perfil
- [x] 7.1-7.5 MiPerfilPage.tsx + routing /perfil + enlace desde home

### Frontend — Tests (4/4 GREEN)
- [x] 8.1-8.4 MiPerfilPage.test.tsx

---

## Scenarios del spec vs test asociado

| Scenario | Test |
|---|---|
| R-1: USER consulta su perfil | `should_return_profile_when_user_exists` |
| R-1: USER actualiza campos válidos | `should_update_profile_when_fields_are_valid` |
| R-1: Role/status ignorados en PATCH /me | `should_ignore_role_and_status_fields_in_update_command` |
| R-1: Conflicto email en PATCH /me | `should_throw_email_conflict_when_email_already_taken` |
| R-2: ADMIN crea usuario con status=ACTIVE | `should_create_user_with_active_status_and_bcrypt_hash` |
| R-2: ADMIN crea usuario email duplicado | `should_throw_email_conflict_when_creating_duplicate_email` |
| R-2: ADMIN aprueba PENDING | `should_approve_pending_user_and_audit` |
| R-2: ADMIN aprueba no-PENDING | `should_throw_when_approving_non_pending_user` |
| R-2: Paginación máx 100 | `should_return_paged_users_with_max_size_100` |
| R-2: Usuario inexistente | `should_throw_not_found_when_user_does_not_exist` |
| R-2+R-3: ADMIN desactiva usuario | `should_deactivate_user_and_audit` |
| R-3: ADMIN self-deactivation | `should_throw_admin_self_deactivation_exception` |

---

## Decisiones de diseño materializadas

| Decisión | Valor |
|---|---|
| Reutilización entidad | User + UserRepositoryPort de auth-local sin duplicar |
| Dos servicios separados | UserProfileService (propio) + UserAdminService (admin) |
| DTOs distintos | UpdateMyProfileCommand sin role/status vs UpdateUserAdminCommand completo |
| RN-AUTH-05 | Verificación targetId == adminId en servicio → 422 ADMIN_SELF_DEACTIVATION |
| Soft delete | status=INACTIVE, sin hard delete (RN-RGPD-01) |
| Paginación | Math.min(size, 100) forzado en servicio |
| Auditoría | USER_CREATED_BY_ADMIN, USER_APPROVED, USER_DEACTIVATED, USER_ROLE_CHANGED |
| Migración V4 | phone + telegram_chat_id + telegram_linked_at (nullable) añadidos a users |

---

## Nota: migración V4 (gap corregido)

La migración V1 no incluía `phone`, `telegram_chat_id` ni `telegram_linked_at`. Se añade V4 como parte de este change. Estos campos son nullable y no rompen datos existentes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added user profile page allowing authenticated users to view and edit personal information (name, email, phone).
  * Added admin user management endpoints for creating, listing, approving, and deactivating user accounts.
  * Added phone number and Telegram linkage tracking to user profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->