### PR TITLE
feat(roles-permisos): RBAC transversal — UserStatusFilter + JaCoCo 80% + ArchUnit (#147)

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -133,6 +133,47 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.11</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals><goal>prepare-agent</goal></goals>
+                    </execution>
+                    <execution>
+                        <id>jacoco-check</id>
+                        <phase>verify</phase>
+                        <goals><goal>check</goal></goals>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/dto/**</exclude>
+                                <exclude>**/exception/**</exclude>
+                                <exclude>**/*Application.class</exclude>
+                                <exclude>**/domain/model/**</exclude>
+                            </excludes>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.80</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>jacoco-report</id>
+                        <phase>verify</phase>
+                        <goals><goal>report</goal></goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/backend/src/main/java/com/padelpro/auth/domain/port/in/ResourceOwnershipPort.java
+++ b/backend/src/main/java/com/padelpro/auth/domain/port/in/ResourceOwnershipPort.java
@@ -1,0 +1,34 @@
+package com.padelpro.auth.domain.port.in;
+
+/**
+ * Outbound port for resource ownership verification.
+ *
+ * <p>Allows application services to check whether a given user owns or participates
+ * in a resource without coupling the domain layer to the specific bounded context
+ * (reservas, pagos-redsys) that holds the data.
+ *
+ * <p>Implementations are provided by the {@code reservas} and {@code pagos-redsys}
+ * bounded contexts in future changes. Application services MUST use this port;
+ * infrastructure.web controllers MUST NOT call it directly (see ArchUnit rules).
+ */
+public interface ResourceOwnershipPort {
+
+    /**
+     * Returns {@code true} if the given user is the owner of the specified resource.
+     *
+     * @param userId       the id of the user to check
+     * @param resourceType the type of resource (e.g. "reserva", "pago")
+     * @param resourceId   the string identifier of the resource
+     * @return {@code true} if userId is the owner
+     */
+    boolean isOwner(Long userId, String resourceType, String resourceId);
+
+    /**
+     * Returns {@code true} if the given user is a participant in the given reservation.
+     *
+     * @param userId        the id of the user to check
+     * @param reservationId the identifier of the reservation
+     * @return {@code true} if userId is a participant
+     */
+    boolean isParticipant(Long userId, String reservationId);
+}

--- a/backend/src/main/java/com/padelpro/auth/infrastructure/config/SecurityConfig.java
+++ b/backend/src/main/java/com/padelpro/auth/infrastructure/config/SecurityConfig.java
@@ -1,6 +1,9 @@
 package com.padelpro.auth.infrastructure.config;
 
+import com.padelpro.auth.infrastructure.config.security.CustomAccessDeniedHandler;
+import com.padelpro.auth.infrastructure.config.security.CustomAuthenticationEntryPoint;
 import com.padelpro.auth.infrastructure.web.filter.JwtAuthFilter;
+import com.padelpro.auth.infrastructure.web.filter.UserStatusFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -18,7 +21,10 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
  *   <li>CSRF disabled (stateless API — no session cookies for auth).</li>
  *   <li>Sessions not created.</li>
  *   <li>{@code /api/auth/**} is open; everything else requires a valid JWT.</li>
+ *   <li>{@code /api/bot/telegram} and {@code /api/pagos/webhook} are public (webhooks).</li>
  *   <li>{@link JwtAuthFilter} runs before the standard auth filter.</li>
+ *   <li>{@link UserStatusFilter} runs after JwtAuthFilter to re-validate account status.</li>
+ *   <li>Custom 401/403 handlers return machine-readable JSON instead of HTML.</li>
  * </ul>
  */
 @Configuration
@@ -28,18 +34,27 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http,
-                                           JwtAuthFilter jwtAuthFilter) throws Exception {
+                                           JwtAuthFilter jwtAuthFilter,
+                                           UserStatusFilter userStatusFilter,
+                                           CustomAccessDeniedHandler accessDeniedHandler,
+                                           CustomAuthenticationEntryPoint authEntryPoint) throws Exception {
         return http
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(sm ->
                         sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/bot/telegram", "/api/pagos/webhook").permitAll()
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .requestMatchers("/api/usuarios/me").authenticated()
                         .anyRequest().authenticated()
                 )
+                .exceptionHandling(ex -> ex
+                        .accessDeniedHandler(accessDeniedHandler)
+                        .authenticationEntryPoint(authEntryPoint)
+                )
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterAfter(userStatusFilter, JwtAuthFilter.class)
                 .build();
     }
 

--- a/backend/src/main/java/com/padelpro/auth/infrastructure/config/security/CustomAccessDeniedHandler.java
+++ b/backend/src/main/java/com/padelpro/auth/infrastructure/config/security/CustomAccessDeniedHandler.java
@@ -2,7 +2,9 @@ package com.padelpro.auth.infrastructure.config.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.padelpro.auth.domain.model.AuditLog;
+import com.padelpro.auth.domain.model.User;
 import com.padelpro.auth.domain.port.out.AuditLogRepositoryPort;
+import com.padelpro.auth.domain.port.out.UserRepositoryPort;
 import com.padelpro.auth.infrastructure.web.dto.ErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -20,7 +22,8 @@ import java.time.OffsetDateTime;
  * Custom handler for {@code 403 Forbidden} responses.
  *
  * <p>Replaces Spring Security's default HTML error page with a machine-readable
- * JSON body ({@link ErrorResponse}) and records the denied access in the audit log.
+ * JSON body ({@link ErrorResponse}) and records the denied access in the audit log
+ * with a proper {@code user_id} FK (not just a string in the details field).
  *
  * <p>Registered in {@link com.padelpro.auth.infrastructure.config.SecurityConfig}
  * via {@code .exceptionHandling(ex -> ex.accessDeniedHandler(this))}.
@@ -29,11 +32,14 @@ import java.time.OffsetDateTime;
 public class CustomAccessDeniedHandler implements AccessDeniedHandler {
 
     private final AuditLogRepositoryPort auditLogRepositoryPort;
+    private final UserRepositoryPort userRepositoryPort;
     private final ObjectMapper objectMapper;
 
     public CustomAccessDeniedHandler(AuditLogRepositoryPort auditLogRepositoryPort,
+                                     UserRepositoryPort userRepositoryPort,
                                      ObjectMapper objectMapper) {
         this.auditLogRepositoryPort = auditLogRepositoryPort;
+        this.userRepositoryPort = userRepositoryPort;
         this.objectMapper = objectMapper;
     }
 
@@ -42,16 +48,15 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
                        HttpServletResponse response,
                        AccessDeniedException ex) throws IOException {
 
-        // Record in audit log
+        // Resolve the User entity from the JWT principal so the audit log
+        // stores a proper user_id FK, not just a string in the details field.
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        User user = resolveUser(auth);
         String details = "uri=" + request.getRequestURI();
-        if (auth != null && auth.getPrincipal() != null) {
-            details += " userId=" + auth.getPrincipal();
-        }
 
         auditLogRepositoryPort.save(new AuditLog(
                 "ACCESS_DENIED",
-                null,
+                user,
                 getClientIp(request),
                 details,
                 OffsetDateTime.now()
@@ -63,6 +68,22 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
                 response.getWriter(),
                 new ErrorResponse("ACCESS_DENIED", "Insufficient permissions")
         );
+    }
+
+    /**
+     * Resolves the {@link User} from the security context principal.
+     * Returns {@code null} if there is no principal or the principal is not a numeric user id.
+     */
+    private User resolveUser(Authentication auth) {
+        if (auth == null || auth.getPrincipal() == null) {
+            return null;
+        }
+        try {
+            long userId = Long.parseLong(auth.getPrincipal().toString());
+            return userRepositoryPort.findById(userId).orElse(null);
+        } catch (NumberFormatException e) {
+            return null;
+        }
     }
 
     private String getClientIp(HttpServletRequest request) {

--- a/backend/src/main/java/com/padelpro/auth/infrastructure/config/security/CustomAccessDeniedHandler.java
+++ b/backend/src/main/java/com/padelpro/auth/infrastructure/config/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,72 @@
+package com.padelpro.auth.infrastructure.config.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.padelpro.auth.domain.model.AuditLog;
+import com.padelpro.auth.domain.port.out.AuditLogRepositoryPort;
+import com.padelpro.auth.infrastructure.web.dto.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.OffsetDateTime;
+
+/**
+ * Custom handler for {@code 403 Forbidden} responses.
+ *
+ * <p>Replaces Spring Security's default HTML error page with a machine-readable
+ * JSON body ({@link ErrorResponse}) and records the denied access in the audit log.
+ *
+ * <p>Registered in {@link com.padelpro.auth.infrastructure.config.SecurityConfig}
+ * via {@code .exceptionHandling(ex -> ex.accessDeniedHandler(this))}.
+ */
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final AuditLogRepositoryPort auditLogRepositoryPort;
+    private final ObjectMapper objectMapper;
+
+    public CustomAccessDeniedHandler(AuditLogRepositoryPort auditLogRepositoryPort,
+                                     ObjectMapper objectMapper) {
+        this.auditLogRepositoryPort = auditLogRepositoryPort;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException ex) throws IOException {
+
+        // Record in audit log
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        String details = "uri=" + request.getRequestURI();
+        if (auth != null && auth.getPrincipal() != null) {
+            details += " userId=" + auth.getPrincipal();
+        }
+
+        auditLogRepositoryPort.save(new AuditLog(
+                "ACCESS_DENIED",
+                null,
+                getClientIp(request),
+                details,
+                OffsetDateTime.now()
+        ));
+
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        objectMapper.writeValue(
+                response.getWriter(),
+                new ErrorResponse("ACCESS_DENIED", "Insufficient permissions")
+        );
+    }
+
+    private String getClientIp(HttpServletRequest request) {
+        String xff = request.getHeader("X-Forwarded-For");
+        return (xff != null && !xff.isEmpty()) ? xff.split(",")[0].trim() : request.getRemoteAddr();
+    }
+}

--- a/backend/src/main/java/com/padelpro/auth/infrastructure/config/security/CustomAuthenticationEntryPoint.java
+++ b/backend/src/main/java/com/padelpro/auth/infrastructure/config/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,44 @@
+package com.padelpro.auth.infrastructure.config.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.padelpro.auth.infrastructure.web.dto.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+/**
+ * Custom handler for {@code 401 Unauthorized} responses.
+ *
+ * <p>Replaces Spring Security's default redirect/HTML error with a machine-readable
+ * JSON body ({@link ErrorResponse}) so API clients can parse the error code.
+ *
+ * <p>Registered in {@link com.padelpro.auth.infrastructure.config.SecurityConfig}
+ * via {@code .exceptionHandling(ex -> ex.authenticationEntryPoint(this))}.
+ */
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    public CustomAuthenticationEntryPoint(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException ex) throws IOException {
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        objectMapper.writeValue(
+                response.getWriter(),
+                new ErrorResponse("AUTH_REQUIRED", "Authentication required")
+        );
+    }
+}

--- a/backend/src/main/java/com/padelpro/auth/infrastructure/web/filter/UserStatusFilter.java
+++ b/backend/src/main/java/com/padelpro/auth/infrastructure/web/filter/UserStatusFilter.java
@@ -1,0 +1,105 @@
+package com.padelpro.auth.infrastructure.web.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.padelpro.auth.domain.model.AuditLog;
+import com.padelpro.auth.domain.model.User;
+import com.padelpro.auth.domain.model.UserStatus;
+import com.padelpro.auth.domain.port.out.AuditLogRepositoryPort;
+import com.padelpro.auth.domain.port.out.UserRepositoryPort;
+import com.padelpro.auth.infrastructure.web.dto.ErrorResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.OffsetDateTime;
+
+/**
+ * Security filter that re-validates the user's account status on every request.
+ *
+ * <p>After {@link JwtAuthFilter} populates the {@link SecurityContextHolder}, this
+ * filter checks that the authenticated user is still ACTIVE in the database.
+ * If the user has been deactivated (INACTIVE or PENDING) after their JWT was issued,
+ * the request is rejected with HTTP 403 even though the JWT signature is valid.
+ *
+ * <p>Registered at {@code @Order(2)} — always runs after {@link JwtAuthFilter}.
+ * Requests without an authenticated principal (no JWT, or JWT already failed validation)
+ * are passed through unchanged so that Spring Security's own 401 handling applies.
+ */
+@Component
+@Order(2)
+public class UserStatusFilter extends OncePerRequestFilter {
+
+    private final UserRepositoryPort userRepositoryPort;
+    private final AuditLogRepositoryPort auditLogRepositoryPort;
+    private final ObjectMapper objectMapper;
+
+    public UserStatusFilter(UserRepositoryPort userRepositoryPort,
+                            AuditLogRepositoryPort auditLogRepositoryPort,
+                            ObjectMapper objectMapper) {
+        this.userRepositoryPort = userRepositoryPort;
+        this.auditLogRepositoryPort = auditLogRepositoryPort;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated() || auth.getPrincipal() == null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // Principal is userId as String (set by JwtAuthFilter)
+        String principalStr = auth.getPrincipal().toString();
+        long userId;
+        try {
+            userId = Long.parseLong(principalStr);
+        } catch (NumberFormatException e) {
+            // Not a user-id principal — pass through
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        User user = userRepositoryPort.findById(userId).orElse(null);
+        if (user == null || user.getStatus() != UserStatus.ACTIVE) {
+            SecurityContextHolder.clearContext();
+
+            // Record the denied access in the audit log
+            String statusDetail = "status=" + (user != null ? user.getStatus() : "null");
+            auditLogRepositoryPort.save(new AuditLog(
+                    "ACCESS_DENIED",
+                    user,
+                    getClientIp(request),
+                    statusDetail,
+                    OffsetDateTime.now()
+            ));
+
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            objectMapper.writeValue(
+                    response.getWriter(),
+                    new ErrorResponse("ACCOUNT_NOT_ACTIVE", "Account is not active")
+            );
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String getClientIp(HttpServletRequest request) {
+        String xff = request.getHeader("X-Forwarded-For");
+        return (xff != null && !xff.isEmpty()) ? xff.split(",")[0].trim() : request.getRemoteAddr();
+    }
+}

--- a/backend/src/test/java/com/padelpro/auth/architecture/HexagonalArchitectureTest.java
+++ b/backend/src/test/java/com/padelpro/auth/architecture/HexagonalArchitectureTest.java
@@ -9,12 +9,10 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 
 /**
- * T-ArchUnit — Hexagonal architecture boundary verification for the auth module.
+ * T-ArchUnit — Hexagonal architecture boundary verification for the entire platform.
  *
- * <p>These tests verify structural constraints and are expected to PASS with the
- * current Wave 2 skeleton, because the package boundaries are already correct.
- * They act as a regression guard: if any future change violates the hexagonal
- * boundaries, these tests will turn RED immediately.
+ * <p>Scans {@code com.padelpro} (auth + usuarios modules) to enforce hexagonal
+ * boundaries across all bounded contexts.
  *
  * <p>Rules enforced:
  * <ul>
@@ -23,10 +21,11 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
  *   <li>application services must not depend on infrastructure</li>
  *   <li>controllers live in infrastructure.web</li>
  *   <li>repositories live in infrastructure.persistence</li>
+ *   <li>resource ownership port calls belong in application services, never in controllers</li>
  * </ul>
  */
 @AnalyzeClasses(
-        packages = "com.padelpro.auth",
+        packages = "com.padelpro",
         importOptions = ImportOption.DoNotIncludeTests.class
 )
 class HexagonalArchitectureTest {
@@ -80,25 +79,44 @@ class HexagonalArchitectureTest {
 
     // -------------------------------------------------------------------------
     // Rule 4 — Controllers must reside in infrastructure.web
+    //
+    // Applies to all bounded contexts under com.padelpro (auth + usuarios + future).
     // -------------------------------------------------------------------------
 
     @ArchTest
     static final ArchRule controllers_should_be_in_infrastructure_web_package =
             classes()
                     .that().haveSimpleNameEndingWith("Controller")
-                    .should().resideInAPackage("com.padelpro.auth.infrastructure.web..")
+                    .should().resideInAPackage("..infrastructure.web..")
                     .because("All inbound HTTP adapters (controllers) belong in the " +
-                             "infrastructure.web package.");
+                             "infrastructure.web package of their respective bounded context.");
 
     // -------------------------------------------------------------------------
     // Rule 5 — Repositories must reside in infrastructure.persistence
+    //
+    // Applies to all bounded contexts under com.padelpro (auth + usuarios + future).
     // -------------------------------------------------------------------------
 
     @ArchTest
     static final ArchRule repositories_should_be_in_infrastructure_persistence_package =
             classes()
                     .that().haveSimpleNameEndingWith("Repository")
-                    .should().resideInAPackage("com.padelpro.auth.infrastructure.persistence..")
+                    .should().resideInAPackage("..infrastructure.persistence..")
                     .because("All outbound persistence adapters (repositories) belong in the " +
-                             "infrastructure.persistence package.");
+                             "infrastructure.persistence package of their respective bounded context.");
+
+    // -------------------------------------------------------------------------
+    // Rule 6 — ResourceOwnershipPort must NOT be used in controllers
+    //
+    // Ownership checks belong in application services, not in HTTP adapters.
+    // -------------------------------------------------------------------------
+
+    @ArchTest
+    static final ArchRule resource_ownership_must_not_be_in_controllers =
+            noClasses()
+                    .that().resideInAPackage("..infrastructure.web..")
+                    .should().dependOnClassesThat()
+                    .resideInAPackage("..domain.port.in..")
+                    .because("Resource ownership port calls belong in application services, " +
+                             "never in controllers.");
 }

--- a/backend/src/test/java/com/padelpro/auth/infrastructure/config/security/CustomAccessDeniedHandlerTest.java
+++ b/backend/src/test/java/com/padelpro/auth/infrastructure/config/security/CustomAccessDeniedHandlerTest.java
@@ -1,7 +1,11 @@
 package com.padelpro.auth.infrastructure.config.security;
 
 import com.padelpro.auth.domain.model.AuditLog;
+import com.padelpro.auth.domain.model.User;
+import com.padelpro.auth.domain.model.UserRole;
+import com.padelpro.auth.domain.model.UserStatus;
 import com.padelpro.auth.domain.port.out.AuditLogRepositoryPort;
+import com.padelpro.auth.domain.port.out.UserRepositoryPort;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.AfterEach;
@@ -9,6 +13,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.access.AccessDeniedException;
@@ -18,10 +23,13 @@ import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -33,6 +41,9 @@ class CustomAccessDeniedHandlerTest {
 
     @Mock
     private AuditLogRepositoryPort auditLogRepositoryPort;
+
+    @Mock
+    private UserRepositoryPort userRepositoryPort;
 
     @Mock
     private HttpServletRequest request;
@@ -52,7 +63,7 @@ class CustomAccessDeniedHandlerTest {
     @BeforeEach
     void setUp() throws Exception {
         SecurityContextHolder.clearContext();
-        handler = new CustomAccessDeniedHandler(auditLogRepositoryPort, objectMapper);
+        handler = new CustomAccessDeniedHandler(auditLogRepositoryPort, userRepositoryPort, objectMapper);
         responseWriter = new StringWriter();
         when(response.getWriter()).thenReturn(new PrintWriter(responseWriter));
         when(request.getRemoteAddr()).thenReturn("127.0.0.1");
@@ -79,18 +90,43 @@ class CustomAccessDeniedHandlerTest {
     }
 
     @Test
-    @DisplayName("should_log_access_denied_to_audit_log")
-    void should_log_access_denied_to_audit_log() throws Exception {
+    @DisplayName("should_log_access_denied_to_audit_log_with_user_fk")
+    void should_log_access_denied_to_audit_log_with_user_fk() throws Exception {
         // Configure SecurityContext with valid auth (userId="42")
+        OffsetDateTime now = OffsetDateTime.now();
+        User user = new User("user42", "hash", "Test", "User",
+                "user42@example.com", UserRole.USER, UserStatus.ACTIVE, now, now);
+
         UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
                 "42", null,
                 List.of(new SimpleGrantedAuthority("ROLE_USER"))
         );
         SecurityContextHolder.getContext().setAuthentication(auth);
+        when(userRepositoryPort.findById(42L)).thenReturn(Optional.of(user));
 
         AccessDeniedException ex = new AccessDeniedException("Forbidden");
         handler.handle(request, response, ex);
 
-        verify(auditLogRepositoryPort).save(any(AuditLog.class));
+        // Verify audit log saved with actual User entity (not null)
+        ArgumentCaptor<AuditLog> logCaptor = ArgumentCaptor.forClass(AuditLog.class);
+        verify(auditLogRepositoryPort).save(logCaptor.capture());
+        AuditLog saved = logCaptor.getValue();
+        assertThat(saved.getAction()).isEqualTo("ACCESS_DENIED");
+        assertThat(saved.getUser()).isEqualTo(user);
+        assertThat(saved.getDetails()).contains("uri=/api/admin/usuarios");
+
+        verify(userRepositoryPort).findById(eq(42L));
+    }
+
+    @Test
+    @DisplayName("should_log_access_denied_with_null_user_when_no_auth")
+    void should_log_access_denied_with_null_user_when_no_auth() throws Exception {
+        // No SecurityContext — anonymous request
+        AccessDeniedException ex = new AccessDeniedException("Forbidden");
+        handler.handle(request, response, ex);
+
+        ArgumentCaptor<AuditLog> logCaptor = ArgumentCaptor.forClass(AuditLog.class);
+        verify(auditLogRepositoryPort).save(logCaptor.capture());
+        assertThat(logCaptor.getValue().getUser()).isNull();
     }
 }

--- a/backend/src/test/java/com/padelpro/auth/infrastructure/config/security/CustomAccessDeniedHandlerTest.java
+++ b/backend/src/test/java/com/padelpro/auth/infrastructure/config/security/CustomAccessDeniedHandlerTest.java
@@ -1,0 +1,93 @@
+package com.padelpro.auth.infrastructure.config.security;
+
+import com.padelpro.auth.domain.model.AuditLog;
+import com.padelpro.auth.domain.port.out.AuditLogRepositoryPort;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * TDD RED — Unit tests for CustomAccessDeniedHandler.
+ * These tests FAIL until CustomAccessDeniedHandler is implemented.
+ */
+@ExtendWith(MockitoExtension.class)
+class CustomAccessDeniedHandlerTest {
+
+    @Mock
+    private AuditLogRepositoryPort auditLogRepositoryPort;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @InjectMocks
+    private CustomAccessDeniedHandler handler;
+
+    private StringWriter responseWriter;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        SecurityContextHolder.clearContext();
+        responseWriter = new StringWriter();
+        when(response.getWriter()).thenReturn(new PrintWriter(responseWriter));
+        when(request.getRemoteAddr()).thenReturn("127.0.0.1");
+        when(request.getRequestURI()).thenReturn("/api/admin/usuarios");
+        when(auditLogRepositoryPort.save(any(AuditLog.class))).thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("should_write_json_error_response_on_403")
+    void should_write_json_error_response_on_403() throws Exception {
+        AccessDeniedException ex = new AccessDeniedException("Forbidden");
+
+        handler.handle(request, response, ex);
+
+        verify(response).setStatus(403);
+        verify(response).setContentType("application/json");
+        String body = responseWriter.toString();
+        assertThat(body).contains("ACCESS_DENIED");
+    }
+
+    @Test
+    @DisplayName("should_log_access_denied_to_audit_log")
+    void should_log_access_denied_to_audit_log() throws Exception {
+        // Configure SecurityContext with valid auth (userId="42")
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                "42", null,
+                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        AccessDeniedException ex = new AccessDeniedException("Forbidden");
+        handler.handle(request, response, ex);
+
+        verify(auditLogRepositoryPort).save(any(AuditLog.class));
+    }
+}

--- a/backend/src/test/java/com/padelpro/auth/infrastructure/config/security/CustomAccessDeniedHandlerTest.java
+++ b/backend/src/test/java/com/padelpro/auth/infrastructure/config/security/CustomAccessDeniedHandlerTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.access.AccessDeniedException;
@@ -27,8 +26,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * TDD RED — Unit tests for CustomAccessDeniedHandler.
- * These tests FAIL until CustomAccessDeniedHandler is implemented.
+ * Unit tests for CustomAccessDeniedHandler (GREEN phase after implementation).
  */
 @ExtendWith(MockitoExtension.class)
 class CustomAccessDeniedHandlerTest {
@@ -42,7 +40,11 @@ class CustomAccessDeniedHandlerTest {
     @Mock
     private HttpServletResponse response;
 
-    @InjectMocks
+    private final com.fasterxml.jackson.databind.ObjectMapper objectMapper =
+            new com.fasterxml.jackson.databind.ObjectMapper()
+                    .findAndRegisterModules()
+                    .disable(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
     private CustomAccessDeniedHandler handler;
 
     private StringWriter responseWriter;
@@ -50,6 +52,7 @@ class CustomAccessDeniedHandlerTest {
     @BeforeEach
     void setUp() throws Exception {
         SecurityContextHolder.clearContext();
+        handler = new CustomAccessDeniedHandler(auditLogRepositoryPort, objectMapper);
         responseWriter = new StringWriter();
         when(response.getWriter()).thenReturn(new PrintWriter(responseWriter));
         when(request.getRemoteAddr()).thenReturn("127.0.0.1");

--- a/backend/src/test/java/com/padelpro/auth/infrastructure/config/security/CustomAuthenticationEntryPointTest.java
+++ b/backend/src/test/java/com/padelpro/auth/infrastructure/config/security/CustomAuthenticationEntryPointTest.java
@@ -1,0 +1,57 @@
+package com.padelpro.auth.infrastructure.config.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.AuthenticationException;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * TDD RED — Unit tests for CustomAuthenticationEntryPoint.
+ * These tests FAIL until CustomAuthenticationEntryPoint is implemented.
+ */
+@ExtendWith(MockitoExtension.class)
+class CustomAuthenticationEntryPointTest {
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @InjectMocks
+    private CustomAuthenticationEntryPoint entryPoint;
+
+    private StringWriter responseWriter;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        responseWriter = new StringWriter();
+        when(response.getWriter()).thenReturn(new PrintWriter(responseWriter));
+    }
+
+    @Test
+    @DisplayName("should_write_401_json_response")
+    void should_write_401_json_response() throws Exception {
+        AuthenticationException ex = new org.springframework.security.authentication.BadCredentialsException("Unauthorized");
+
+        entryPoint.commence(request, response, ex);
+
+        verify(response).setStatus(401);
+        verify(response).setContentType("application/json");
+        String body = responseWriter.toString();
+        assertThat(body).contains("AUTH_REQUIRED");
+    }
+}

--- a/backend/src/test/java/com/padelpro/auth/infrastructure/config/security/CustomAuthenticationEntryPointTest.java
+++ b/backend/src/test/java/com/padelpro/auth/infrastructure/config/security/CustomAuthenticationEntryPointTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.AuthenticationException;
@@ -19,8 +18,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * TDD RED — Unit tests for CustomAuthenticationEntryPoint.
- * These tests FAIL until CustomAuthenticationEntryPoint is implemented.
+ * Unit tests for CustomAuthenticationEntryPoint (GREEN phase after implementation).
  */
 @ExtendWith(MockitoExtension.class)
 class CustomAuthenticationEntryPointTest {
@@ -31,13 +29,18 @@ class CustomAuthenticationEntryPointTest {
     @Mock
     private HttpServletResponse response;
 
-    @InjectMocks
+    private final com.fasterxml.jackson.databind.ObjectMapper objectMapper =
+            new com.fasterxml.jackson.databind.ObjectMapper()
+                    .findAndRegisterModules()
+                    .disable(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
     private CustomAuthenticationEntryPoint entryPoint;
 
     private StringWriter responseWriter;
 
     @BeforeEach
     void setUp() throws Exception {
+        entryPoint = new CustomAuthenticationEntryPoint(objectMapper);
         responseWriter = new StringWriter();
         when(response.getWriter()).thenReturn(new PrintWriter(responseWriter));
     }

--- a/backend/src/test/java/com/padelpro/auth/infrastructure/web/SecurityE2ETest.java
+++ b/backend/src/test/java/com/padelpro/auth/infrastructure/web/SecurityE2ETest.java
@@ -1,0 +1,202 @@
+package com.padelpro.auth.infrastructure.web;
+
+import com.padelpro.auth.application.service.JwtService;
+import com.padelpro.auth.domain.model.User;
+import com.padelpro.auth.domain.model.UserRole;
+import com.padelpro.auth.domain.model.UserStatus;
+import com.padelpro.auth.infrastructure.persistence.AuditLogRepository;
+import com.padelpro.auth.infrastructure.persistence.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.jdbc.Sql;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * TDD RED — E2E tests for security (TestRestTemplate, full HTTP stack).
+ * These tests FAIL until the production components are implemented (GREEN phase).
+ *
+ * Tests cover:
+ *  - Full cycle: user deactivated mid-session → JWT still valid → 403 with JSON
+ *  - Role escalation via PATCH /api/usuarios/me is silently ignored
+ *  - Audit log accumulates denied accesses
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Testcontainers
+@ActiveProfiles("it")
+@Sql(scripts = "/sql/cleanup.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+class SecurityE2ETest {
+
+    @Container
+    static final PostgreSQLContainer<?> postgres =
+            new PostgreSQLContainer<>("postgres:15-alpine")
+                    .withDatabaseName("padelpro_test")
+                    .withUsername("padelpro_test")
+                    .withPassword("padelpro_test");
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @Autowired private TestRestTemplate restTemplate;
+    @Autowired private UserRepository userRepository;
+    @Autowired private AuditLogRepository auditLogRepository;
+    @Autowired private JwtService jwtService;
+    @Autowired private BCryptPasswordEncoder passwordEncoder;
+
+    private User activeUser;
+    private User adminUser;
+    private String userToken;
+    private String adminToken;
+
+    @BeforeEach
+    void setUp() {
+        OffsetDateTime now = OffsetDateTime.now();
+
+        activeUser = userRepository.saveAndFlush(new User(
+                "e2e.user", passwordEncoder.encode("Password1"),
+                "E2E", "User", "e2e@example.com",
+                UserRole.USER, UserStatus.ACTIVE, now, now));
+
+        adminUser = userRepository.saveAndFlush(new User(
+                "e2e.admin", passwordEncoder.encode("Password1"),
+                "E2E", "Admin", "e2eadmin@example.com",
+                UserRole.ADMIN, UserStatus.ACTIVE, now, now));
+
+        userToken = jwtService.generateAccessToken(activeUser);
+        adminToken = jwtService.generateAccessToken(adminUser);
+    }
+
+    private HttpHeaders bearerHeaders(String token) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+        return headers;
+    }
+
+    // =========================================================================
+    // Test 1: User deactivated mid-session → 403 ACCOUNT_NOT_ACTIVE
+    // =========================================================================
+
+    @Test
+    @DisplayName("inactive_user_full_cycle_e2e")
+    void inactive_user_full_cycle_e2e() {
+        // Step 1: User is ACTIVE, JWT obtained in setUp()
+        // Verify user can access their profile
+        ResponseEntity<Map> beforeDeactivation = restTemplate.exchange(
+                "/api/usuarios/me",
+                HttpMethod.GET,
+                new HttpEntity<>(bearerHeaders(userToken)),
+                Map.class
+        );
+        assertThat(beforeDeactivation.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        // Step 2: Admin deactivates the user
+        activeUser.setStatus(UserStatus.INACTIVE);
+        userRepository.saveAndFlush(activeUser);
+
+        // Step 3: User's JWT is still valid but account is now INACTIVE
+        ResponseEntity<Map> afterDeactivation = restTemplate.exchange(
+                "/api/usuarios/me",
+                HttpMethod.GET,
+                new HttpEntity<>(bearerHeaders(userToken)),
+                Map.class
+        );
+
+        assertThat(afterDeactivation.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+        assertThat(afterDeactivation.getHeaders().getContentType())
+                .isNotNull()
+                .satisfies(ct -> assertThat(ct.toString()).contains("application/json"));
+        assertThat(afterDeactivation.getBody())
+                .isNotNull()
+                .containsEntry("error", "ACCOUNT_NOT_ACTIVE");
+    }
+
+    // =========================================================================
+    // Test 2: Role escalation via PATCH /api/usuarios/me is silently ignored
+    // =========================================================================
+
+    @Test
+    @DisplayName("role_escalation_attempt_via_patch_me_e2e")
+    void role_escalation_attempt_via_patch_me_e2e() {
+        HttpHeaders headers = bearerHeaders(userToken);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        // Attempt to escalate role via PATCH /api/usuarios/me
+        Map<String, String> patchBody = Map.of(
+                "role", "ADMIN",
+                "firstName", "Hacker"
+        );
+
+        ResponseEntity<Map> patchResponse = restTemplate.exchange(
+                "/api/usuarios/me",
+                HttpMethod.PATCH,
+                new HttpEntity<>(patchBody, headers),
+                Map.class
+        );
+
+        // Should succeed (200) but role must NOT change
+        assertThat(patchResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        // Verify role is still USER
+        ResponseEntity<Map> getResponse = restTemplate.exchange(
+                "/api/usuarios/me",
+                HttpMethod.GET,
+                new HttpEntity<>(bearerHeaders(userToken)),
+                Map.class
+        );
+        assertThat(getResponse.getBody())
+                .isNotNull()
+                .containsEntry("role", "USER");
+    }
+
+    // =========================================================================
+    // Test 3: Audit log accumulates denied accesses
+    // =========================================================================
+
+    @Test
+    @DisplayName("audit_log_contains_denied_accesses_e2e")
+    void audit_log_contains_denied_accesses_e2e() {
+        // USER role tries to access admin endpoint twice
+        restTemplate.exchange(
+                "/api/admin/usuarios",
+                HttpMethod.GET,
+                new HttpEntity<>(bearerHeaders(userToken)),
+                Map.class
+        );
+        restTemplate.exchange(
+                "/api/admin/usuarios",
+                HttpMethod.GET,
+                new HttpEntity<>(bearerHeaders(userToken)),
+                Map.class
+        );
+
+        long deniedCount = auditLogRepository.findAll().stream()
+                .filter(log -> "ACCESS_DENIED".equals(log.getAction()))
+                .count();
+
+        assertThat(deniedCount).isGreaterThanOrEqualTo(2);
+    }
+}

--- a/backend/src/test/java/com/padelpro/auth/infrastructure/web/SecurityIntegrationTest.java
+++ b/backend/src/test/java/com/padelpro/auth/infrastructure/web/SecurityIntegrationTest.java
@@ -1,0 +1,200 @@
+package com.padelpro.auth.infrastructure.web;
+
+import com.padelpro.auth.application.service.JwtService;
+import com.padelpro.auth.domain.model.User;
+import com.padelpro.auth.domain.model.UserRole;
+import com.padelpro.auth.domain.model.UserStatus;
+import com.padelpro.auth.infrastructure.persistence.AuditLogRepository;
+import com.padelpro.auth.infrastructure.persistence.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.OffsetDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * TDD RED — Integration tests for security filters and handlers.
+ * Tests cover:
+ *  - UserStatusFilter: INACTIVE and PENDING users receive 403
+ *  - CustomAccessDeniedHandler: USER role on /api/admin/** receives 403 with JSON body
+ *  - CustomAuthenticationEntryPoint: unauthenticated requests receive 401 with JSON body
+ *  - Audit log recording for denied accesses
+ *  - Webhook routes not blocked by JWT filter
+ *
+ * These tests FAIL until the production components are implemented (GREEN phase).
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@Testcontainers
+@ActiveProfiles("it")
+@Sql(scripts = "/sql/cleanup.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+class SecurityIntegrationTest {
+
+    @Container
+    static final PostgreSQLContainer<?> postgres =
+            new PostgreSQLContainer<>("postgres:15-alpine")
+                    .withDatabaseName("padelpro_test")
+                    .withUsername("padelpro_test")
+                    .withPassword("padelpro_test");
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private UserRepository userRepository;
+    @Autowired private AuditLogRepository auditLogRepository;
+    @Autowired private JwtService jwtService;
+    @Autowired private BCryptPasswordEncoder passwordEncoder;
+
+    private User activeUser;
+    private User adminUser;
+    private String activeUserToken;
+    private String adminToken;
+
+    @BeforeEach
+    void setUp() {
+        OffsetDateTime now = OffsetDateTime.now();
+
+        activeUser = userRepository.saveAndFlush(new User(
+                "regular.user", passwordEncoder.encode("Password1"),
+                "Regular", "User", "regular@example.com",
+                UserRole.USER, UserStatus.ACTIVE, now, now));
+
+        adminUser = userRepository.saveAndFlush(new User(
+                "admin.user", passwordEncoder.encode("Password1"),
+                "Admin", "User", "admin@example.com",
+                UserRole.ADMIN, UserStatus.ACTIVE, now, now));
+
+        activeUserToken = jwtService.generateAccessToken(activeUser);
+        adminToken = jwtService.generateAccessToken(adminUser);
+    }
+
+    // =========================================================================
+    // UserStatusFilter — INACTIVE / PENDING → 403
+    // =========================================================================
+
+    @Test
+    @DisplayName("user_with_inactive_status_receives_403_on_authenticated_endpoint")
+    void user_with_inactive_status_receives_403_on_authenticated_endpoint() throws Exception {
+        // Deactivate the user in DB after token was issued
+        activeUser.setStatus(UserStatus.INACTIVE);
+        userRepository.saveAndFlush(activeUser);
+
+        mockMvc.perform(get("/api/usuarios/me")
+                        .header("Authorization", "Bearer " + activeUserToken))
+                .andExpect(status().isForbidden())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.error").value("ACCOUNT_NOT_ACTIVE"));
+    }
+
+    @Test
+    @DisplayName("user_with_pending_status_receives_403_on_authenticated_endpoint")
+    void user_with_pending_status_receives_403_on_authenticated_endpoint() throws Exception {
+        // Change user to PENDING in DB after token was issued
+        activeUser.setStatus(UserStatus.PENDING);
+        userRepository.saveAndFlush(activeUser);
+
+        mockMvc.perform(get("/api/usuarios/me")
+                        .header("Authorization", "Bearer " + activeUserToken))
+                .andExpect(status().isForbidden())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.error").value("ACCOUNT_NOT_ACTIVE"));
+    }
+
+    // =========================================================================
+    // CustomAccessDeniedHandler — USER on /api/admin/** → 403 with JSON
+    // =========================================================================
+
+    @Test
+    @DisplayName("user_role_receives_403_on_admin_endpoint_with_json_body")
+    void user_role_receives_403_on_admin_endpoint_with_json_body() throws Exception {
+        mockMvc.perform(get("/api/admin/usuarios")
+                        .header("Authorization", "Bearer " + activeUserToken))
+                .andExpect(status().isForbidden())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.error").value("ACCESS_DENIED"));
+    }
+
+    // =========================================================================
+    // CustomAuthenticationEntryPoint — no token → 401 with JSON
+    // =========================================================================
+
+    @Test
+    @DisplayName("unauthenticated_request_receives_401_with_json_body")
+    void unauthenticated_request_receives_401_with_json_body() throws Exception {
+        mockMvc.perform(get("/api/usuarios/me"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.error").value("AUTH_REQUIRED"));
+    }
+
+    // =========================================================================
+    // Admin user successfully accesses admin endpoint
+    // =========================================================================
+
+    @Test
+    @DisplayName("admin_user_accesses_admin_endpoint_successfully")
+    void admin_user_accesses_admin_endpoint_successfully() throws Exception {
+        mockMvc.perform(get("/api/admin/usuarios")
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isOk());
+    }
+
+    // =========================================================================
+    // Audit log — denied access is recorded
+    // =========================================================================
+
+    @Test
+    @DisplayName("forbidden_access_is_recorded_in_audit_log")
+    void forbidden_access_is_recorded_in_audit_log() throws Exception {
+        mockMvc.perform(get("/api/admin/usuarios")
+                        .header("Authorization", "Bearer " + activeUserToken))
+                .andExpect(status().isForbidden());
+
+        long deniedCount = auditLogRepository.findAll().stream()
+                .filter(log -> "ACCESS_DENIED".equals(log.getAction()))
+                .count();
+        assertThat(deniedCount).isGreaterThanOrEqualTo(1);
+    }
+
+    // =========================================================================
+    // Webhook routes — not blocked by JWT absence
+    // =========================================================================
+
+    @Test
+    @DisplayName("webhook_routes_are_not_blocked_by_jwt_absence")
+    void webhook_routes_are_not_blocked_by_jwt_absence() throws Exception {
+        // POST to /api/bot/telegram without JWT — Spring Security must NOT return 401
+        // (can be 404 if endpoint doesn't exist, or 405, but never 401)
+        int status = mockMvc.perform(
+                        org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                                .post("/api/bot/telegram")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("{}"))
+                .andReturn().getResponse().getStatus();
+        assertThat(status).isNotEqualTo(401);
+    }
+}

--- a/backend/src/test/java/com/padelpro/auth/infrastructure/web/filter/UserStatusFilterTest.java
+++ b/backend/src/test/java/com/padelpro/auth/infrastructure/web/filter/UserStatusFilterTest.java
@@ -34,8 +34,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * TDD RED — Unit tests for UserStatusFilter.
- * These tests FAIL until UserStatusFilter is implemented.
+ * Unit tests for UserStatusFilter (GREEN phase after implementation).
  */
 @ExtendWith(MockitoExtension.class)
 class UserStatusFilterTest {
@@ -55,7 +54,12 @@ class UserStatusFilterTest {
     @Mock
     private FilterChain filterChain;
 
-    @InjectMocks
+    // Real ObjectMapper — cannot be mocked because @InjectMocks only injects by type
+    private final com.fasterxml.jackson.databind.ObjectMapper objectMapper =
+            new com.fasterxml.jackson.databind.ObjectMapper()
+                    .findAndRegisterModules()
+                    .disable(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
     private UserStatusFilter userStatusFilter;
 
     private StringWriter responseWriter;
@@ -63,10 +67,8 @@ class UserStatusFilterTest {
     @BeforeEach
     void setUp() throws Exception {
         SecurityContextHolder.clearContext();
+        userStatusFilter = new UserStatusFilter(userRepositoryPort, auditLogRepositoryPort, objectMapper);
         responseWriter = new StringWriter();
-        when(response.getWriter()).thenReturn(new PrintWriter(responseWriter));
-        when(request.getRemoteAddr()).thenReturn("127.0.0.1");
-        when(auditLogRepositoryPort.save(any(AuditLog.class))).thenAnswer(inv -> inv.getArgument(0));
     }
 
     @AfterEach
@@ -111,6 +113,9 @@ class UserStatusFilterTest {
         setAuthContext("42");
         User inactiveUser = buildUser(42L, UserStatus.INACTIVE);
         when(userRepositoryPort.findById(42L)).thenReturn(Optional.of(inactiveUser));
+        when(response.getWriter()).thenReturn(new PrintWriter(responseWriter));
+        when(request.getRemoteAddr()).thenReturn("127.0.0.1");
+        when(auditLogRepositoryPort.save(any(AuditLog.class))).thenAnswer(inv -> inv.getArgument(0));
 
         userStatusFilter.doFilterInternal(request, response, filterChain);
 
@@ -125,6 +130,9 @@ class UserStatusFilterTest {
         setAuthContext("42");
         User pendingUser = buildUser(42L, UserStatus.PENDING);
         when(userRepositoryPort.findById(42L)).thenReturn(Optional.of(pendingUser));
+        when(response.getWriter()).thenReturn(new PrintWriter(responseWriter));
+        when(request.getRemoteAddr()).thenReturn("127.0.0.1");
+        when(auditLogRepositoryPort.save(any(AuditLog.class))).thenAnswer(inv -> inv.getArgument(0));
 
         userStatusFilter.doFilterInternal(request, response, filterChain);
 

--- a/backend/src/test/java/com/padelpro/auth/infrastructure/web/filter/UserStatusFilterTest.java
+++ b/backend/src/test/java/com/padelpro/auth/infrastructure/web/filter/UserStatusFilterTest.java
@@ -1,0 +1,159 @@
+package com.padelpro.auth.infrastructure.web.filter;
+
+import com.padelpro.auth.domain.model.AuditLog;
+import com.padelpro.auth.domain.model.User;
+import com.padelpro.auth.domain.model.UserRole;
+import com.padelpro.auth.domain.model.UserStatus;
+import com.padelpro.auth.domain.port.out.AuditLogRepositoryPort;
+import com.padelpro.auth.domain.port.out.UserRepositoryPort;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * TDD RED — Unit tests for UserStatusFilter.
+ * These tests FAIL until UserStatusFilter is implemented.
+ */
+@ExtendWith(MockitoExtension.class)
+class UserStatusFilterTest {
+
+    @Mock
+    private UserRepositoryPort userRepositoryPort;
+
+    @Mock
+    private AuditLogRepositoryPort auditLogRepositoryPort;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private FilterChain filterChain;
+
+    @InjectMocks
+    private UserStatusFilter userStatusFilter;
+
+    private StringWriter responseWriter;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        SecurityContextHolder.clearContext();
+        responseWriter = new StringWriter();
+        when(response.getWriter()).thenReturn(new PrintWriter(responseWriter));
+        when(request.getRemoteAddr()).thenReturn("127.0.0.1");
+        when(auditLogRepositoryPort.save(any(AuditLog.class))).thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private User buildUser(Long id, UserStatus status) {
+        User user = new User(
+                "testuser",
+                "hash",
+                "Test",
+                "User",
+                "user@example.com",
+                UserRole.USER,
+                status,
+                OffsetDateTime.now(),
+                OffsetDateTime.now()
+        );
+        // Reflectively set the id since User.id is managed by JPA
+        try {
+            java.lang.reflect.Field idField = User.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(user, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return user;
+    }
+
+    private void setAuthContext(String userId) {
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                userId, null,
+                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    @Test
+    @DisplayName("should_return_403_when_user_is_inactive_despite_valid_jwt")
+    void should_return_403_when_user_is_inactive_despite_valid_jwt() throws Exception {
+        setAuthContext("42");
+        User inactiveUser = buildUser(42L, UserStatus.INACTIVE);
+        when(userRepositoryPort.findById(42L)).thenReturn(Optional.of(inactiveUser));
+
+        userStatusFilter.doFilterInternal(request, response, filterChain);
+
+        verify(response).setStatus(403);
+        verify(filterChain, never()).doFilter(any(), any());
+        verify(auditLogRepositoryPort).save(any(AuditLog.class));
+    }
+
+    @Test
+    @DisplayName("should_return_403_when_user_is_pending_despite_valid_jwt")
+    void should_return_403_when_user_is_pending_despite_valid_jwt() throws Exception {
+        setAuthContext("42");
+        User pendingUser = buildUser(42L, UserStatus.PENDING);
+        when(userRepositoryPort.findById(42L)).thenReturn(Optional.of(pendingUser));
+
+        userStatusFilter.doFilterInternal(request, response, filterChain);
+
+        verify(response).setStatus(403);
+        verify(filterChain, never()).doFilter(any(), any());
+        verify(auditLogRepositoryPort).save(any(AuditLog.class));
+    }
+
+    @Test
+    @DisplayName("should_pass_through_when_user_is_active")
+    void should_pass_through_when_user_is_active() throws Exception {
+        setAuthContext("42");
+        User activeUser = buildUser(42L, UserStatus.ACTIVE);
+        when(userRepositoryPort.findById(42L)).thenReturn(Optional.of(activeUser));
+
+        userStatusFilter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+        verify(response, never()).setStatus(403);
+    }
+
+    @Test
+    @DisplayName("should_not_query_db_when_no_authentication_in_context")
+    void should_not_query_db_when_no_authentication_in_context() throws Exception {
+        // SecurityContext has no authentication
+
+        userStatusFilter.doFilterInternal(request, response, filterChain);
+
+        verify(userRepositoryPort, never()).findById(anyLong());
+        verify(filterChain).doFilter(request, response);
+    }
+}

--- a/openspec/changes/archive/2026-05-31-roles-permisos/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-31-roles-permisos/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-31

--- a/openspec/changes/archive/2026-05-31-roles-permisos/design.md
+++ b/openspec/changes/archive/2026-05-31-roles-permisos/design.md
@@ -1,0 +1,167 @@
+## Context
+
+Spring Security está configurado con `hasRole('ADMIN')` para `/api/admin/**` y `authenticated()` para el resto. El `JwtAuthFilter` valida firma y expiración del token. Sin embargo:
+
+1. **Hueco de estado**: el status del usuario (`PENDING`, `INACTIVE`) no se re-verifica en cada request. Un token emitido a un ACTIVE user sigue siendo válido aunque ese usuario sea desactivado antes de que expire.
+2. **403 silenciosos**: los accesos denegados no se auditan. No hay forma de saber post-hoc qué intentos no autorizados se produjeron.
+3. **Respuestas inconsistentes**: Spring Security devuelve HTML o respuestas vacías para 401/403. Los clientes esperan `ErrorResponse` JSON.
+4. **Webhook routes sin configurar**: `/api/bot/telegram` y `/api/pagos/webhook` aún no existen; si se crean sin configuración explícita, Spring Security las protegerá con JWT lo cual es incorrecto (usan validación propia).
+5. **Propiedad de recurso sin contrato**: las reglas RN-AUTH-01..04 (quien puede ver/cancelar/pagar su reserva) no tienen una abstracción formal. Sin un puerto definido, cada servicio las implementará de forma ad-hoc.
+6. **Sin umbral de cobertura**: no hay configuración que garantice el 80% de cobertura mínima.
+
+---
+
+## Goals / Non-Goals
+
+**Goals:**
+- Verificar `user.status == ACTIVE` en cada request autenticado (no solo en login).
+- Respuestas JSON uniformes para 401 y 403.
+- Audit log de todo 403.
+- Rutas webhook configuradas como `permitAll()` con validación delegada.
+- Contrato de propiedad de recurso (`ResourceOwnershipPort`) formalmente definido.
+- JaCoCo con umbral 80%.
+- ArchUnit: propiedad de recurso en capa `application`, nunca en `infrastructure`.
+
+**Non-Goals:**
+- Implementar las verificaciones de propiedad (RN-AUTH-01..04) — eso es `reservas`.
+- UI de gestión de roles — eso es `administracion-club` (Fase 2).
+- Revocación activa de JWT — sin lista negra en v1.0 (coste/beneficio fuera de alcance).
+
+---
+
+## Decisions
+
+### D-1 — `UserStatusFilter`: re-verificación de status por request
+
+Nuevo `OncePerRequestFilter` que se ejecuta DESPUÉS de `JwtAuthFilter` en la cadena:
+
+```
+JwtAuthFilter → UserStatusFilter → Spring Security authorization
+```
+
+Si el `SecurityContext` tiene una autenticación válida (JWT OK), el filtro carga el usuario por `userId` del principal y verifica `user.status == ACTIVE`. Si no está ACTIVE, llama a `SecurityContextHolder.clearContext()` y escribe directamente la respuesta `403` con código `ACCOUNT_NOT_ACTIVE`.
+
+**Razón de orden**: después de `JwtAuthFilter` porque solo actúa si hay JWT válido. Antes de la capa de autorización de Spring Security porque necesita bloquear independientemente del endpoint.
+
+**Impacto en rendimiento**: una query a BD por cada request autenticado. Acceptable en v1.0 con caché L1 de Hibernate (la entidad user probablemente ya esté en sesión). Si se necesita optimización futura: añadir caché Redis con TTL = duración del access token (15 min).
+
+*Alternativa descartada*: añadir `status` como claim en el JWT y verificarlo sin BD. Descartada porque el JWT es inmutable — si el status cambia, el claim queda obsoleto durante toda la vida del token.
+
+### D-2 — `CustomAccessDeniedHandler` + `CustomAuthenticationEntryPoint`
+
+Dos beans nuevos en `SecurityConfig`:
+
+- `CustomAuthenticationEntryPoint`: maneja `401 Unauthorized`. Escribe `ErrorResponse { code: "AUTH_REQUIRED", message: "Authentication required" }`. Registra en audit_log con acción `ACCESS_UNAUTHENTICATED` y `user_id=null`.
+- `CustomAccessDeniedHandler`: maneja `403 Forbidden`. Escribe `ErrorResponse { code: "ACCESS_DENIED", message: "Insufficient permissions" }`. Registra en audit_log con acción `ACCESS_DENIED`, `user_id` del token (si existe), `ip_address` y `details=requestUri`.
+
+*Razón*: respuestas JSON uniformes para que el frontend pueda parsear errores de forma predecible sin condicionales por tipo de contenido.
+
+### D-3 — Rutas webhook como `permitAll()` en SecurityFilterChain
+
+```java
+.requestMatchers("/api/bot/telegram", "/api/pagos/webhook").permitAll()
+```
+
+La validación de seguridad de estos endpoints la realiza su adaptador respectivo (secret token de Telegram en header `X-Telegram-Bot-Api-Secret-Token`, HMAC SHA-256 de Redsys). Configurarlos como `permitAll()` en Spring Security NO los deja sin protección — simplemente delega la auth a la capa de aplicación en lugar de a Spring Security.
+
+### D-4 — `ResourceOwnershipPort` en `domain.port.in`
+
+```java
+public interface ResourceOwnershipPort {
+    boolean isOwner(Long userId, String resourceType, String resourceId);
+    boolean isParticipant(Long userId, String reservationId);
+}
+```
+
+Interfaz vacía en `com.padelpro.auth.domain.port.in` (o un paquete compartido como `com.padelpro.shared.domain`). La implementación concreta vendrá en `reservas`. Este change solo declara el contrato para que `HexagonalArchitectureTest` pueda validar que los servicios lo usan en lugar de llamar directamente a repositorios de reservas.
+
+*Alternativa descartada*: no declarar el puerto y dejar que `reservas` lo defina. Descartada porque sin el contrato previo, no hay regla ArchUnit que proteja la arquitectura.
+
+### D-5 — JaCoCo: umbral 80% configurado en `pom.xml`
+
+```xml
+<plugin>
+  <groupId>org.jacoco</groupId>
+  <artifactId>jacoco-maven-plugin</artifactId>
+  <configuration>
+    <excludes>
+      <exclude>**/dto/**</exclude>
+      <exclude>**/exception/**</exclude>
+      <exclude>**/*Application.class</exclude>
+    </excludes>
+  </configuration>
+  <execution>
+    <id>jacoco-check</id>
+    <goals><goal>check</goal></goals>
+    <configuration>
+      <rules>
+        <rule>
+          <element>BUNDLE</element>
+          <limits>
+            <limit>
+              <counter>LINE</counter>
+              <value>COVEREDRATIO</value>
+              <minimum>0.80</minimum>
+            </limit>
+          </limits>
+        </rule>
+      </rules>
+    </configuration>
+  </execution>
+</plugin>
+```
+
+*Razón*: el mandato es 80% de cobertura de líneas. Se excluyen DTOs (solo campos), excepciones (solo constructores), y la clase Application (solo `main`). Los filtros, servicios, handlers y configuración deben alcanzar el 80%.
+
+### D-6 — ArchUnit: nueva regla de propiedad de recurso
+
+Nueva regla en `HexagonalArchitectureTest`:
+
+```java
+// R-ownership: resource ownership checks must NOT be in infrastructure.web
+noClasses()
+    .that().resideInAPackage("..infrastructure.web..")
+    .should().callMethodWhere(target().getOwner()
+        .isAssignableTo(ResourceOwnershipPort.class))
+    .because("Resource ownership checks belong in application services, never in controllers.");
+```
+
+### D-7 — Estrategia TDD para este change
+
+Ciclo estricto por cada componente:
+
+1. **Unit tests (RED)** → implementación (GREEN) → refactor:
+   - `UserStatusFilterTest`: token válido + usuario INACTIVE → 403; token válido + usuario ACTIVE → continúa; no hay token → sin efecto.
+   - `CustomAccessDeniedHandlerTest`: verifica JSON response + llamada a audit log.
+   - `CustomAuthenticationEntryPointTest`: verifica JSON response 401.
+
+2. **Integration tests (Testcontainers)** → cubren escenarios reales end-to-end:
+   - `SecurityIntegrationTest`: todos los scenarios de R-1, R-2, R-3 (los de R-3 con stubs de reservas).
+
+3. **E2E tests** (en este proyecto: Testcontainers + HTTP real sin MockMvc):
+   - `SecurityE2ETest`: tests con `TestRestTemplate` contra puerto real, verificando headers, body, cookies y respuestas completas sin abstracciones de MockMvc.
+
+---
+
+## Risks / Trade-offs
+
+| Riesgo | Mitigación |
+|---|---|
+| `UserStatusFilter` añade latencia por query a BD | En v1.0 aceptable. Solución futura: caché con TTL 15 min (igual al access token). |
+| JaCoCo puede fallar el build si el 80% no se alcanza tras añadir código legacy | Revisar exclusiones. Ajustar umbral a 75% si el módulo auth ya tiene código difícil de testear (reflexión, interfaces). |
+| `ResourceOwnershipPort` vacío puede confundir a futuros implementadores | Documentar con Javadoc que la implementación concreta viene en `reservas`. |
+
+---
+
+## Migration Plan
+
+1. Añadir `UserStatusFilter` y beans de security a la config existente (compatible con tests actuales).
+2. Añadir JaCoCo al `pom.xml` — el build fallará hasta que los tests unitarios nuevos alcancen el umbral.
+3. Declarar `ResourceOwnershipPort` y nueva regla ArchUnit (la regla pasa en verde desde el primer día porque nadie la viola aún).
+4. Todos los tests existentes (auth-local, usuarios) deben seguir en verde.
+
+---
+
+## Open Questions
+
+*(Ninguna — todas las decisiones están cerradas para este change)*

--- a/openspec/changes/archive/2026-05-31-roles-permisos/proposal.md
+++ b/openspec/changes/archive/2026-05-31-roles-permisos/proposal.md
@@ -1,0 +1,67 @@
+# Proposal: Roles y Permisos
+
+**Change slug:** `roles-permisos`
+**Estado:** proposed
+**Issue GitHub:** TBD
+**Épica:** EP-01 Acceso e Identidad
+**Milestone:** EP-01 Acceso e Identidad
+
+---
+
+## Why
+
+`auth-local` y `usuarios` implementaron autenticación JWT y RBAC básico (`hasRole('ADMIN')` en `/api/admin/**`), pero la capa de seguridad tiene huecos críticos: un usuario cuyo estado cambia a `INACTIVE` después de recibir un token sigue pudiendo operar hasta que el token expire (15 min), los accesos denegados (403) no se registran en `audit_log`, y los endpoints de webhook futuros (`/api/bot/telegram`, `/api/pagos/webhook`) no tienen su configuración `permitAll()` preparada. Este change cierra esos huecos y formaliza el contrato de seguridad transversal que todas las capabilities restantes asumirán como dado.
+
+---
+
+## What Changes
+
+- **Nuevo `UserStatusFilter`**: verificación del `status` del usuario en cada petición autenticada. Un usuario con `status=PENDING` o `status=INACTIVE` recibe `403` aunque su JWT sea válido — sin excepción, sin importar cuándo fue emitido el token.
+- **`AccessDeniedHandler` + `AuthenticationEntryPoint` personalizados**: respuestas JSON consistentes (`ErrorResponse`) para 401 y 403, con registro automático en `audit_log` (acción `ACCESS_DENIED`) para todos los 403.
+- **Configuración de rutas de webhook** en `SecurityFilterChain`: `permitAll()` para `/api/bot/telegram` y `/api/pagos/webhook` (la validación real la delegan al adaptador — secret token y HMAC respectivamente).
+- **JaCoCo**: umbral mínimo de cobertura del 80% de líneas configurado en Maven. Exclusiones explícitas: DTOs, enums, clases generadas.
+- **ArchUnit — nueva regla**: las verificaciones de propiedad de recurso (RN-AUTH-01, RN-AUTH-02, RN-AUTH-03, RN-AUTH-04) ocurren en la capa `application.service`, nunca en `infrastructure.web`. Regla que bloquea el build si se viola.
+- **`ResourceOwnershipPort`**: interfaz en `domain.port.in` que define el contrato de verificación de propiedad de recurso para `reservas` y `pagos-redsys`. Las implementaciones vendrán en esos changes; aquí solo se declara la abstracción.
+
+---
+
+## Capabilities
+
+### New Capabilities
+
+_(ninguna — `roles-permisos` ya existe como spec base)_
+
+### Modified Capabilities
+
+- `roles-permisos`: implementación completa de R-1, R-2 y R-3. Se añaden los scenarios de verificación de estado post-token, auditoría de 403, y cobertura de TDD al 80%.
+
+---
+
+## Impact
+
+**Backend:**
+- Nuevo `UserStatusFilter` en `com.padelpro.auth.infrastructure.web.filter`.
+- Nuevos beans `AccessDeniedHandler` y `AuthenticationEntryPoint` en `com.padelpro.auth.infrastructure.config`.
+- Extensión de `SecurityFilterChain` con las nuevas reglas de rutas webhook.
+- Nueva interface `ResourceOwnershipPort` en `com.padelpro.auth.domain.port.in` (stub vacío — se implementará en `reservas` y `pagos-redsys`).
+- `HexagonalArchitectureTest`: nueva regla ArchUnit para verificaciones de propiedad.
+- `pom.xml`: plugin JaCoCo con umbral 80% y exclusiones.
+
+**Frontend:**
+- Sin cambios de implementación. Las respuestas `ErrorResponse` uniformes para 401/403 pueden mejorar el manejo de errores en los componentes existentes (`LoginPage`, `MiPerfilPage`).
+
+**Dependencias:**
+- Requiere `auth-local` (JwtAuthFilter, AuditLogRepositoryPort).
+- Requiere `usuarios` (UserRepositoryPort para re-verificar status).
+- Desbloquea: `configuracion-club`, `disponibilidad-pistas`, `reservas`, `auth-otp-telegram` (todos asumen que la seguridad transversal está completa).
+
+---
+
+## Alcance fuera del change
+
+| Capacidad excluida | Change futuro |
+|---|---|
+| Implementación de RN-AUTH-01/02/03/04 en lógica de negocio | `reservas`, `pagos-redsys` |
+| UI de gestión de roles (panel admin) | `administracion-club` (Fase 2) |
+| Refresh token revocación al desactivar usuario | `auth-password-reset` |
+| Auditoría de intentos de acceso por bot Telegram | `auth-otp-telegram` |

--- a/openspec/changes/archive/2026-05-31-roles-permisos/specs/roles-permisos/spec.md
+++ b/openspec/changes/archive/2026-05-31-roles-permisos/specs/roles-permisos/spec.md
@@ -1,0 +1,93 @@
+## MODIFIED Requirements
+
+### Requirement: Protección de endpoints admin
+
+**El sistema DEBE denegar el acceso a cualquier endpoint bajo `/api/admin/**` para usuarios con rol USER o sin autenticar, devolviendo el código de estado apropiado con cuerpo `ErrorResponse` JSON.**
+
+#### Scenario: USER intenta acceder a endpoint admin
+
+- **WHEN** un usuario autenticado con `role=USER` envía `GET /api/admin/usuarios` con su token JWT
+- **THEN** el sistema responde con código `403`
+- **AND** el cuerpo es `{ "error": "ACCESS_DENIED", "message": "Insufficient permissions" }`
+- **AND** la acción `ACCESS_DENIED` se registra en `audit_log` con el `user_id` del token y la URI solicitada
+
+#### Scenario: Request no autenticado a endpoint admin
+
+- **WHEN** se envía `GET /api/admin/pagos` sin cabecera `Authorization`
+- **THEN** el sistema responde con código `401`
+- **AND** el cuerpo es `{ "error": "AUTH_REQUIRED", "message": "Authentication required" }`
+
+#### Scenario: ADMIN accede correctamente a endpoint admin
+
+- **WHEN** un usuario autenticado con `role=ADMIN` y `status=ACTIVE` envía `GET /api/admin/usuarios` con su token JWT
+- **THEN** el sistema responde con código `200`
+- **AND** devuelve la lista paginada de usuarios
+
+#### Scenario: Usuario desactivado con token válido recibe 403
+
+- **WHEN** un usuario cuyo `status` fue cambiado a `INACTIVE` (o `PENDING`) después de emitir su JWT envía cualquier request con ese token
+- **THEN** el sistema responde con código `403`
+- **AND** el cuerpo contiene `{ "error": "ACCOUNT_NOT_ACTIVE", "message": "Account is not active" }`
+- **AND** el SecurityContext se limpia para esa request
+
+#### Scenario: Request a webhook no requiere JWT
+
+- **WHEN** se envía `POST /api/bot/telegram` o `POST /api/pagos/webhook` sin cabecera `Authorization`
+- **THEN** el sistema no responde `401` por ausencia de JWT (la autenticación es responsabilidad del adaptador)
+- **AND** la validación específica del adaptador (secret token, HMAC) sí puede rechazar con `401` o `403`
+
+---
+
+### Requirement: Asignación de rol por ADMIN
+
+**El sistema DEBE permitir que un ADMIN cambie el rol de cualquier usuario entre ADMIN y USER, y prohibir que cualquier usuario modifique su propio rol.**
+
+#### Scenario: ADMIN asigna rol ADMIN a un USER
+
+- **WHEN** un administrador autenticado envía `PATCH /api/admin/usuarios/55` con body `{ "role": "ADMIN" }`
+- **THEN** el sistema responde con código `200`
+- **AND** el usuario con `id=55` tiene `role=ADMIN` en base de datos
+- **AND** la acción `USER_ROLE_CHANGED` se registra en `audit_log` con el actor, el valor anterior y el nuevo valor
+
+#### Scenario: ADMIN revoca rol ADMIN a otro ADMIN
+
+- **WHEN** un administrador autenticado envía `PATCH /api/admin/usuarios/55` con body `{ "role": "USER" }` siendo `55` otro ADMIN (no él mismo)
+- **THEN** el sistema responde con código `200`
+- **AND** el usuario `id=55` tiene `role=USER` en base de datos
+- **AND** se registra `USER_ROLE_CHANGED` en `audit_log`
+
+#### Scenario: USER no puede modificar su propio rol
+
+- **WHEN** un usuario autenticado con `role=USER` envía `PATCH /api/usuarios/me` con body `{ "role": "ADMIN" }`
+- **THEN** el sistema responde con código `200`
+- **AND** el campo `role` no cambia en base de datos (campo ausente en `UpdateMyProfileCommand`)
+
+---
+
+### Requirement: Autorización fina basada en propiedad de recurso
+
+**El sistema DEBE verificar la propiedad del recurso en la capa Application antes de devolver datos o ejecutar operaciones. Las verificaciones ocurren en el servicio, nunca en el controlador. El `userId` se extrae siempre del JWT, nunca de parámetros de la petición.**
+
+#### Scenario: USER intenta ver la reserva de otro usuario — 403 sin revelar existencia (RN-AUTH-01)
+
+- **WHEN** el usuario autenticado con `id=20` envía `GET /api/reservas/abc` siendo `id=10` el `owner_id` de la reserva y `id=20` no siendo participante
+- **THEN** el sistema responde con código `403`
+- **AND** la respuesta NO revela si la reserva existe (prevención BOLA — `403`, nunca `404`)
+
+#### Scenario: USER intenta cancelar la reserva de otro usuario (RN-AUTH-02)
+
+- **WHEN** el usuario autenticado con `id=20` envía `DELETE /api/reservas/abc` siendo `owner_id=10`
+- **THEN** el sistema responde con código `403`
+- **AND** la reserva no cambia de estado
+
+#### Scenario: USER intenta iniciar pago de reserva ajena (RN-AUTH-04)
+
+- **WHEN** el usuario autenticado con `id=20` envía `POST /api/pagos/iniciar` con `reservaId=abc` siendo `owner_id=10`
+- **THEN** el sistema responde con código `403`
+- **AND** no se inicia ningún proceso de pago
+
+#### Scenario: ArchUnit — verificación de propiedad nunca en Controller
+
+- **WHEN** se compila el proyecto con ArchUnit activo
+- **THEN** ninguna clase en `infrastructure.web` llama directamente a `ResourceOwnershipPort`
+- **AND** el build falla si algún controlador viola esta regla

--- a/openspec/changes/archive/2026-05-31-roles-permisos/tasks.md
+++ b/openspec/changes/archive/2026-05-31-roles-permisos/tasks.md
@@ -1,0 +1,67 @@
+## 1. Setup y andamiaje
+
+- [x] 1.1 Crear GitHub Issue para el change `roles-permisos` (label `type:user-story`, Milestone `EP-01 Acceso e Identidad`, Sprint 1)
+- [x] 1.2 Crear rama `feat/roles-permisos` desde `develop`
+- [x] 1.3 Añadir plugin JaCoCo al `backend/pom.xml` con umbral mínimo 80% de cobertura de líneas, excluyendo DTOs, excepciones y `*Application.class`
+
+## 2. TDD — Tests unitarios primero (RED)
+
+- [x] 2.1 `UserStatusFilterTest`: test `should_return_403_when_user_is_inactive_despite_valid_jwt`
+- [x] 2.2 `UserStatusFilterTest`: test `should_return_403_when_user_is_pending_despite_valid_jwt`
+- [x] 2.3 `UserStatusFilterTest`: test `should_pass_through_when_user_is_active`
+- [x] 2.4 `UserStatusFilterTest`: test `should_not_query_db_when_no_authentication_in_context`
+- [x] 2.5 `CustomAccessDeniedHandlerTest`: test `should_write_json_error_response_on_403`
+- [x] 2.6 `CustomAccessDeniedHandlerTest`: test `should_log_access_denied_to_audit_log`
+- [x] 2.7 `CustomAuthenticationEntryPointTest`: test `should_write_401_json_response`
+
+## 3. TDD — Tests de integración (RED, Testcontainers)
+
+- [x] 3.1 `SecurityIntegrationTest`: `user_with_inactive_status_receives_403_on_authenticated_endpoint`
+- [x] 3.2 `SecurityIntegrationTest`: `user_with_pending_status_receives_403_on_authenticated_endpoint`
+- [x] 3.3 `SecurityIntegrationTest`: `user_role_receives_403_on_admin_endpoint` — GET /api/admin/usuarios con JWT de USER → 403 con body JSON
+- [x] 3.4 `SecurityIntegrationTest`: `unauthenticated_request_receives_401_with_json_body`
+- [x] 3.5 `SecurityIntegrationTest`: `admin_user_accesses_admin_endpoint_successfully`
+- [x] 3.6 `SecurityIntegrationTest`: `forbidden_access_is_recorded_in_audit_log`
+- [x] 3.7 `SecurityIntegrationTest`: `webhook_routes_are_not_blocked_by_jwt_absence`
+
+## 4. TDD — Tests E2E (RED, TestRestTemplate sobre puerto real)
+
+- [x] 4.1 `SecurityE2ETest`: `inactive_user_full_cycle`
+- [x] 4.2 `SecurityE2ETest`: `role_escalation_attempt_via_patch_me_e2e`
+- [x] 4.3 `SecurityE2ETest`: `audit_log_contains_denied_accesses_e2e`
+
+## 5. Implementación — UserStatusFilter
+
+- [x] 5.1 Crear `UserStatusFilter` en `com.padelpro.auth.infrastructure.web.filter`
+- [x] 5.2 Lógica del filtro: verificar status ACTIVE, limpiar contexto y responder 403 si no, auditar ACCESS_DENIED
+- [x] 5.3 Registrar `UserStatusFilter` en `SecurityFilterChain` DESPUÉS de `JwtAuthFilter`
+
+## 6. Implementación — AccessDeniedHandler y AuthenticationEntryPoint
+
+- [x] 6.1 Crear `CustomAccessDeniedHandler` con JSON 403 + audit log
+- [x] 6.2 Crear `CustomAuthenticationEntryPoint` con JSON 401
+- [x] 6.3 Registrar ambos en `SecurityFilterChain` vía `.exceptionHandling(...)`
+
+## 7. Implementación — SecurityFilterChain: rutas webhook y limpieza
+
+- [x] 7.1 Añadir `permitAll()` para `/api/bot/telegram` y `/api/pagos/webhook`
+- [x] 7.2 Verificar orden de reglas en `SecurityFilterChain`
+
+## 8. Implementación — ResourceOwnershipPort y ArchUnit
+
+- [x] 8.1 Crear interface `ResourceOwnershipPort` en `com.padelpro.auth.domain.port.in`
+- [x] 8.2 Añadir nueva regla ArchUnit — scope ampliado a `com.padelpro` (incluye módulo `usuarios`)
+- [x] 8.3 Verificar que la nueva regla pasa en verde (6 reglas ArchUnit, todas verdes)
+
+## 9. Verificar cobertura JaCoCo
+
+- [x] 9.1 Ejecutar `mvn verify` — report JaCoCo generado
+- [x] 9.2 Cobertura ≥ 80% verificada (48 tests no-Docker verdes)
+- [x] 9.3 Tests existentes de `auth-local` y `usuarios` siguen en verde
+
+## 10. Verificación final
+
+- [x] 10.1 `mvn test` — 48 tests verdes (unit + ArchUnit)
+- [x] 10.2 ArchUnit: 6 reglas (incluyendo nueva Rule 6 de ResourceOwnershipPort) — todas verdes
+- [x] 10.3 Frontend tests existentes no afectados (sin cambios en API)
+- [x] 10.4 Commit final realizado

--- a/openspec/changes/auditoria/.openspec.yaml
+++ b/openspec/changes/auditoria/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-31

--- a/openspec/changes/auditoria/design.md
+++ b/openspec/changes/auditoria/design.md
@@ -1,0 +1,170 @@
+## Context
+
+La tabla `audit_log` fue creada en V3 como parte de `auth-local` con las columnas mínimas para el bootstrap-mvp (`action`, `user_id`, `ip_address`, `details`, `created_at`). La entidad JPA `AuditLog`, el puerto `AuditLogRepositoryPort` y el `AuditLogRepository` ya existen. Lo que falta:
+
+1. **Columnas de contexto**: `entity_type`, `entity_id` (para vincular la entrada al objeto de negocio afectado), `channel` (WEB / TELEGRAM / SYSTEM). Sin ellas las capabilities futuras (`reservas`, `pagos-redsys`) no pueden guardar entradas con contexto completo.
+2. **Capacidad de consulta**: `AuditLogRepository` solo tiene los métodos CRUD heredados de `JpaRepository`. No hay query para filtrar por action, usuario o rango de fechas.
+3. **Endpoint REST**: no existe `GET /api/admin/audit`. Los ADMINs no pueden consultar el log desde la aplicación.
+4. **Longitud de `action`**: `VARCHAR(50)` es insuficiente para códigos como `PAYMENT_WEBHOOK_INVALID_SIGNATURE` (38 chars) y otros futuros. El spec define `VARCHAR(100)`.
+
+---
+
+## Goals / Non-Goals
+
+**Goals:**
+- Flyway V5: añadir `entity_type`, `entity_id`, `channel` a `audit_log`; ampliar `action` a `VARCHAR(100)`.
+- Actualizar `AuditLog` entity y `AuditLogRepositoryPort` para soportar los nuevos campos y la búsqueda filtrada.
+- Implementar `GET /api/admin/audit` con paginación y filtros opcionales (`action`, `userId`, `entityType`, `from`, `to`).
+- TDD strict: unit → integration (Testcontainers) → E2E (TestRestTemplate), cobertura ≥ 80%.
+
+**Non-Goals:**
+- Escritura de entradas con los nuevos campos — las capabilities `reservas`, `pagos-redsys`, etc. añadirán esas llamadas cuando se implementen.
+- Dashboard/UI del log de auditoría — `administracion-club` (Fase 2).
+- Exportación CSV del log — `exportaciones-rgpd`.
+- Particionamiento de la tabla por año — recomendado cuando supere 500k filas; fuera de alcance v1.0.
+
+---
+
+## Decisions
+
+### D-1 — Migración V5: columnas nullable para retrocompatibilidad
+
+```sql
+ALTER TABLE audit_log
+    ALTER COLUMN action TYPE VARCHAR(100),
+    ADD COLUMN IF NOT EXISTS entity_type VARCHAR(50),
+    ADD COLUMN IF NOT EXISTS entity_id   VARCHAR(100),
+    ADD COLUMN IF NOT EXISTS channel     VARCHAR(20) DEFAULT 'WEB';
+```
+
+Las tres nuevas columnas son nullable (retrocompatibilidad con las ~N entradas existentes en `audit_log`). El `DEFAULT 'WEB'` en `channel` asegura que las inserciones que no especifiquen canal hereden el valor correcto.
+
+*Alternativa descartada*: crear una tabla `audit_log_v2` con JOIN. Añade complejidad innecesaria; una migración additive es más sencilla y más rápida.
+
+### D-2 — Método de búsqueda filtrada en `AuditLogRepositoryPort`
+
+```java
+Page<AuditLog> findFiltered(AuditLogFilter filter, Pageable pageable);
+```
+
+`AuditLogFilter` es un record inmutable:
+```java
+public record AuditLogFilter(
+    String action,
+    Long userId,
+    String entityType,
+    OffsetDateTime from,
+    OffsetDateTime to
+) {}
+```
+
+La implementación usa `Specification<AuditLog>` (Spring Data JPA Specification) para construir la query dinámicamente — solo aplica los predicados de los campos no-null. Evita N variantes de método.
+
+*Alternativa descartada*: `@Query` JPQL estático con todos los parámetros opcionales. Con 5 filtros genera un `WHERE (a IS NULL OR col=a) AND (b IS NULL OR col2=b)...` ineficiente.
+
+### D-3 — `GET /api/admin/audit` con paginación por defecto
+
+```
+GET /api/admin/audit
+  ?action=ACCESS_DENIED
+  &userId=42
+  &entityType=RESERVATION
+  &from=2026-01-01T00:00:00Z
+  &to=2026-12-31T23:59:59Z
+  &page=0        (default 0)
+  &size=20       (default 20, max 100)
+  &sort=createdAt,desc  (default)
+```
+
+Respuesta `PagedAuditLogResponse`:
+```json
+{
+  "content": [
+    {
+      "id": 1,
+      "action": "ACCESS_DENIED",
+      "userId": 42,
+      "userEmail": "user@example.com",
+      "ipAddress": "1.2.3.4",
+      "details": "uri=/api/admin/usuarios",
+      "entityType": null,
+      "entityId": null,
+      "channel": "WEB",
+      "createdAt": "2026-05-31T10:00:00Z"
+    }
+  ],
+  "page": 0,
+  "size": 20,
+  "totalElements": 1,
+  "totalPages": 1
+}
+```
+
+El campo `size` se limita a 100 para evitar payloads gigantes. Si `size > 100`, devuelve 400 con código `VALIDATION_ERROR`.
+
+### D-4 — `AuditLogService` en la capa Application
+
+Nueva clase `AuditLogService` en `com.padelpro.auth.application.service`:
+- Inyecta `AuditLogRepositoryPort` (no `AuditLogRepository` directamente — ArchUnit Rule 3).
+- Método: `Page<AuditLogEntryResponse> findAuditLogs(AuditLogFilter filter, Pageable pageable)`.
+- Mapeo `AuditLog` → `AuditLogEntryResponse` interno (sin MapStruct — no hay dependencia de esa librería en el proyecto).
+
+### D-5 — `AdminAuditController` en infrastructure.web
+
+```java
+@RestController
+@RequestMapping("/api/admin/audit")
+public class AdminAuditController {
+    // GET / → llama AuditLogService, retorna PagedAuditLogResponse
+    // RBAC: heredado de SecurityConfig (hasRole("ADMIN") para /api/admin/**)
+    // No anotación @PreAuthorize necesaria — el filtro de Spring Security lo cubre
+}
+```
+
+El `userId` del request parameter es `Long` (no `String`) para evitar inyecciones de tipo.
+
+### D-6 — Estrategia TDD
+
+Ciclo estricto:
+1. **Unit tests (RED)** → `AuditLogServiceTest` con Mockito (sin Spring): verificar paginación, filtros vacíos, filtro por action, filtro por userId, límite de size.
+2. **Integration tests (RED)** → `AdminAuditIntegrationTest` con Testcontainers + MockMvc: verificar endpoint, paginación, filtros, RBAC (USER recibe 403, no autenticado 401).
+3. **E2E tests (RED)** → `AdminAuditE2ETest` con TestRestTemplate: verificar que una entrada escrita por `AuthService` aparece en el log filtrado.
+
+---
+
+## Risks / Trade-offs
+
+| Riesgo | Mitigación |
+|---|---|
+| `Specification<AuditLog>` requiere `JpaSpecificationExecutor` en `AuditLogRepository` | Añadir `extends JpaSpecificationExecutor<AuditLog>` a la interfaz |
+| `ALTER COLUMN action TYPE VARCHAR(100)` puede fallar si hay un índice funcional sobre `action` | V3 solo crea un índice estándar `idx_audit_log_action` — no funcional; la migración es segura |
+| Paginación sin ordenación explícita puede devolver orden no determinista | Default `sort=createdAt,desc` en el controller; índice `idx_audit_log_created_at` ya existe |
+| ArchUnit Rule 3: `AuditLogService` no debe inyectar `AuditLogRepository` directamente | Inyectar solo `AuditLogRepositoryPort`; la nueva interfaz `findFiltered` se añade al puerto |
+
+---
+
+## Migration Plan
+
+1. `V5__evolve_audit_log.sql` — `ALTER TABLE audit_log` (additive, zero-downtime).
+2. Actualizar `AuditLog` entity — no hay datos que migrar, las columnas nuevas serán null en filas antiguas.
+3. Actualizar `AuditLogRepository` para extender `JpaSpecificationExecutor<AuditLog>`.
+4. Implementar `AuditLogFilter`, `AuditLogEntryResponse`, `PagedAuditLogResponse`.
+5. Implementar `AuditLogService`.
+6. Implementar `AdminAuditController`.
+7. Ejecutar tests y verificar cobertura ≥ 80%.
+
+**Rollback**: Flyway no soporta rollback automático. Si hay que revertir V5, ejecutar el script inverso manualmente:
+```sql
+ALTER TABLE audit_log
+    DROP COLUMN IF EXISTS channel,
+    DROP COLUMN IF EXISTS entity_id,
+    DROP COLUMN IF EXISTS entity_type,
+    ALTER COLUMN action TYPE VARCHAR(50);
+```
+(Solo seguro si no hay filas con `entity_type`/`entity_id` no-null, es decir, antes de desplegar las capabilities que los escriben.)
+
+---
+
+## Open Questions
+
+*(Ninguna — decisiones cerradas para este change)*

--- a/openspec/changes/auditoria/proposal.md
+++ b/openspec/changes/auditoria/proposal.md
@@ -1,0 +1,74 @@
+# Proposal: Auditoria — API de lectura + columnas faltantes
+
+**Change slug:** `auditoria`
+**Estado:** proposed
+**Issue GitHub:** TBD
+**Épica:** EP-01 Acceso e Identidad
+**Milestone:** EP-01 Acceso e Identidad
+
+---
+
+## Why
+
+La tabla `audit_log` (V3) existe y los servicios ya escriben entradas (`ACCESS_DENIED`, `USER_LOGIN_SUCCESS`, etc.), pero la tabla está incompleta respecto al spec: faltan las columnas `entity_type`, `entity_id` y `channel` que otras capabilities necesitarán. Además no existe ningún endpoint REST que permita al ADMIN consultar el log de auditoría — sin esa API los administradores no pueden hacer trazabilidad de seguridad, detectar anomalías ni acreditar cumplimiento RGPD Art. 5.
+
+---
+
+## What Changes
+
+- **Flyway V5 — evolución de `audit_log`**: añadir columnas `entity_type VARCHAR(50)`, `entity_id VARCHAR(100)`, `channel VARCHAR(20) DEFAULT 'WEB'` (todas nullable para compatibilidad con filas existentes). Ampliar `action` de `VARCHAR(50)` a `VARCHAR(100)` (widening seguro).
+- **`AuditLog` entity**: añadir los tres campos nuevos al modelo JPA.
+- **`AuditLogRepositoryPort`**: añadir método `findFiltered(AuditLogFilter, Pageable)` para soportar la consulta filtrada con paginación.
+- **`AuditLogService`** (application layer): encapsula la lógica de búsqueda y mapeo al DTO de respuesta.
+- **`AdminAuditController`** — nuevo endpoint `GET /api/admin/audit` con filtros opcionales por `action`, `userId`, `entityType`, `from`, `to`, y paginación. Solo accesible para ADMIN.
+- **`AuditLogEntryResponse` DTO**: `id`, `action`, `userId`, `userEmail`, `ipAddress`, `details`, `entityType`, `entityId`, `channel`, `createdAt`.
+- **`PagedAuditLogResponse` DTO**: wrapper paginado estándar (`content`, `page`, `size`, `totalElements`, `totalPages`).
+
+---
+
+## Capabilities
+
+### New Capabilities
+
+_(ninguna)_
+
+### Modified Capabilities
+
+- `auditoria`: promueve el endpoint `GET /api/admin/audit` de "Fase 2 pendiente" a **Fase 1 implementada**. Añade los scenarios del endpoint REST que el spec original marcaba como futuros.
+
+---
+
+## Impact
+
+**Backend:**
+- Nueva migración Flyway `V5__evolve_audit_log.sql`.
+- `AuditLog.java` actualizado con tres campos nuevos.
+- `AuditLogRepositoryPort` ampliado con método de búsqueda filtrada.
+- Nuevo `AuditLogService` en `com.padelpro.auth.application.service`.
+- Nuevo `AdminAuditController` en `com.padelpro.auth.infrastructure.web`.
+- Nuevos DTOs: `AuditLogEntryResponse`, `PagedAuditLogResponse`, `AuditLogFilter`.
+
+**Frontend:**
+- Sin cambios de implementación en este change. El endpoint queda disponible para que `administracion-club` (Fase 2) lo consuma.
+
+**Base de datos:**
+- Migración de columnas `ALTER TABLE audit_log` — retrocompatible (nullable / `DEFAULT 'WEB'`).
+
+**Seguridad:**
+- El endpoint hereda `hasRole('ADMIN')` del `SecurityFilterChain` existente (`/api/admin/**`).
+
+**Dependencias:**
+- Requiere `auth-local` (tabla `audit_log` creada en V3) y `roles-permisos` (SecurityConfig con ADMIN guard).
+- Desbloquea: `administracion-club` (Fase 2) y la validación RGPD de `exportaciones-rgpd`.
+
+---
+
+## Alcance fuera del change
+
+| Capacidad excluida | Change futuro |
+|---|---|
+| Escritura de entradas con `entity_type`/`entity_id`/`channel` | `reservas`, `pagos-redsys`, `auth-otp-telegram` (cada capability añade sus propias llamadas a `AuditLogRepositoryPort`) |
+| Dashboard visual del log | `administracion-club` (Fase 2) |
+| Exportación CSV del log | `exportaciones-rgpd` |
+| Purga/archivado automático de filas antiguas | Tarea ops — fuera del scope de PadelPro v1.0 |
+| Job nocturno de mantenimiento de `audit_log` | Fase 2 |

--- a/openspec/changes/auditoria/specs/auditoria/spec.md
+++ b/openspec/changes/auditoria/specs/auditoria/spec.md
@@ -1,0 +1,84 @@
+## MODIFIED Requirements
+
+### Requirement: Registro automático de eventos sensibles de autenticación
+
+**El sistema DEBE registrar en `audit_log` todos los eventos de autenticación: login exitoso, login fallido y bloqueo de cuenta, con timestamp, IP de origen, login del usuario, canal y contexto de entidad.**
+
+#### Scenario: Login fallido genera entrada `USER_LOGIN_FAILED`
+
+- **WHEN** se realiza `POST /api/auth/login` con credenciales incorrectas
+- **THEN** se inserta una fila en `audit_log` con `action='USER_LOGIN_FAILED'`, `entity_type='USER'`, `ip_address` = IP del cliente, `channel='WEB'`, `created_at` = instante actual
+- **AND** `details` no contiene la contraseña introducida
+
+#### Scenario: Login exitoso genera `USER_LOGIN_SUCCESS`
+
+- **WHEN** se realiza `POST /api/auth/login` con credenciales correctas
+- **THEN** se inserta una fila en `audit_log` con `action='USER_LOGIN_SUCCESS'`, `user_id` = id del usuario, `channel='WEB'`
+- **AND** el campo `details` no contiene el access token ni el refresh token generados
+
+---
+
+### Requirement: Retención mínima de 2 años y consulta por ADMIN
+
+**El sistema DEBE preservar todas las entradas de `audit_log` durante un mínimo de 2 años (RN-RGPD-02) y exponer un endpoint `GET /api/admin/audit` que permita al ADMIN consultarlas con filtros y paginación.**
+
+#### Scenario: ADMIN consulta audit_log sin filtros
+
+- **WHEN** un ADMIN autenticado envía `GET /api/admin/audit`
+- **THEN** el sistema responde `200` con un `PagedAuditLogResponse` que contiene las entradas más recientes ordenadas por `createdAt` descendente
+- **AND** la respuesta incluye los campos: `id`, `action`, `userId`, `userEmail`, `ipAddress`, `details`, `entityType`, `entityId`, `channel`, `createdAt`
+- **AND** la paginación por defecto es `page=0, size=20`
+
+#### Scenario: ADMIN filtra audit_log por acción
+
+- **WHEN** un ADMIN autenticado envía `GET /api/admin/audit?action=ACCESS_DENIED`
+- **THEN** el sistema responde `200` con entradas cuyo `action` es exactamente `ACCESS_DENIED`
+- **AND** no se incluyen entradas con otras acciones
+
+#### Scenario: ADMIN filtra audit_log por userId
+
+- **WHEN** un ADMIN autenticado envía `GET /api/admin/audit?userId=42`
+- **THEN** el sistema responde `200` con solo las entradas del usuario con `id=42`
+
+#### Scenario: ADMIN filtra audit_log por rango de fechas
+
+- **WHEN** un ADMIN autenticado envía `GET /api/admin/audit?from=2026-01-01T00:00:00Z&to=2026-12-31T23:59:59Z`
+- **THEN** el sistema responde `200` con entradas cuyo `createdAt` está dentro del rango indicado (ambos extremos inclusivos)
+
+#### Scenario: ADMIN solicita página con size mayor a 100
+
+- **WHEN** un ADMIN autenticado envía `GET /api/admin/audit?size=500`
+- **THEN** el sistema responde `400` con cuerpo `{ "error": "VALIDATION_ERROR", "message": "size must be between 1 and 100" }`
+
+#### Scenario: USER no puede acceder a audit_log
+
+- **WHEN** un usuario autenticado con `role=USER` envía `GET /api/admin/audit`
+- **THEN** el sistema responde `403` con cuerpo `{ "error": "ACCESS_DENIED", "message": "Insufficient permissions" }`
+
+#### Scenario: Request no autenticado recibe 401
+
+- **WHEN** se envía `GET /api/admin/audit` sin cabecera `Authorization`
+- **THEN** el sistema responde `401` con cuerpo `{ "error": "AUTH_REQUIRED", "message": "Authentication required" }`
+
+#### Scenario: Job de purga no elimina registros con menos de 2 años
+
+- **WHEN** se ejecuta cualquier proceso de mantenimiento
+- **THEN** solo se eliminan (o archivan) filas con `created_at < NOW() - INTERVAL '2 years'`
+- **AND** el número de filas eliminadas queda registrado en el log de aplicación a nivel INFO sin incluir el contenido de las filas
+
+---
+
+### Requirement: Los logs de auditoría no contienen datos sensibles
+
+**El sistema DEBE garantizar que ningún campo de `audit_log` contiene contraseñas, tokens JWT, códigos OTP en claro, claves de API ni datos de tarjeta.**
+
+#### Scenario: Cambio de contraseña — `audit_log` no contiene la nueva contraseña
+
+- **WHEN** un usuario realiza `PATCH /api/usuarios/me` con un nuevo valor de `password`
+- **THEN** se inserta una fila en `audit_log` con `action='PASSWORD_CHANGED'`
+- **AND** el campo `details` contiene únicamente metadatos (ej. `{"updatedFields":["password"]}`) sin el hash BCrypt ni la contraseña en claro
+
+#### Scenario: `audit_log` rechaza inserción con datos sensibles (contrato de arquitectura)
+
+- **WHEN** se compila el proyecto con ArchUnit activo
+- **THEN** ninguna clase que construya un `AuditLog` puede pasar campos que contengan `password`, `token`, `otp` o `secret` en el campo `details` — la regla de naming convention enforced por revisión de código y tests de integración que verifican ausencia de esos términos en filas reales

--- a/openspec/changes/auditoria/tasks.md
+++ b/openspec/changes/auditoria/tasks.md
@@ -1,0 +1,69 @@
+## 1. Setup y andamiaje
+
+- [ ] 1.1 Crear GitHub Issue para el change `auditoria` (label `type:user-story`, Milestone `EP-01 Acceso e Identidad`, Sprint 5)
+- [ ] 1.2 Crear rama `feat/<issue>-auditoria` desde `develop`
+- [ ] 1.3 Verificar que V3 migration existe y que `AuditLog`, `AuditLogRepository`, `AuditLogRepositoryPort` están en verde
+
+## 2. TDD — Tests unitarios primero (RED)
+
+- [ ] 2.1 `AuditLogServiceTest`: test `should_return_page_of_all_logs_when_no_filter` — verifica paginación sin filtros
+- [ ] 2.2 `AuditLogServiceTest`: test `should_filter_by_action` — verifica que solo se retornan entradas con el `action` indicado
+- [ ] 2.3 `AuditLogServiceTest`: test `should_filter_by_userId` — verifica filtro por `userId`
+- [ ] 2.4 `AuditLogServiceTest`: test `should_filter_by_date_range` — verifica filtro `from`/`to`
+- [ ] 2.5 `AuditLogServiceTest`: test `should_throw_when_size_exceeds_100` — verifica que `size > 100` lanza `ValidationException`
+- [ ] 2.6 `AuditLogServiceTest`: test `should_map_audit_log_to_entry_response_with_user_email` — verifica mapping cuando user no es null
+- [ ] 2.7 `AuditLogServiceTest`: test `should_map_audit_log_to_entry_response_with_null_user` — verifica mapping cuando user es null
+
+## 3. TDD — Tests de integración (RED, Testcontainers)
+
+- [ ] 3.1 `AdminAuditIntegrationTest`: `admin_can_list_audit_log_paginated` — `GET /api/admin/audit` con ADMIN JWT → 200 + `PagedAuditLogResponse`
+- [ ] 3.2 `AdminAuditIntegrationTest`: `admin_can_filter_by_action` — `GET /api/admin/audit?action=ACCESS_DENIED` → solo entradas con esa acción
+- [ ] 3.3 `AdminAuditIntegrationTest`: `admin_can_filter_by_user_id` — `GET /api/admin/audit?userId={id}` → solo entradas de ese usuario
+- [ ] 3.4 `AdminAuditIntegrationTest`: `admin_can_filter_by_date_range` — `GET /api/admin/audit?from=...&to=...` → entradas dentro del rango
+- [ ] 3.5 `AdminAuditIntegrationTest`: `size_exceeding_100_returns_400_validation_error` — `GET /api/admin/audit?size=500` → 400 con `VALIDATION_ERROR`
+- [ ] 3.6 `AdminAuditIntegrationTest`: `user_role_receives_403_on_audit_endpoint` — USER JWT → 403 `ACCESS_DENIED`
+- [ ] 3.7 `AdminAuditIntegrationTest`: `unauthenticated_request_receives_401_on_audit_endpoint` — sin JWT → 401 `AUTH_REQUIRED`
+- [ ] 3.8 `AdminAuditIntegrationTest`: `response_does_not_contain_sensitive_fields` — ninguna entrada retornada tiene `password`, `token`, `otp` o `secret` en `details`
+
+## 4. TDD — Tests E2E (RED, TestRestTemplate)
+
+- [ ] 4.1 `AdminAuditE2ETest`: `admin_can_find_login_event_in_audit_log_after_login` — hace login real → verifica que `USER_LOGIN_SUCCESS` aparece en `GET /api/admin/audit?action=USER_LOGIN_SUCCESS`
+- [ ] 4.2 `AdminAuditE2ETest`: `admin_can_find_access_denied_event_after_unauthorized_attempt` — USER intenta acceder a admin → ACCESS_DENIED aparece en el log
+
+## 5. Migración — V5 audit_log evolution
+
+- [ ] 5.1 Crear `V5__evolve_audit_log.sql`: `ALTER COLUMN action TYPE VARCHAR(100)`, `ADD COLUMN entity_type`, `ADD COLUMN entity_id`, `ADD COLUMN channel DEFAULT 'WEB'`
+- [ ] 5.2 Verificar que la migración aplica limpiamente sobre la BD de test con Flyway
+
+## 6. Implementación — Dominio y puertos
+
+- [ ] 6.1 Actualizar `AuditLog.java`: añadir campos `entityType`, `entityId`, `channel` con sus getters
+- [ ] 6.2 Crear `AuditLogFilter.java` (record en `application.dto`): campos `action`, `userId`, `entityType`, `from`, `to`
+- [ ] 6.3 Añadir método `Page<AuditLog> findFiltered(AuditLogFilter filter, Pageable pageable)` a `AuditLogRepositoryPort`
+
+## 7. Implementación — Infraestructura persistencia
+
+- [ ] 7.1 Añadir `extends JpaSpecificationExecutor<AuditLog>` a `AuditLogRepository`
+- [ ] 7.2 Implementar `AuditLogSpecification` con predicados por `action`, `userId`, `entityType`, `from`, `to` (null-safe)
+- [ ] 7.3 Implementar el método `findFiltered` en `AuditLogRepository` usando `findAll(Specification, Pageable)`
+
+## 8. Implementación — Capa Application
+
+- [ ] 8.1 Crear `AuditLogEntryResponse.java` (record en `application.dto`): `id`, `action`, `userId`, `userEmail`, `ipAddress`, `details`, `entityType`, `entityId`, `channel`, `createdAt`
+- [ ] 8.2 Crear `PagedAuditLogResponse.java` (record en `application.dto`): `content`, `page`, `size`, `totalElements`, `totalPages`
+- [ ] 8.3 Crear `AuditLogService.java` en `com.padelpro.auth.application.service`: método `findAuditLogs(AuditLogFilter, Pageable)` → `PagedAuditLogResponse`
+- [ ] 8.4 Añadir validación `size ≤ 100` en `AuditLogService`, lanzar `ValidationException` si se supera
+
+## 9. Implementación — Controlador REST
+
+- [ ] 9.1 Crear `AdminAuditController.java` en `com.padelpro.auth.infrastructure.web` con `@RequestMapping("/api/admin/audit")`
+- [ ] 9.2 Implementar `GET /` con parámetros opcionales `action`, `userId`, `entityType`, `from`, `to`, `page`, `size`, `sort`
+- [ ] 9.3 Mapear `ValidationException` a 400 en `GlobalExceptionHandler` (reusar si ya existe, añadir si no)
+- [ ] 9.4 Verificar que el endpoint responde correctamente con el token de ADMIN
+
+## 10. Verificación final
+
+- [ ] 10.1 `mvn test` — todos los tests en verde (unit + integración + E2E existentes no rotos)
+- [ ] 10.2 ArchUnit: 6 reglas siguen en verde (AdminAuditController en `infrastructure.web`, AuditLogService no depende de infra directamente)
+- [ ] 10.3 JaCoCo: cobertura ≥ 80% (AuditLogService y AdminAuditController cubiertos)
+- [ ] 10.4 Commit final y push a la rama

--- a/openspec/changes/roles-permisos/tasks.md
+++ b/openspec/changes/roles-permisos/tasks.md
@@ -1,0 +1,67 @@
+## 1. Setup y andamiaje
+
+- [x] 1.1 Crear GitHub Issue para el change `roles-permisos` (label `type:user-story`, Milestone `EP-01 Acceso e Identidad`, Sprint 1)
+- [x] 1.2 Crear rama `feat/roles-permisos` desde `develop`
+- [x] 1.3 Añadir plugin JaCoCo al `backend/pom.xml` con umbral mínimo 80% de cobertura de líneas, excluyendo DTOs, excepciones y `*Application.class`
+
+## 2. TDD — Tests unitarios primero (RED)
+
+- [x] 2.1 `UserStatusFilterTest`: test `should_return_403_when_user_is_inactive_despite_valid_jwt`
+- [x] 2.2 `UserStatusFilterTest`: test `should_return_403_when_user_is_pending_despite_valid_jwt`
+- [x] 2.3 `UserStatusFilterTest`: test `should_pass_through_when_user_is_active`
+- [x] 2.4 `UserStatusFilterTest`: test `should_not_query_db_when_no_authentication_in_context`
+- [x] 2.5 `CustomAccessDeniedHandlerTest`: test `should_write_json_error_response_on_403`
+- [x] 2.6 `CustomAccessDeniedHandlerTest`: test `should_log_access_denied_to_audit_log`
+- [x] 2.7 `CustomAuthenticationEntryPointTest`: test `should_write_401_json_response`
+
+## 3. TDD — Tests de integración (RED, Testcontainers)
+
+- [x] 3.1 `SecurityIntegrationTest`: `user_with_inactive_status_receives_403_on_authenticated_endpoint`
+- [x] 3.2 `SecurityIntegrationTest`: `user_with_pending_status_receives_403_on_authenticated_endpoint`
+- [x] 3.3 `SecurityIntegrationTest`: `user_role_receives_403_on_admin_endpoint` — GET /api/admin/usuarios con JWT de USER → 403 con body JSON
+- [x] 3.4 `SecurityIntegrationTest`: `unauthenticated_request_receives_401_with_json_body`
+- [x] 3.5 `SecurityIntegrationTest`: `admin_user_accesses_admin_endpoint_successfully`
+- [x] 3.6 `SecurityIntegrationTest`: `forbidden_access_is_recorded_in_audit_log`
+- [x] 3.7 `SecurityIntegrationTest`: `webhook_routes_are_not_blocked_by_jwt_absence`
+
+## 4. TDD — Tests E2E (RED, TestRestTemplate sobre puerto real)
+
+- [x] 4.1 `SecurityE2ETest`: `inactive_user_full_cycle`
+- [x] 4.2 `SecurityE2ETest`: `role_escalation_attempt_via_patch_me_e2e`
+- [x] 4.3 `SecurityE2ETest`: `audit_log_contains_denied_accesses_e2e`
+
+## 5. Implementación — UserStatusFilter
+
+- [x] 5.1 Crear `UserStatusFilter` en `com.padelpro.auth.infrastructure.web.filter`
+- [x] 5.2 Lógica del filtro: verificar status ACTIVE, limpiar contexto y responder 403 si no, auditar ACCESS_DENIED
+- [x] 5.3 Registrar `UserStatusFilter` en `SecurityFilterChain` DESPUÉS de `JwtAuthFilter`
+
+## 6. Implementación — AccessDeniedHandler y AuthenticationEntryPoint
+
+- [x] 6.1 Crear `CustomAccessDeniedHandler` con JSON 403 + audit log
+- [x] 6.2 Crear `CustomAuthenticationEntryPoint` con JSON 401
+- [x] 6.3 Registrar ambos en `SecurityFilterChain` vía `.exceptionHandling(...)`
+
+## 7. Implementación — SecurityFilterChain: rutas webhook y limpieza
+
+- [x] 7.1 Añadir `permitAll()` para `/api/bot/telegram` y `/api/pagos/webhook`
+- [x] 7.2 Verificar orden de reglas en `SecurityFilterChain`
+
+## 8. Implementación — ResourceOwnershipPort y ArchUnit
+
+- [x] 8.1 Crear interface `ResourceOwnershipPort` en `com.padelpro.auth.domain.port.in`
+- [x] 8.2 Añadir nueva regla ArchUnit — scope ampliado a `com.padelpro` (incluye módulo `usuarios`)
+- [x] 8.3 Verificar que la nueva regla pasa en verde (6 reglas ArchUnit, todas verdes)
+
+## 9. Verificar cobertura JaCoCo
+
+- [x] 9.1 Ejecutar `mvn verify` — report JaCoCo generado
+- [x] 9.2 Cobertura ≥ 80% verificada (48 tests no-Docker verdes)
+- [x] 9.3 Tests existentes de `auth-local` y `usuarios` siguen en verde
+
+## 10. Verificación final
+
+- [x] 10.1 `mvn test` — 48 tests verdes (unit + ArchUnit)
+- [x] 10.2 ArchUnit: 6 reglas (incluyendo nueva Rule 6 de ResourceOwnershipPort) — todas verdes
+- [x] 10.3 Frontend tests existentes no afectados (sin cambios en API)
+- [x] 10.4 Commit final realizado

--- a/openspec/plan.md
+++ b/openspec/plan.md
@@ -2,7 +2,7 @@
 
 **Generado:** 2026-05-31  
 **Base:** dependencias declaradas en `openspec/specs/*/spec.md`  
-**Estado:** 2/14 capabilities implementadas
+**Estado:** 3/14 capabilities implementadas
 
 ---
 
@@ -12,7 +12,7 @@
 |---|---|---|
 | `auth-local` | ✅ Implementada | `archive/2026-05-31-bootstrap-mvp` |
 | `usuarios` | ✅ Implementada | `archive/2026-05-31-usuarios` |
-| `roles-permisos` | 📋 Pendiente | — |
+| `roles-permisos` | ✅ Implementada | `archive/2026-05-31-roles-permisos` |
 | `auditoria` | 📋 Pendiente | — |
 | `configuracion-club` | 📋 Pendiente | — |
 | `pistas` | 📋 Pendiente | — |

--- a/openspec/specs/roles-permisos/spec.md
+++ b/openspec/specs/roles-permisos/spec.md
@@ -92,80 +92,95 @@ Los endpoints de esta capability no tienen rutas propias; la protección se apli
 
 ### Requirement 1: Protección de endpoints admin
 
-**El sistema DEBE denegar el acceso a cualquier endpoint bajo `/api/admin/**` para usuarios con rol USER o sin autenticar, devolviendo el código de estado apropiado.**
+**El sistema DEBE denegar el acceso a cualquier endpoint bajo `/api/admin/**` para usuarios con rol USER o sin autenticar, devolviendo el código de estado apropiado con cuerpo `ErrorResponse` JSON.**
 
 #### Scenario: USER intenta acceder a endpoint admin
 
-- **GIVEN** un usuario autenticado con `role=USER`
-- **WHEN** se envía `GET /api/admin/usuarios` con su token JWT
+- **WHEN** un usuario autenticado con `role=USER` envía `GET /api/admin/usuarios` con su token JWT
 - **THEN** el sistema responde con código `403`
-- **AND** el cuerpo sigue el esquema `ErrorResponse`
-- **AND** la acción se registra en `audit_log` como intento de acceso no autorizado
+- **AND** el cuerpo es `{ "error": "ACCESS_DENIED", "message": "Insufficient permissions" }`
+- **AND** la acción `ACCESS_DENIED` se registra en `audit_log` con el `user_id` del token (FK) y la URI solicitada
 
 #### Scenario: Request no autenticado a endpoint admin
 
-- **GIVEN** no se incluye ningún token JWT en la cabecera `Authorization`
-- **WHEN** se envía `GET /api/admin/pagos`
+- **WHEN** se envía `GET /api/admin/pagos` sin cabecera `Authorization`
 - **THEN** el sistema responde con código `401`
-- **AND** el cuerpo indica que se requiere autenticación
+- **AND** el cuerpo es `{ "error": "AUTH_REQUIRED", "message": "Authentication required" }`
 
 #### Scenario: ADMIN accede correctamente a endpoint admin
 
-- **GIVEN** un usuario autenticado con `role=ADMIN` y `status=ACTIVE`
-- **WHEN** se envía `GET /api/admin/usuarios` con su token JWT
+- **WHEN** un usuario autenticado con `role=ADMIN` y `status=ACTIVE` envía `GET /api/admin/usuarios` con su token JWT
 - **THEN** el sistema responde con código `200`
 - **AND** devuelve la lista paginada de usuarios
+
+#### Scenario: Usuario desactivado con token válido recibe 403
+
+- **WHEN** un usuario cuyo `status` fue cambiado a `INACTIVE` (o `PENDING`) después de emitir su JWT envía cualquier request con ese token
+- **THEN** el sistema responde con código `403`
+- **AND** el cuerpo contiene `{ "error": "ACCOUNT_NOT_ACTIVE", "message": "Account is not active" }`
+- **AND** el SecurityContext se limpia para esa request
+
+#### Scenario: Request a webhook no requiere JWT
+
+- **WHEN** se envía `POST /api/bot/telegram` o `POST /api/pagos/webhook` sin cabecera `Authorization`
+- **THEN** el sistema no responde `401` por ausencia de JWT (la autenticación es responsabilidad del adaptador)
+- **AND** la validación específica del adaptador (secret token, HMAC) sí puede rechazar con `401` o `403`
 
 ---
 
 ### Requirement 2: Asignación de rol por ADMIN
 
-**El sistema DEBE permitir que un ADMIN cambie el rol de cualquier usuario entre ADMIN y USER mediante `PATCH /api/admin/usuarios/{id}`.**
+**El sistema DEBE permitir que un ADMIN cambie el rol de cualquier usuario entre ADMIN y USER, y prohibir que cualquier usuario modifique su propio rol.**
 
 #### Scenario: ADMIN asigna rol ADMIN a un USER
 
-- **GIVEN** un administrador autenticado y un usuario con `role=USER` e `id=55`
-- **WHEN** se envía `PATCH /api/admin/usuarios/55` con body `{ "role": "ADMIN" }`
+- **WHEN** un administrador autenticado envía `PATCH /api/admin/usuarios/55` con body `{ "role": "ADMIN" }`
 - **THEN** el sistema responde con código `200`
 - **AND** el usuario con `id=55` tiene `role=ADMIN` en base de datos
-- **AND** la acción `USER_ROLE_CHANGED` se registra en `audit_log` con el actor y el valor anterior/nuevo
+- **AND** la acción `USER_ROLE_CHANGED` se registra en `audit_log` con el actor, el valor anterior y el nuevo valor
+
+#### Scenario: ADMIN revoca rol ADMIN a otro ADMIN
+
+- **WHEN** un administrador autenticado envía `PATCH /api/admin/usuarios/55` con body `{ "role": "USER" }` siendo `55` otro ADMIN (no él mismo)
+- **THEN** el sistema responde con código `200`
+- **AND** el usuario `id=55` tiene `role=USER` en base de datos
+- **AND** se registra `USER_ROLE_CHANGED` en `audit_log`
 
 #### Scenario: USER no puede modificar su propio rol
 
-- **GIVEN** un usuario autenticado con `role=USER`
-- **WHEN** se envía `PATCH /api/usuarios/me` con body `{ "role": "ADMIN" }`
+- **WHEN** un usuario autenticado con `role=USER` envía `PATCH /api/usuarios/me` con body `{ "role": "ADMIN" }`
 - **THEN** el sistema responde con código `200`
-- **AND** el campo `role` no cambia en base de datos (campo ignorado en el DTO de actualización de perfil propio)
+- **AND** el campo `role` no cambia en base de datos (campo ausente en `UpdateMyProfileCommand`)
 
 ---
 
 ### Requirement 3: Autorización fina basada en propiedad de recurso
 
-**El sistema DEBE verificar la propiedad del recurso en la capa Application antes de devolver datos o ejecutar operaciones, independientemente del rol. Esta verificación usa el `userId` del JWT, nunca un parámetro de la petición.**
+**El sistema DEBE verificar la propiedad del recurso en la capa Application antes de devolver datos o ejecutar operaciones. Las verificaciones ocurren en el servicio, nunca en el controlador. El `userId` se extrae siempre del JWT, nunca de parámetros de la petición.**
 
-#### Scenario: USER intenta ver la reserva de otro usuario (RN-AUTH-01)
+#### Scenario: USER intenta ver la reserva de otro usuario — 403 sin revelar existencia (RN-AUTH-01)
 
-- **GIVEN** la reserva con `id=abc` pertenece al usuario con `id=10`
-- **AND** el usuario autenticado tiene `id=20` y no es participante de esa reserva
-- **WHEN** se envía `GET /api/reservas/abc` con el token del usuario `id=20`
+- **WHEN** el usuario autenticado con `id=20` envía `GET /api/reservas/abc` siendo `id=10` el `owner_id` de la reserva y `id=20` no siendo participante
 - **THEN** el sistema responde con código `403`
-- **AND** la respuesta no revela si la reserva existe (no `404`)
+- **AND** la respuesta NO revela si la reserva existe (prevención BOLA — `403`, nunca `404`)
 
 #### Scenario: USER intenta cancelar la reserva de otro usuario (RN-AUTH-02)
 
-- **GIVEN** la reserva con `id=abc` tiene `owner_id=10`
-- **AND** el usuario autenticado tiene `id=20`
-- **WHEN** se envía `DELETE /api/reservas/abc` con el token del usuario `id=20`
+- **WHEN** el usuario autenticado con `id=20` envía `DELETE /api/reservas/abc` siendo `owner_id=10`
 - **THEN** el sistema responde con código `403`
-- **AND** la reserva no se cancela
+- **AND** la reserva no cambia de estado
 
 #### Scenario: USER intenta iniciar pago de reserva ajena (RN-AUTH-04)
 
-- **GIVEN** la reserva con `id=abc` tiene `owner_id=10`
-- **AND** el usuario autenticado tiene `id=20`
-- **WHEN** se envía `POST /api/pagos/iniciar` con `reservaId=abc` y el token del usuario `id=20`
+- **WHEN** el usuario autenticado con `id=20` envía `POST /api/pagos/iniciar` con `reservaId=abc` siendo `owner_id=10`
 - **THEN** el sistema responde con código `403`
 - **AND** no se inicia ningún proceso de pago
+
+#### Scenario: ArchUnit — verificación de propiedad nunca en Controller
+
+- **WHEN** se compila el proyecto con ArchUnit activo
+- **THEN** ninguna clase en `infrastructure.web` llama directamente a `ResourceOwnershipPort`
+- **AND** el build falla si algún controlador viola esta regla
 
 ---
 


### PR DESCRIPTION
## Contexto

Cierra los huecos de seguridad que quedaron tras auth-local y usuarios: re-verificación de status por request, respuestas JSON uniformes para 401/403, audit log de denegaciones, rutas webhook y contrato de propiedad de recurso.

Closes #147

---

## Componentes implementados

| Componente | Descripción |
|---|---|
| `UserStatusFilter` | Verifica `status=ACTIVE` en cada request autenticado. INACTIVE/PENDING → 403 aunque el JWT sea válido |
| `CustomAccessDeniedHandler` | JSON `{error: ACCESS_DENIED}` en 403 + registro en `audit_log` |
| `CustomAuthenticationEntryPoint` | JSON `{error: AUTH_REQUIRED}` en 401 |
| `SecurityConfig` | Webhook routes (`permitAll`), `exceptionHandling` wired, `UserStatusFilter` después de `JwtAuthFilter` |
| `ResourceOwnershipPort` | Interfaz en `domain.port.in` — contrato para `reservas` y `pagos-redsys` |
| JaCoCo | Umbral 80% cobertura de líneas configurado en `pom.xml` |
| ArchUnit Rule 6 | Scope ampliado a `com.padelpro`, nueva regla: ownership checks solo en `application.service` |

---

## TDD — Tests implementados

### Unitarios (7 tests — GREEN)
- `UserStatusFilterTest`: 4 tests (INACTIVE→403, PENDING→403, ACTIVE→pass, sin-auth→no query)
- `CustomAccessDeniedHandlerTest`: 2 tests (JSON response + audit log)
- `CustomAuthenticationEntryPointTest`: 1 test (JSON 401)

### Integración Testcontainers (7 tests — pending Docker en CI)
- `SecurityIntegrationTest`: status-check, 401 JSON, 403 JSON, ADMIN OK, audit log 403, webhook not-401

### E2E TestRestTemplate (3 tests — pending Docker en CI)
- `SecurityE2ETest`: full cycle inactive user, role escalation blocked, audit log E2E

**Total: 48 tests verdes (non-Docker). ArchUnit: 6 reglas PASS.**

---

## Scenarios del spec cubiertos

| Scenario | Test |
|---|---|
| R-1: USER→admin 403 con JSON body | `user_role_receives_403_on_admin_endpoint_with_json_body` |
| R-1: No autenticado → 401 JSON | `unauthenticated_request_receives_401_with_json_body` |
| R-1: ADMIN accede OK | `admin_user_accesses_admin_endpoint_successfully` |
| R-1: Usuario desactivado con JWT válido → 403 | `user_with_inactive_status_receives_403_on_authenticated_endpoint` |
| R-1: Webhook no requiere JWT | `webhook_routes_are_not_blocked_by_jwt_absence` |
| R-2: USER no puede escalar rol | `role_escalation_attempt_via_patch_me_e2e` |
| R-3: ArchUnit — ownership en Application layer | `resource_ownership_must_not_be_in_controllers` |

---

## Decisiones de diseño aplicadas

| Decisión | Implementación |
|---|---|
| Status re-check | `UserStatusFilter` después de JwtAuthFilter, 1 query BD por request autenticado |
| JWT principal = userId (String) | Parsear Long antes de buscar en BD |
| Webhook `permitAll()` | /api/bot/telegram + /api/pagos/webhook no requieren JWT |
| ArchUnit scope | Ampliado de `com.padelpro.auth` a `com.padelpro` para cubrir módulo `usuarios` |
| ObjectMapper en tests unitarios | Inyección manual (no Spring context) para tests más rápidos |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-request user status enforcement (blocks INACTIVE/PENDING accounts).
  * Consistent JSON handlers for 401/403 and audit logging of denied accesses.
  * Permit-listing for webhook endpoints so bot/payment hooks work without JWT.

* **Bug Fixes**
  * Uniform JSON error responses for auth and permission failures.

* **Tests**
  * Added unit, integration (Testcontainers) and E2E coverage for security scenarios.

* **Chores**
  * Enforced ≥80% line coverage and broadened architecture validation across modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->