### PR TITLE
feat(reservas): disponibilidad de pista + tablas reservations/participants (#13)

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -52,6 +52,16 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
 
+        <!-- Caching (Caffeine, in-JVM) — available-slots 30s TTL (data-model §7.3) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+
         <!-- Flyway -->
         <dependency>
             <groupId>org.flywaydb</groupId>

--- a/backend/src/main/java/com/padelpro/reservas/application/dto/DisponibilidadResponse.java
+++ b/backend/src/main/java/com/padelpro/reservas/application/dto/DisponibilidadResponse.java
@@ -1,0 +1,15 @@
+package com.padelpro.reservas.application.dto;
+
+import java.util.List;
+
+/**
+ * Availability of the (single) court for a specific date (OpenAPI schema {@code DisponibilidadResponse}).
+ *
+ * <p>When the court is in MANTENIMIENTO (RN-RES-04) {@code tramosDisponibles} is an empty list and
+ * no field reveals the reason.
+ *
+ * @param fecha             the queried date formatted as {@code YYYY-MM-DD}
+ * @param tramosDisponibles slots that have at least one free seat (full slots are omitted)
+ */
+public record DisponibilidadResponse(String fecha, List<TramoDisponible> tramosDisponibles) {
+}

--- a/backend/src/main/java/com/padelpro/reservas/application/dto/TramoDisponible.java
+++ b/backend/src/main/java/com/padelpro/reservas/application/dto/TramoDisponible.java
@@ -1,0 +1,11 @@
+package com.padelpro.reservas.application.dto;
+
+/**
+ * A single available time slot with its free seats (OpenAPI schema {@code TramoDisponible}).
+ *
+ * @param horaInicio      slot start time formatted as {@code HH:mm} (e.g. {@code "09:00"})
+ * @param duracionMinutos slot length in minutes (60 by default; see {@code DisponibilidadService})
+ * @param plazasLibres    number of free seats in the slot; always {@code >= 1} (full slots are omitted)
+ */
+public record TramoDisponible(String horaInicio, int duracionMinutos, int plazasLibres) {
+}

--- a/backend/src/main/java/com/padelpro/reservas/application/service/DisponibilidadCacheInvalidator.java
+++ b/backend/src/main/java/com/padelpro/reservas/application/service/DisponibilidadCacheInvalidator.java
@@ -1,0 +1,20 @@
+package com.padelpro.reservas.application.service;
+
+import java.time.LocalDate;
+
+/**
+ * Reusable invalidation hook for the {@code available-slots} cache (D6, data-model §7.3).
+ *
+ * <p>This wave is read-only, so nothing invokes invalidation yet. Wave 3 (capability {@code reservas})
+ * MUST call {@link #invalidate(LocalDate)} after creating or cancelling a reservation so that the
+ * 30 s cache never serves a slot as free immediately after it was taken.
+ */
+public interface DisponibilidadCacheInvalidator {
+
+    /**
+     * Evict the cached availability for the given date.
+     *
+     * @param fecha the date whose cached availability must be discarded
+     */
+    void invalidate(LocalDate fecha);
+}

--- a/backend/src/main/java/com/padelpro/reservas/application/service/DisponibilidadService.java
+++ b/backend/src/main/java/com/padelpro/reservas/application/service/DisponibilidadService.java
@@ -1,0 +1,112 @@
+package com.padelpro.reservas.application.service;
+
+import com.padelpro.auth.domain.model.SystemConfig;
+import com.padelpro.auth.domain.model.SystemConfig.PistaState;
+import com.padelpro.auth.domain.port.out.SystemConfigRepositoryPort;
+import com.padelpro.reservas.application.dto.DisponibilidadResponse;
+import com.padelpro.reservas.application.dto.TramoDisponible;
+import com.padelpro.reservas.domain.model.ReservationOccupancy;
+import com.padelpro.reservas.domain.port.out.ReservationQueryPort;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Computes court availability per date (capability disponibilidad-pistas, US-006 / #13).
+ *
+ * <p>Implements RN-RES-01 (active reservations occupy, CANCELLED never counts), RN-RES-02
+ * ({@code plazasLibres = max_participants − participantes activos que solapan el tramo}) and
+ * RN-RES-04 (MANTENIMIENTO ⇒ empty list without revealing the reason).
+ *
+ * <h2>Opening hours / slot granularity</h2>
+ * The current {@code system_config} schema (migration V6) only exposes {@code pista_state} and
+ * {@code max_participants_per_pista} — it has no opening/closing/granularity columns. Until those
+ * columns exist, the club schedule is fixed by the documented defaults below
+ * (open {@value #OPEN_HOUR}:00, close {@value #CLOSE_HOUR}:00, {@value #SLOT_MINUTES}-minute slots),
+ * aligned with the {@code duracionMinutos: 60} example in {@code docs/openapi.yaml}.
+ *
+ * <h2>Caching</h2>
+ * Results are cached for 30 s keyed by {@code fecha} (cache {@code available-slots}, data-model §7.3).
+ * {@link #invalidate(LocalDate)} is the reusable eviction hook Wave 3 must call on write.
+ *
+ * <p>Wired explicitly as a bean (see {@code DisponibilidadConfig}) to keep the application layer
+ * free of Spring stereotypes, mirroring {@code SystemConfigService}.
+ */
+public class DisponibilidadService implements DisponibilidadCacheInvalidator {
+
+    /** Club opening hour (inclusive). Default until {@code system_config} exposes it. */
+    static final int OPEN_HOUR = 8;
+    /** Club closing hour (exclusive end of the last slot). Default until {@code system_config} exposes it. */
+    static final int CLOSE_HOUR = 23;
+    /** Slot granularity in minutes. Default until {@code system_config} exposes it. */
+    static final int SLOT_MINUTES = 60;
+
+    private static final DateTimeFormatter TIME_FMT = DateTimeFormatter.ofPattern("HH:mm");
+
+    private final ReservationQueryPort reservationQueryPort;
+    private final SystemConfigRepositoryPort systemConfigRepositoryPort;
+
+    public DisponibilidadService(ReservationQueryPort reservationQueryPort,
+                                 SystemConfigRepositoryPort systemConfigRepositoryPort) {
+        this.reservationQueryPort = reservationQueryPort;
+        this.systemConfigRepositoryPort = systemConfigRepositoryPort;
+    }
+
+    /**
+     * Compute the available slots for {@code fecha}.
+     *
+     * @param fecha the date to query (already parsed/validated by the controller)
+     * @return the response with only slots that have at least one free seat; an empty list when the
+     *         court is in MANTENIMIENTO
+     */
+    @Cacheable(value = "available-slots", key = "#fecha")
+    public DisponibilidadResponse getDisponibilidad(LocalDate fecha) {
+        SystemConfig config = systemConfigRepositoryPort.findById(1L)
+                .orElseThrow(() -> new IllegalStateException("System configuration (id=1) not found"));
+
+        String fechaStr = fecha.toString();
+
+        // RN-RES-04 — court under maintenance: empty list, no reason exposed.
+        if (config.getPistaState() == PistaState.MANTENIMIENTO) {
+            return new DisponibilidadResponse(fechaStr, List.of());
+        }
+
+        int maxParticipants = config.getMaxParticipantsPerPista();
+        List<ReservationOccupancy> occupancies = reservationQueryPort.findActiveOccupanciesByDate(fecha);
+
+        List<TramoDisponible> tramos = new ArrayList<>();
+        for (int hour = OPEN_HOUR; hour < CLOSE_HOUR; hour++) {
+            LocalTime slotStart = LocalTime.of(hour, 0);
+            LocalTime slotEnd = slotStart.plusMinutes(SLOT_MINUTES);
+
+            int occupied = 0;
+            for (ReservationOccupancy occ : occupancies) {
+                if (occ.overlaps(slotStart, slotEnd)) {
+                    occupied += occ.participantCount();
+                }
+            }
+
+            int plazasLibres = maxParticipants - occupied;
+            if (plazasLibres >= 1) {
+                tramos.add(new TramoDisponible(slotStart.format(TIME_FMT), SLOT_MINUTES, plazasLibres));
+            }
+        }
+
+        return new DisponibilidadResponse(fechaStr, tramos);
+    }
+
+    /**
+     * Reusable invalidation hook (D6). Evicts the cached availability for {@code fecha}.
+     * No-op behaviour beyond eviction; intended to be called by Wave 3 on reservation write.
+     */
+    @Override
+    @CacheEvict(value = "available-slots", key = "#fecha")
+    public void invalidate(LocalDate fecha) {
+        // Eviction handled by @CacheEvict; method body intentionally empty.
+    }
+}

--- a/backend/src/main/java/com/padelpro/reservas/domain/model/Participant.java
+++ b/backend/src/main/java/com/padelpro/reservas/domain/model/Participant.java
@@ -1,0 +1,110 @@
+package com.padelpro.reservas.domain.model;
+
+import jakarta.persistence.*;
+
+import java.time.OffsetDateTime;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Participant of a reservation (maps table {@code participants}, data-model §3.4).
+ *
+ * <p>A participant is either a registered user ({@code userId != null}) or an external guest
+ * ({@code externalName != null}); the DB enforces the XOR. For availability the only fact that
+ * matters is the count of participants attached to active reservations overlapping a slot
+ * (RN-RES-02: {@code plazasLibres = max_participants − COUNT(active participants)}).
+ */
+@Entity
+@Table(name = "participants")
+public class Participant {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reservation_id", nullable = false)
+    private Reservation reservation;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "external_name")
+    private String externalName;
+
+    @Column(name = "external_phone")
+    private String externalPhone;
+
+    @Column(name = "slot_position", nullable = false)
+    private Integer slotPosition;
+
+    @Column(name = "is_owner", nullable = false)
+    private boolean owner;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "joined_via", nullable = false)
+    private ReservationChannel joinedVia;
+
+    @Column(name = "joined_at", nullable = false)
+    private OffsetDateTime joinedAt;
+
+    protected Participant() {
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        if (joinedAt == null) {
+            joinedAt = OffsetDateTime.now();
+        }
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Reservation getReservation() {
+        return reservation;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public String getExternalName() {
+        return externalName;
+    }
+
+    public String getExternalPhone() {
+        return externalPhone;
+    }
+
+    public Integer getSlotPosition() {
+        return slotPosition;
+    }
+
+    public boolean isOwner() {
+        return owner;
+    }
+
+    public ReservationChannel getJoinedVia() {
+        return joinedVia;
+    }
+
+    public OffsetDateTime getJoinedAt() {
+        return joinedAt;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (id == null) return false;
+        if (o == null || getClass() != o.getClass()) return false;
+        Participant that = (Participant) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return id != null ? Objects.hash(id) : System.identityHashCode(this);
+    }
+}

--- a/backend/src/main/java/com/padelpro/reservas/domain/model/Reservation.java
+++ b/backend/src/main/java/com/padelpro/reservas/domain/model/Reservation.java
@@ -1,0 +1,243 @@
+package com.padelpro.reservas.domain.model;
+
+import jakarta.persistence.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Reservation aggregate root (maps table {@code reservations}, data-model §3.3).
+ *
+ * <p>In the capability disponibilidad-pistas this entity is used read-only: the availability
+ * service queries active reservations for a given date together with their participants in
+ * order to compute free slots. Write operations (create/confirm/cancel) belong to Wave 3.
+ *
+ * <p>The Postgres enum columns ({@code reservation_status}, {@code reservation_channel}) are
+ * mapped as {@code EnumType.STRING}; Hibernate sends the text value which Postgres casts to the
+ * enum type. Under the H2 (PostgreSQL mode) test profile the columns are plain varchars, so the
+ * same mapping works for both engines.
+ */
+@Entity
+@Table(name = "reservations")
+public class Reservation {
+
+    @Id
+    @Column(columnDefinition = "uuid")
+    private UUID id;
+
+    @Column(name = "owner_id", nullable = false)
+    private Long ownerId;
+
+    @Column(name = "reservation_date", nullable = false)
+    private LocalDate reservationDate;
+
+    @Column(name = "start_time", nullable = false)
+    private LocalTime startTime;
+
+    @Column(name = "end_time", nullable = false)
+    private LocalTime endTime;
+
+    @Column(name = "duration_minutes", nullable = false)
+    private Integer durationMinutes;
+
+    // NOTE: no columnDefinition — Hibernate maps the enum as varchar, which works on both H2
+    // (test profile, ddl-auto=create-drop) and PostgreSQL. On Postgres the Flyway-created column is
+    // the native reservation_status enum; Hibernate sends the text value which Postgres casts.
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ReservationStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ReservationChannel channel;
+
+    @Column(columnDefinition = "TEXT")
+    private String notes;
+
+    @Column(name = "telegram_message_id")
+    private String telegramMessageId;
+
+    @Column(name = "cancellation_reason")
+    private String cancellationReason;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    @OneToMany(mappedBy = "reservation", fetch = FetchType.LAZY)
+    private List<Participant> participants = new ArrayList<>();
+
+    protected Reservation() {
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        if (id == null) {
+            id = UUID.randomUUID();
+        }
+        OffsetDateTime now = OffsetDateTime.now();
+        if (createdAt == null) {
+            createdAt = now;
+        }
+        if (updatedAt == null) {
+            updatedAt = now;
+        }
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = OffsetDateTime.now();
+    }
+
+    /**
+     * Whether this reservation occupies its time slot for availability purposes (RN-RES-01):
+     * {@code PENDING_CONFIRMATION} and {@code CONFIRMED} occupy; {@code CANCELLED}/{@code COMPLETED} do not.
+     */
+    public boolean isActiveOccupant() {
+        return status == ReservationStatus.PENDING_CONFIRMATION
+                || status == ReservationStatus.CONFIRMED;
+    }
+
+    /**
+     * Whether this reservation overlaps the half-open interval {@code [slotStart, slotEnd)} on
+     * its own date. Overlap uses the same {@code '[)'} semantics as the DB exclusion constraint.
+     */
+    public boolean overlaps(LocalTime slotStart, LocalTime slotEnd) {
+        return startTime.isBefore(slotEnd) && endTime.isAfter(slotStart);
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public Long getOwnerId() {
+        return ownerId;
+    }
+
+    public LocalDate getReservationDate() {
+        return reservationDate;
+    }
+
+    public LocalTime getStartTime() {
+        return startTime;
+    }
+
+    public LocalTime getEndTime() {
+        return endTime;
+    }
+
+    public Integer getDurationMinutes() {
+        return durationMinutes;
+    }
+
+    public ReservationStatus getStatus() {
+        return status;
+    }
+
+    public ReservationChannel getChannel() {
+        return channel;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public String getTelegramMessageId() {
+        return telegramMessageId;
+    }
+
+    public String getCancellationReason() {
+        return cancellationReason;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public OffsetDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public List<Participant> getParticipants() {
+        return participants;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (id == null) return false;
+        if (o == null || getClass() != o.getClass()) return false;
+        Reservation that = (Reservation) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return id != null ? Objects.hash(id) : System.identityHashCode(this);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** Test/factory builder. Production write paths (Wave 3) will replace this. */
+    public static class Builder {
+        private final Reservation r = new Reservation();
+
+        public Builder id(UUID id) {
+            r.id = id;
+            return this;
+        }
+
+        public Builder ownerId(Long ownerId) {
+            r.ownerId = ownerId;
+            return this;
+        }
+
+        public Builder reservationDate(LocalDate date) {
+            r.reservationDate = date;
+            return this;
+        }
+
+        public Builder startTime(LocalTime startTime) {
+            r.startTime = startTime;
+            return this;
+        }
+
+        public Builder endTime(LocalTime endTime) {
+            r.endTime = endTime;
+            return this;
+        }
+
+        public Builder durationMinutes(Integer durationMinutes) {
+            r.durationMinutes = durationMinutes;
+            return this;
+        }
+
+        public Builder status(ReservationStatus status) {
+            r.status = status;
+            return this;
+        }
+
+        public Builder channel(ReservationChannel channel) {
+            r.channel = channel;
+            return this;
+        }
+
+        public Builder participants(List<Participant> participants) {
+            r.participants = participants;
+            return this;
+        }
+
+        public Reservation build() {
+            return r;
+        }
+    }
+}

--- a/backend/src/main/java/com/padelpro/reservas/domain/model/ReservationChannel.java
+++ b/backend/src/main/java/com/padelpro/reservas/domain/model/ReservationChannel.java
@@ -1,0 +1,10 @@
+package com.padelpro.reservas.domain.model;
+
+/**
+ * Channel through which a reservation (or participant) was created
+ * (data-model §3.3 / §3.4, enum {@code reservation_channel}).
+ */
+public enum ReservationChannel {
+    WEB,
+    TELEGRAM
+}

--- a/backend/src/main/java/com/padelpro/reservas/domain/model/ReservationOccupancy.java
+++ b/backend/src/main/java/com/padelpro/reservas/domain/model/ReservationOccupancy.java
@@ -1,0 +1,25 @@
+package com.padelpro.reservas.domain.model;
+
+import java.time.LocalTime;
+
+/**
+ * Read model describing how much of a time window an active reservation occupies on a given date.
+ *
+ * <p>Used by the availability calculation (RN-RES-02): for each requested slot the service sums
+ * {@code participantCount} of the occupancies whose {@code [startTime, endTime)} interval overlaps
+ * the slot, and derives {@code plazasLibres = maxParticipants − occupied}.
+ *
+ * @param startTime        reservation start (inclusive)
+ * @param endTime          reservation end (exclusive)
+ * @param participantCount number of participants attached to the reservation
+ */
+public record ReservationOccupancy(LocalTime startTime, LocalTime endTime, int participantCount) {
+
+    /**
+     * Whether this occupancy overlaps the half-open slot {@code [slotStart, slotEnd)}.
+     * Uses the same {@code '[)'} semantics as the DB {@code excl_res_no_overlap} constraint.
+     */
+    public boolean overlaps(LocalTime slotStart, LocalTime slotEnd) {
+        return startTime.isBefore(slotEnd) && endTime.isAfter(slotStart);
+    }
+}

--- a/backend/src/main/java/com/padelpro/reservas/domain/model/ReservationStatus.java
+++ b/backend/src/main/java/com/padelpro/reservas/domain/model/ReservationStatus.java
@@ -1,0 +1,15 @@
+package com.padelpro.reservas.domain.model;
+
+/**
+ * Lifecycle states of a reservation (data-model §3.3, enum {@code reservation_status}).
+ *
+ * <p>For availability calculation (capability disponibilidad-pistas, RN-RES-01),
+ * a reservation is considered an active occupant when its status is one of
+ * {@link #PENDING_CONFIRMATION} or {@link #CONFIRMED}. {@link #CANCELLED} never occupies.
+ */
+public enum ReservationStatus {
+    PENDING_CONFIRMATION,
+    CONFIRMED,
+    CANCELLED,
+    COMPLETED
+}

--- a/backend/src/main/java/com/padelpro/reservas/infrastructure/config/CacheConfig.java
+++ b/backend/src/main/java/com/padelpro/reservas/infrastructure/config/CacheConfig.java
@@ -1,0 +1,37 @@
+package com.padelpro.reservas.infrastructure.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+/**
+ * Enables Spring caching and configures the Caffeine cache manager (data-model §7.3).
+ *
+ * <p>The {@code available-slots} cache keeps availability results for 30 s keyed by date; the
+ * short TTL bounds inconsistency while the cache absorbs the high read frequency. Eviction on write
+ * is provided by {@code DisponibilidadService.invalidate(LocalDate)} (the reusable hook for Wave 3).
+ */
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    /** Logical name of the availability cache. */
+    public static final String AVAILABLE_SLOTS = "available-slots";
+
+    /** Availability cache TTL (D6). */
+    public static final Duration AVAILABLE_SLOTS_TTL = Duration.ofSeconds(30);
+
+    @Bean
+    public CacheManager cacheManager() {
+        CaffeineCacheManager manager = new CaffeineCacheManager(AVAILABLE_SLOTS);
+        manager.setCaffeine(Caffeine.newBuilder()
+                .expireAfterWrite(AVAILABLE_SLOTS_TTL)
+                .maximumSize(1_000));
+        return manager;
+    }
+}

--- a/backend/src/main/java/com/padelpro/reservas/infrastructure/config/DisponibilidadConfig.java
+++ b/backend/src/main/java/com/padelpro/reservas/infrastructure/config/DisponibilidadConfig.java
@@ -1,0 +1,32 @@
+package com.padelpro.reservas.infrastructure.config;
+
+import com.padelpro.auth.domain.port.out.SystemConfigRepositoryPort;
+import com.padelpro.reservas.application.service.DisponibilidadCacheInvalidator;
+import com.padelpro.reservas.application.service.DisponibilidadService;
+import com.padelpro.reservas.domain.port.out.ReservationQueryPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Wiring for the disponibilidad-pistas capability.
+ *
+ * <p>Instantiates {@link DisponibilidadService} explicitly (mirroring {@code SystemConfigConfig})
+ * so the application layer stays free of Spring stereotypes. The same instance is exposed under the
+ * {@link DisponibilidadCacheInvalidator} type so Wave 3 can depend on the narrow invalidation hook.
+ */
+@Configuration
+public class DisponibilidadConfig {
+
+    @Bean
+    public DisponibilidadService disponibilidadService(
+            ReservationQueryPort reservationQueryPort,
+            SystemConfigRepositoryPort systemConfigRepositoryPort) {
+        return new DisponibilidadService(reservationQueryPort, systemConfigRepositoryPort);
+    }
+
+    @Bean
+    public DisponibilidadCacheInvalidator disponibilidadCacheInvalidator(
+            DisponibilidadService disponibilidadService) {
+        return disponibilidadService;
+    }
+}

--- a/backend/src/main/java/com/padelpro/reservas/infrastructure/persistence/ReservationJpaRepository.java
+++ b/backend/src/main/java/com/padelpro/reservas/infrastructure/persistence/ReservationJpaRepository.java
@@ -1,0 +1,32 @@
+package com.padelpro.reservas.infrastructure.persistence;
+
+import com.padelpro.reservas.domain.model.Reservation;
+import com.padelpro.reservas.domain.model.ReservationStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Spring Data JPA repository for {@link Reservation}.
+ *
+ * <p>The availability query fetches active reservations for a date (status {@code IN
+ * ('PENDING_CONFIRMATION','CONFIRMED')}, RN-RES-01) and eagerly joins participants to avoid N+1
+ * loads when counting seats. Backed by the partial index {@code idx_res_date_status}.
+ */
+@Repository
+public interface ReservationJpaRepository extends JpaRepository<Reservation, UUID> {
+
+    @Query("""
+            SELECT DISTINCT r FROM Reservation r
+            LEFT JOIN FETCH r.participants
+            WHERE r.reservationDate = :date
+              AND r.status IN :statuses
+            """)
+    List<Reservation> findActiveByDateWithParticipants(@Param("date") LocalDate date,
+                                                        @Param("statuses") List<ReservationStatus> statuses);
+}

--- a/backend/src/main/java/com/padelpro/reservas/infrastructure/persistence/ReservationQueryAdapter.java
+++ b/backend/src/main/java/com/padelpro/reservas/infrastructure/persistence/ReservationQueryAdapter.java
@@ -1,0 +1,43 @@
+package com.padelpro.reservas.infrastructure.persistence;
+
+import com.padelpro.reservas.domain.model.Reservation;
+import com.padelpro.reservas.domain.model.ReservationOccupancy;
+import com.padelpro.reservas.domain.model.ReservationStatus;
+import com.padelpro.reservas.domain.port.out.ReservationQueryPort;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * Outbound adapter implementing {@link ReservationQueryPort} on top of {@link ReservationJpaRepository}.
+ *
+ * <p>Maps each active reservation to a {@link ReservationOccupancy} carrying its participant count,
+ * so the application service computes free slots without touching JPA entities or lazy collections.
+ */
+@Component
+public class ReservationQueryAdapter implements ReservationQueryPort {
+
+    /** Active occupants for availability (RN-RES-01): CANCELLED and COMPLETED are excluded. */
+    private static final List<ReservationStatus> ACTIVE_STATUSES =
+            List.of(ReservationStatus.PENDING_CONFIRMATION, ReservationStatus.CONFIRMED);
+
+    private final ReservationJpaRepository repository;
+
+    public ReservationQueryAdapter(ReservationJpaRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ReservationOccupancy> findActiveOccupanciesByDate(LocalDate date) {
+        List<Reservation> reservations = repository.findActiveByDateWithParticipants(date, ACTIVE_STATUSES);
+        return reservations.stream()
+                .map(r -> new ReservationOccupancy(
+                        r.getStartTime(),
+                        r.getEndTime(),
+                        r.getParticipants().size()))
+                .toList();
+    }
+}

--- a/backend/src/main/java/com/padelpro/reservas/infrastructure/web/ReservaDisponibilidadController.java
+++ b/backend/src/main/java/com/padelpro/reservas/infrastructure/web/ReservaDisponibilidadController.java
@@ -1,0 +1,62 @@
+package com.padelpro.reservas.infrastructure.web;
+
+import com.padelpro.auth.domain.exception.ValidationException;
+import com.padelpro.reservas.application.dto.DisponibilidadResponse;
+import com.padelpro.reservas.application.service.DisponibilidadService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
+
+/**
+ * REST controller for court availability (capability disponibilidad-pistas, US-006 / #13).
+ *
+ * <p>Endpoint: {@code GET /api/reservas/disponibles?fecha=YYYY-MM-DD} (OpenAPI operationId
+ * {@code getDisponibilidad}). Requires an authenticated USER or ADMIN; anonymous/expired tokens get
+ * 401 via the security filter chain ({@code anyRequest().authenticated()}).
+ *
+ * <p>The {@code fecha} parameter is mandatory and must be ISO {@code YYYY-MM-DD}; a missing or
+ * malformed value yields 400 {@code VALIDATION_ERROR} through {@code GlobalExceptionHandler}
+ * (which maps {@link ValidationException}). Declaring {@code fecha} as required (and not binding to
+ * a {@code LocalDate} directly) keeps full control over the error code instead of producing a
+ * generic Spring type-mismatch / missing-parameter response.
+ */
+@RestController
+@RequestMapping("/api/reservas")
+public class ReservaDisponibilidadController {
+
+    /** Strict ISO date parser: rejects out-of-range values (e.g. 2025-13-40) and non-ISO formats. */
+    private static final DateTimeFormatter FECHA_FORMAT =
+            DateTimeFormatter.ofPattern("uuuu-MM-dd").withResolverStyle(ResolverStyle.STRICT);
+
+    private final DisponibilidadService disponibilidadService;
+
+    public ReservaDisponibilidadController(DisponibilidadService disponibilidadService) {
+        this.disponibilidadService = disponibilidadService;
+    }
+
+    @GetMapping("/disponibles")
+    public ResponseEntity<DisponibilidadResponse> getDisponibilidad(
+            @RequestParam(name = "fecha", required = false) String fecha) {
+        LocalDate parsed = parseFecha(fecha);
+        return ResponseEntity.ok(disponibilidadService.getDisponibilidad(parsed));
+    }
+
+    private LocalDate parseFecha(String fecha) {
+        if (fecha == null || fecha.isBlank()) {
+            throw new ValidationException("El parámetro 'fecha' es obligatorio (formato YYYY-MM-DD)");
+        }
+        try {
+            return LocalDate.parse(fecha.trim(), FECHA_FORMAT);
+        } catch (DateTimeParseException ex) {
+            throw new ValidationException(
+                    "El parámetro 'fecha' debe tener el formato YYYY-MM-DD");
+        }
+    }
+}

--- a/backend/src/main/resources/db/migration/V7__create_reservations_and_participants.sql
+++ b/backend/src/main/resources/db/migration/V7__create_reservations_and_participants.sql
@@ -1,0 +1,99 @@
+-- Migration: Create reservations + participants tables (capability disponibilidad-pistas, US-006 / #13)
+-- Source of truth: docs/data-model.md §3.3 (reservations) and §3.4 (participants).
+--
+-- D-RES-01 (FINAL, Option A): anti-overlap guaranteed at DB level via an EXCLUDE USING gist
+-- constraint over the tsrange(date+start, date+end, '[)'), partial WHERE status <> 'CANCELLED'.
+-- Requires the btree_gist extension to combine the equality operator on reservation_date with
+-- the range overlap operator inside a single GiST exclusion constraint.
+
+-- Extension required for the exclusion constraint (equality + range in one GiST index).
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+
+-- ─── Enums ──────────────────────────────────────────────────────────────────
+CREATE TYPE reservation_status  AS ENUM ('PENDING_CONFIRMATION', 'CONFIRMED', 'CANCELLED', 'COMPLETED');
+CREATE TYPE reservation_channel AS ENUM ('WEB', 'TELEGRAM');
+
+-- ─── Table: reservations (data-model §3.3) ───────────────────────────────────
+CREATE TABLE reservations (
+    id                   UUID                 NOT NULL DEFAULT gen_random_uuid(),
+    owner_id             BIGINT               NOT NULL,
+    reservation_date     DATE                 NOT NULL,
+    start_time           TIME                 NOT NULL,
+    end_time             TIME                 NOT NULL,
+    duration_minutes     INTEGER              NOT NULL,
+    status               reservation_status   NOT NULL DEFAULT 'PENDING_CONFIRMATION',
+    channel              reservation_channel  NOT NULL,
+    notes                TEXT,
+    telegram_message_id  VARCHAR(50),
+    cancellation_reason  VARCHAR(255),
+    created_at           TIMESTAMPTZ          NOT NULL DEFAULT now(),
+    updated_at           TIMESTAMPTZ          NOT NULL DEFAULT now(),
+    CONSTRAINT reservations_pkey PRIMARY KEY (id),
+    CONSTRAINT fk_res_owner FOREIGN KEY (owner_id) REFERENCES users(id) ON DELETE RESTRICT,
+    CONSTRAINT chk_res_duration CHECK (duration_minutes IN (60, 90, 120, 150, 180)),
+    CONSTRAINT chk_res_end_time CHECK (end_time = (start_time + (duration_minutes || ' minutes')::INTERVAL)),
+    CONSTRAINT chk_res_start_minutes CHECK (EXTRACT(MINUTE FROM start_time) IN (0, 30))
+);
+
+-- Indexes (data-model §3.3)
+CREATE INDEX idx_res_owner_id   ON reservations (owner_id);
+CREATE INDEX idx_res_date_status
+    ON reservations (reservation_date, status)
+    WHERE status <> 'CANCELLED';
+CREATE INDEX idx_res_date_start ON reservations (reservation_date, start_time);
+CREATE INDEX idx_res_owner_date ON reservations (owner_id, reservation_date DESC);
+CREATE INDEX idx_res_owner_status
+    ON reservations (owner_id, status)
+    WHERE status IN ('PENDING_CONFIRMATION', 'CONFIRMED');
+
+-- DB-level anti-overlap barrier (D-RES-01). Two active reservations on the same date
+-- whose [start, end) ranges overlap are rejected. CANCELLED reservations are exempt.
+ALTER TABLE reservations ADD CONSTRAINT excl_res_no_overlap
+    EXCLUDE USING gist (
+        reservation_date WITH =,
+        tsrange(
+            reservation_date + start_time,
+            reservation_date + end_time,
+            '[)'
+        ) WITH &&
+    )
+    WHERE (status <> 'CANCELLED');
+
+-- ─── Table: participants (data-model §3.4) ───────────────────────────────────
+CREATE TABLE participants (
+    id              BIGSERIAL            NOT NULL,
+    reservation_id  UUID                 NOT NULL,
+    user_id         BIGINT,
+    external_name   VARCHAR(100),
+    external_phone  VARCHAR(20),
+    slot_position   INTEGER              NOT NULL,
+    is_owner        BOOLEAN              NOT NULL DEFAULT false,
+    joined_via      reservation_channel  NOT NULL,
+    joined_at       TIMESTAMPTZ          NOT NULL DEFAULT now(),
+    CONSTRAINT participants_pkey PRIMARY KEY (id),
+    CONSTRAINT fk_part_reservation FOREIGN KEY (reservation_id) REFERENCES reservations(id) ON DELETE CASCADE,
+    CONSTRAINT fk_part_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL,
+    CONSTRAINT chk_part_slot CHECK (slot_position BETWEEN 1 AND 4),
+    CONSTRAINT chk_part_user_or_external CHECK (
+        (user_id IS NOT NULL AND external_name IS NULL) OR
+        (user_id IS NULL     AND external_name IS NOT NULL)
+    ),
+    CONSTRAINT chk_part_phone_format CHECK (
+        external_phone IS NULL OR external_phone ~ '^\+[1-9]\d{7,14}$'
+    )
+);
+
+-- Indexes (data-model §3.4)
+CREATE INDEX idx_part_reservation_id ON participants (reservation_id);
+CREATE INDEX idx_part_user_id
+    ON participants (user_id)
+    WHERE user_id IS NOT NULL;
+CREATE UNIQUE INDEX idx_part_slot_unique
+    ON participants (reservation_id, slot_position);
+CREATE INDEX idx_part_user_reservation
+    ON participants (user_id, reservation_id)
+    WHERE user_id IS NOT NULL;
+-- Only one owner per reservation
+CREATE UNIQUE INDEX idx_part_one_owner
+    ON participants (reservation_id)
+    WHERE is_owner = true;

--- a/backend/src/test/java/com/padelpro/reservas/application/service/DisponibilidadServiceTest.java
+++ b/backend/src/test/java/com/padelpro/reservas/application/service/DisponibilidadServiceTest.java
@@ -1,0 +1,197 @@
+package com.padelpro.reservas.application.service;
+
+import com.padelpro.auth.domain.model.SystemConfig;
+import com.padelpro.auth.domain.model.SystemConfig.PaymentGateway;
+import com.padelpro.auth.domain.model.SystemConfig.PistaState;
+import com.padelpro.auth.domain.port.out.SystemConfigRepositoryPort;
+import com.padelpro.reservas.application.dto.DisponibilidadResponse;
+import com.padelpro.reservas.application.dto.TramoDisponible;
+import com.padelpro.reservas.domain.model.ReservationOccupancy;
+import com.padelpro.reservas.domain.port.out.ReservationQueryPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link DisponibilidadService} — slot calculation (capability disponibilidad-pistas).
+ *
+ * <p>Covers tasks 3.1–3.6 and the spec scenarios (RN-RES-01, RN-RES-02, RN-RES-04). Pure logic with
+ * both outbound ports mocked; no database involved. Schedule defaults: 08:00–23:00, 60-min slots
+ * ⇒ 15 slots per day when the court is fully free.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DisponibilidadService — cálculo de tramos libres")
+class DisponibilidadServiceTest {
+
+    private static final LocalDate FECHA = LocalDate.of(2025, 8, 1);
+    private static final int TOTAL_SLOTS = 23 - 8; // 08..22 inclusive => 15 slots
+
+    @Mock
+    private ReservationQueryPort reservationQueryPort;
+
+    @Mock
+    private SystemConfigRepositoryPort systemConfigRepositoryPort;
+
+    private DisponibilidadService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new DisponibilidadService(reservationQueryPort, systemConfigRepositoryPort);
+    }
+
+    private void configWith(PistaState state, int maxParticipants) {
+        SystemConfig config = SystemConfig.builder()
+                .id(1L)
+                .clubName("Club")
+                .pistaState(state)
+                .paymentGateway(PaymentGateway.CASH)
+                .maxParticipantsPerPista(maxParticipants)
+                .createdAt(OffsetDateTime.now())
+                .updatedAt(OffsetDateTime.now())
+                .build();
+        when(systemConfigRepositoryPort.findById(1L)).thenReturn(Optional.of(config));
+    }
+
+    private TramoDisponible slotAt(DisponibilidadResponse resp, String horaInicio) {
+        return resp.tramosDisponibles().stream()
+                .filter(t -> t.horaInicio().equals(horaInicio))
+                .findFirst()
+                .orElse(null);
+    }
+
+    // 3.1 — Día sin ninguna reserva activa → todos los tramos con plazasLibres = max_participants
+    @Test
+    @DisplayName("3.1 should_return_all_slots_free_when_no_active_reservations")
+    void should_return_all_slots_free_when_no_active_reservations() {
+        configWith(PistaState.ACTIVA, 4);
+        when(reservationQueryPort.findActiveOccupanciesByDate(FECHA)).thenReturn(List.of());
+
+        DisponibilidadResponse resp = service.getDisponibilidad(FECHA);
+
+        assertThat(resp.fecha()).isEqualTo("2025-08-01");
+        assertThat(resp.tramosDisponibles()).hasSize(TOTAL_SLOTS);
+        assertThat(resp.tramosDisponibles())
+                .allSatisfy(t -> {
+                    assertThat(t.plazasLibres()).isEqualTo(4);
+                    assertThat(t.duracionMinutos()).isEqualTo(60);
+                });
+        assertThat(slotAt(resp, "08:00")).isNotNull();
+        assertThat(slotAt(resp, "22:00")).isNotNull();
+        assertThat(slotAt(resp, "23:00")).isNull(); // closing hour is exclusive
+    }
+
+    // 3.2 — Reserva CONFIRMED 10:00-11:00 con 2 participantes, max 4 → tramo 10:00 con plazasLibres = 2
+    @Test
+    @DisplayName("3.2 should_return_partial_slots_when_reservation_incomplete")
+    void should_return_partial_slots_when_reservation_incomplete() {
+        configWith(PistaState.ACTIVA, 4);
+        when(reservationQueryPort.findActiveOccupanciesByDate(FECHA)).thenReturn(List.of(
+                new ReservationOccupancy(LocalTime.of(10, 0), LocalTime.of(11, 0), 2)
+        ));
+
+        DisponibilidadResponse resp = service.getDisponibilidad(FECHA);
+
+        TramoDisponible t10 = slotAt(resp, "10:00");
+        assertThat(t10).isNotNull();
+        assertThat(t10.plazasLibres()).isEqualTo(2);
+        assertThat(t10.duracionMinutos()).isEqualTo(60);
+        // Neighbouring slots remain fully free
+        assertThat(slotAt(resp, "09:00").plazasLibres()).isEqualTo(4);
+        assertThat(slotAt(resp, "11:00").plazasLibres()).isEqualTo(4);
+    }
+
+    // 3.3 — PENDING_CONFIRMATION ocupa igual que CONFIRMED
+    @Test
+    @DisplayName("3.3 should_count_pending_confirmation_as_occupying")
+    void should_count_pending_confirmation_as_occupying() {
+        configWith(PistaState.ACTIVA, 4);
+        // The query port only returns active occupants (PENDING_CONFIRMATION + CONFIRMED);
+        // a pending reservation of 1 participant at 18:00-19:00 reduces seats by 1.
+        when(reservationQueryPort.findActiveOccupanciesByDate(FECHA)).thenReturn(List.of(
+                new ReservationOccupancy(LocalTime.of(18, 0), LocalTime.of(19, 0), 1)
+        ));
+
+        DisponibilidadResponse resp = service.getDisponibilidad(FECHA);
+
+        TramoDisponible t18 = slotAt(resp, "18:00");
+        assertThat(t18).isNotNull();
+        assertThat(t18.plazasLibres()).isEqualTo(3);
+    }
+
+    // 3.4 — CANCELLED no ocupa. The query port excludes cancelled rows, so an empty result means free.
+    @Test
+    @DisplayName("3.4 should_ignore_cancelled_reservations")
+    void should_ignore_cancelled_reservations() {
+        configWith(PistaState.ACTIVA, 4);
+        // Only a CANCELLED reservation existed at 12:00-13:00; the port returns no active occupants.
+        when(reservationQueryPort.findActiveOccupanciesByDate(FECHA)).thenReturn(List.of());
+
+        DisponibilidadResponse resp = service.getDisponibilidad(FECHA);
+
+        TramoDisponible t12 = slotAt(resp, "12:00");
+        assertThat(t12).isNotNull();
+        assertThat(t12.plazasLibres()).isEqualTo(4);
+    }
+
+    // 3.5 — Tramo lleno (0 plazas) se omite; vecinos con reservas parciales sí aparecen.
+    @Test
+    @DisplayName("3.5 should_hide_full_slots")
+    void should_hide_full_slots() {
+        configWith(PistaState.ACTIVA, 4);
+        when(reservationQueryPort.findActiveOccupanciesByDate(FECHA)).thenReturn(List.of(
+                new ReservationOccupancy(LocalTime.of(9, 0), LocalTime.of(10, 0), 3),  // 09:00 -> 1 libre
+                new ReservationOccupancy(LocalTime.of(11, 0), LocalTime.of(12, 0), 4)  // 11:00 -> 0 libres (omitido)
+        ));
+
+        DisponibilidadResponse resp = service.getDisponibilidad(FECHA);
+
+        assertThat(slotAt(resp, "09:00").plazasLibres()).isEqualTo(1);
+        assertThat(slotAt(resp, "10:00").plazasLibres()).isEqualTo(4);
+        assertThat(slotAt(resp, "11:00")).isNull(); // full slot omitted
+        // 14 visible slots (15 total minus the full one)
+        assertThat(resp.tramosDisponibles()).hasSize(TOTAL_SLOTS - 1);
+    }
+
+    // 3.6 — MANTENIMIENTO → lista vacía sin revelar motivo (RN-RES-04)
+    @Test
+    @DisplayName("3.6 should_return_empty_list_when_pista_in_mantenimiento")
+    void should_return_empty_list_when_pista_in_mantenimiento() {
+        configWith(PistaState.MANTENIMIENTO, 4);
+        // Query port must not even be consulted, but keep it lenient in case of refactor.
+        lenient().when(reservationQueryPort.findActiveOccupanciesByDate(FECHA)).thenReturn(List.of());
+
+        DisponibilidadResponse resp = service.getDisponibilidad(FECHA);
+
+        assertThat(resp.fecha()).isEqualTo("2025-08-01");
+        assertThat(resp.tramosDisponibles()).isEmpty();
+    }
+
+    // Extra — reserva de 90 min solapa dos tramos consecutivos (tsrange '[)')
+    @Test
+    @DisplayName("extra: a 90-min reservation occupies both overlapped hourly slots")
+    void should_occupy_both_slots_for_90_minute_reservation() {
+        configWith(PistaState.ACTIVA, 4);
+        when(reservationQueryPort.findActiveOccupanciesByDate(FECHA)).thenReturn(List.of(
+                new ReservationOccupancy(LocalTime.of(10, 0), LocalTime.of(11, 30), 2)
+        ));
+
+        DisponibilidadResponse resp = service.getDisponibilidad(FECHA);
+
+        assertThat(slotAt(resp, "10:00").plazasLibres()).isEqualTo(2);
+        assertThat(slotAt(resp, "11:00").plazasLibres()).isEqualTo(2);
+        assertThat(slotAt(resp, "12:00").plazasLibres()).isEqualTo(4); // 11:30 end is exclusive at 12:00
+    }
+}

--- a/backend/src/test/java/com/padelpro/reservas/infrastructure/persistence/ReservationsMigrationIT.java
+++ b/backend/src/test/java/com/padelpro/reservas/infrastructure/persistence/ReservationsMigrationIT.java
@@ -5,8 +5,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -16,45 +14,87 @@ import java.sql.Statement;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Migration integration tests for V7 (reservations + participants), tasks 2.1–2.4.
  *
- * <p>Runs the full Flyway chain V1..V7 on a real PostgreSQL 15 (Testcontainers) and verifies the
- * anti-overlap exclusion constraint behaves as designed (D-RES-01). H2 cannot host {@code EXCLUDE
- * USING gist}/{@code btree_gist}, so these checks require a real engine.
+ * <p>Runs the full Flyway chain V1..V7 on a real PostgreSQL 15 and verifies the anti-overlap
+ * exclusion constraint behaves as designed (D-RES-01). H2 cannot host {@code EXCLUDE USING gist}/
+ * {@code btree_gist}, so these checks require a real engine.
  *
- * <p>The class self-disables when Docker is unavailable ({@code disabledWithoutDocker = true}),
- * so the rest of the suite (H2-based) still runs locally without Docker.
+ * <p><b>Two ways to provide that PostgreSQL</b> (Vía A vs Testcontainers):
+ * <ul>
+ *   <li><b>External (default for local runs):</b> pass system properties
+ *       {@code -Dit.postgres.url=jdbc:postgresql://localhost:5433/padelpro_it
+ *       -Dit.postgres.user=padelpro -Dit.postgres.password=padelpro_dev}. The test connects over
+ *       plain JDBC/TCP to a PostgreSQL started via {@code docker compose}/{@code docker run},
+ *       so it does NOT touch docker-java/Testcontainers — useful where the Docker Desktop named
+ *       pipe breaks the Testcontainers client.</li>
+ *   <li><b>Testcontainers (default for CI):</b> if {@code it.postgres.url} is absent, spin an
+ *       ephemeral {@code postgres:15-alpine} container. Requires a reachable Docker daemon; the
+ *       whole class is skipped (assumption) when neither an external URL nor Docker is available.</li>
+ * </ul>
  */
-@Testcontainers(disabledWithoutDocker = true)
-@DisplayName("Migración V7 — reservations + participants (Testcontainers)")
+@DisplayName("Migración V7 — reservations + participants (Postgres real)")
 class ReservationsMigrationIT {
 
-    @Container
-    static final PostgreSQLContainer<?> POSTGRES =
-            new PostgreSQLContainer<>("postgres:15-alpine");
+    private static String jdbcUrl;
+    private static String username;
+    private static String password;
+    private static PostgreSQLContainer<?> container;
 
     @BeforeAll
     static void migrate() {
+        String externalUrl = System.getProperty("it.postgres.url");
+        if (externalUrl != null && !externalUrl.isBlank()) {
+            // Vía A — external PostgreSQL (docker compose / docker run), no Testcontainers.
+            jdbcUrl = externalUrl;
+            username = System.getProperty("it.postgres.user", "padelpro");
+            password = System.getProperty("it.postgres.password", "padelpro_dev");
+        } else {
+            // CI fallback — ephemeral container via Testcontainers (needs a working Docker daemon).
+            boolean dockerAvailable;
+            try {
+                dockerAvailable = org.testcontainers.DockerClientFactory.instance().isDockerAvailable();
+            } catch (Throwable t) {
+                dockerAvailable = false;
+            }
+            assumeTrue(dockerAvailable,
+                    "Skipping migration ITs: no external it.postgres.url and Docker not reachable by Testcontainers");
+            container = new PostgreSQLContainer<>("postgres:15-alpine");
+            container.start();
+            jdbcUrl = container.getJdbcUrl();
+            username = container.getUsername();
+            password = container.getPassword();
+        }
+
         Flyway.configure()
-                .dataSource(POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword())
+                .dataSource(jdbcUrl, username, password)
                 .locations("classpath:db/migration")
+                .cleanDisabled(false)
                 .load()
                 .migrate();
     }
 
+    @org.junit.jupiter.api.AfterAll
+    static void stopContainer() {
+        if (container != null) {
+            container.stop();
+        }
+    }
+
     private Connection connection() throws SQLException {
-        return java.sql.DriverManager.getConnection(
-                POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword());
+        return java.sql.DriverManager.getConnection(jdbcUrl, username, password);
     }
 
     /** Inserts the seed user/owner reused by overlap tests. Returns the generated user id. */
     private long insertOwner(Connection c) throws SQLException {
+        // Use RETURNING id with a plain executeQuery(); do NOT combine with RETURN_GENERATED_KEYS,
+        // since the PostgreSQL driver then yields no ResultSet ("query returned no results").
         try (PreparedStatement ps = c.prepareStatement(
                 "INSERT INTO users (login, password_hash, first_name, last_name, phone, email, status, role) " +
-                        "VALUES (?, ?, ?, ?, ?, ?, 'ACTIVE', 'USER') RETURNING id",
-                Statement.RETURN_GENERATED_KEYS)) {
+                        "VALUES (?, ?, ?, ?, ?, ?, 'ACTIVE', 'USER') RETURNING id")) {
             String unique = String.valueOf(System.nanoTime());
             ps.setString(1, "owner" + unique.substring(unique.length() - 6));
             ps.setString(2, "$2a$12$abcdefghijklmnopqrstuv");

--- a/backend/src/test/java/com/padelpro/reservas/infrastructure/persistence/ReservationsMigrationIT.java
+++ b/backend/src/test/java/com/padelpro/reservas/infrastructure/persistence/ReservationsMigrationIT.java
@@ -1,0 +1,148 @@
+package com.padelpro.reservas.infrastructure.persistence;
+
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Migration integration tests for V7 (reservations + participants), tasks 2.1–2.4.
+ *
+ * <p>Runs the full Flyway chain V1..V7 on a real PostgreSQL 15 (Testcontainers) and verifies the
+ * anti-overlap exclusion constraint behaves as designed (D-RES-01). H2 cannot host {@code EXCLUDE
+ * USING gist}/{@code btree_gist}, so these checks require a real engine.
+ *
+ * <p>The class self-disables when Docker is unavailable ({@code disabledWithoutDocker = true}),
+ * so the rest of the suite (H2-based) still runs locally without Docker.
+ */
+@Testcontainers(disabledWithoutDocker = true)
+@DisplayName("Migración V7 — reservations + participants (Testcontainers)")
+class ReservationsMigrationIT {
+
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES =
+            new PostgreSQLContainer<>("postgres:15-alpine");
+
+    @BeforeAll
+    static void migrate() {
+        Flyway.configure()
+                .dataSource(POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword())
+                .locations("classpath:db/migration")
+                .load()
+                .migrate();
+    }
+
+    private Connection connection() throws SQLException {
+        return java.sql.DriverManager.getConnection(
+                POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword());
+    }
+
+    /** Inserts the seed user/owner reused by overlap tests. Returns the generated user id. */
+    private long insertOwner(Connection c) throws SQLException {
+        try (PreparedStatement ps = c.prepareStatement(
+                "INSERT INTO users (login, password_hash, first_name, last_name, phone, email, status, role) " +
+                        "VALUES (?, ?, ?, ?, ?, ?, 'ACTIVE', 'USER') RETURNING id",
+                Statement.RETURN_GENERATED_KEYS)) {
+            String unique = String.valueOf(System.nanoTime());
+            ps.setString(1, "owner" + unique.substring(unique.length() - 6));
+            ps.setString(2, "$2a$12$abcdefghijklmnopqrstuv");
+            ps.setString(3, "Owner");
+            ps.setString(4, "Test");
+            ps.setString(5, "+3460" + unique.substring(unique.length() - 7));
+            ps.setString(6, "owner" + unique + "@padelpro.local");
+            try (ResultSet rs = ps.executeQuery()) {
+                rs.next();
+                return rs.getLong(1);
+            }
+        }
+    }
+
+    private void insertReservation(Connection c, long ownerId, String date,
+                                    String start, String end, int minutes, String status) throws SQLException {
+        try (PreparedStatement ps = c.prepareStatement(
+                "INSERT INTO reservations (owner_id, reservation_date, start_time, end_time, " +
+                        "duration_minutes, status, channel) " +
+                        "VALUES (?, ?::date, ?::time, ?::time, ?, ?::reservation_status, 'WEB'::reservation_channel)")) {
+            ps.setLong(1, ownerId);
+            ps.setString(2, date);
+            ps.setString(3, start);
+            ps.setString(4, end);
+            ps.setInt(5, minutes);
+            ps.setString(6, status);
+            ps.executeUpdate();
+        }
+    }
+
+    // 2.1 — V1..V7 aplican limpiamente (si migrate() falla, @BeforeAll aborta la clase)
+    @Test
+    @DisplayName("2.1 migrations_v1_to_v7_apply_cleanly")
+    void migrations_v1_to_v7_apply_cleanly() throws SQLException {
+        try (Connection c = connection();
+             Statement st = c.createStatement();
+             ResultSet rs = st.executeQuery(
+                     "SELECT to_regclass('public.reservations') AS r, to_regclass('public.participants') AS p")) {
+            rs.next();
+            assertThat(rs.getString("r")).isEqualTo("reservations");
+            assertThat(rs.getString("p")).isEqualTo("participants");
+        }
+    }
+
+    // 2.2 — btree_gist disponible tras V7
+    @Test
+    @DisplayName("2.2 btree_gist_extension_is_available")
+    void btree_gist_extension_is_available() throws SQLException {
+        try (Connection c = connection();
+             Statement st = c.createStatement();
+             ResultSet rs = st.executeQuery(
+                     "SELECT count(*) AS n FROM pg_extension WHERE extname = 'btree_gist'")) {
+            rs.next();
+            assertThat(rs.getInt("n")).isEqualTo(1);
+        }
+    }
+
+    // 2.3 — dos reservas activas solapadas → la BD rechaza la segunda
+    @Test
+    @DisplayName("2.3 overlapping_active_reservations_are_rejected")
+    void overlapping_active_reservations_are_rejected() throws SQLException {
+        try (Connection c = connection()) {
+            long owner = insertOwner(c);
+            insertReservation(c, owner, "2030-01-10", "10:00", "11:00", 60, "CONFIRMED");
+
+            assertThatThrownBy(() ->
+                    insertReservation(c, owner, "2030-01-10", "10:30", "11:30", 60, "PENDING_CONFIRMATION"))
+                    .isInstanceOf(SQLException.class)
+                    .hasMessageContaining("excl_res_no_overlap");
+        }
+    }
+
+    // 2.4 — la segunda CANCELLED SÍ se permite (constraint parcial WHERE status <> 'CANCELLED')
+    @Test
+    @DisplayName("2.4 overlapping_with_second_cancelled_is_allowed")
+    void overlapping_with_second_cancelled_is_allowed() throws SQLException {
+        try (Connection c = connection()) {
+            long owner = insertOwner(c);
+            insertReservation(c, owner, "2030-02-10", "12:00", "13:00", 60, "CONFIRMED");
+            // Second one CANCELLED at the same window — exempt from the partial exclusion constraint.
+            insertReservation(c, owner, "2030-02-10", "12:00", "13:00", 60, "CANCELLED");
+
+            try (Statement st = c.createStatement();
+                 ResultSet rs = st.executeQuery(
+                         "SELECT count(*) AS n FROM reservations WHERE reservation_date = '2030-02-10'")) {
+                rs.next();
+                assertThat(rs.getInt("n")).isEqualTo(2);
+            }
+        }
+    }
+}

--- a/backend/src/test/java/com/padelpro/reservas/infrastructure/web/ReservaDisponibilidadE2ETest.java
+++ b/backend/src/test/java/com/padelpro/reservas/infrastructure/web/ReservaDisponibilidadE2ETest.java
@@ -1,0 +1,128 @@
+package com.padelpro.reservas.infrastructure.web;
+
+import com.padelpro.reservas.application.dto.DisponibilidadResponse;
+import com.padelpro.reservas.application.dto.TramoDisponible;
+import com.padelpro.reservas.application.service.DisponibilidadService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * E2E tests for {@link ReservaDisponibilidadController} with Spring Security + MockMvc
+ * (capability disponibilidad-pistas, US-006 / #13). Covers tasks 4.1–4.7.
+ *
+ * <p>The {@link DisponibilidadService} bean is replaced by a Mockito mock so these tests focus on
+ * the HTTP contract (OpenAPI {@code getDisponibilidad}), authentication (401), authorization
+ * (USER/ADMIN allowed) and {@code fecha} validation (400 {@code VALIDATION_ERROR}).
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DisplayName("E2E — GET /api/reservas/disponibles")
+class ReservaDisponibilidadE2ETest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private DisponibilidadService disponibilidadService;
+
+    // 4.1 — USER autenticado → 200 con tramos
+    @Test
+    @DisplayName("4.1 user_authenticated_gets_200_with_slots")
+    @WithMockUser(roles = "USER")
+    void user_authenticated_gets_200_with_slots() throws Exception {
+        when(disponibilidadService.getDisponibilidad(any(LocalDate.class)))
+                .thenReturn(new DisponibilidadResponse("2025-08-01",
+                        List.of(new TramoDisponible("09:00", 60, 3))));
+
+        mockMvc.perform(get("/api/reservas/disponibles").param("fecha", "2025-08-01"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.fecha").value("2025-08-01"))
+                .andExpect(jsonPath("$.tramosDisponibles[0].horaInicio").value("09:00"))
+                .andExpect(jsonPath("$.tramosDisponibles[0].duracionMinutos").value(60))
+                .andExpect(jsonPath("$.tramosDisponibles[0].plazasLibres").value(3));
+    }
+
+    // 4.2 — ADMIN autenticado → 200
+    @Test
+    @DisplayName("4.2 admin_authenticated_gets_200")
+    @WithMockUser(roles = "ADMIN")
+    void admin_authenticated_gets_200() throws Exception {
+        when(disponibilidadService.getDisponibilidad(any(LocalDate.class)))
+                .thenReturn(new DisponibilidadResponse("2025-08-01", List.of()));
+
+        mockMvc.perform(get("/api/reservas/disponibles").param("fecha", "2025-08-01"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.fecha").value("2025-08-01"));
+    }
+
+    // 4.3 — Sin Authorization → 401
+    @Test
+    @DisplayName("4.3 anonymous_gets_401")
+    void anonymous_gets_401() throws Exception {
+        mockMvc.perform(get("/api/reservas/disponibles").param("fecha", "2025-08-01"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // 4.4 — JWT expirado/ inválido → 401 (el filtro limpia el contexto)
+    @Test
+    @DisplayName("4.4 expired_or_invalid_jwt_gets_401")
+    void expired_or_invalid_jwt_gets_401() throws Exception {
+        // A malformed/expired bearer token is rejected by JwtAuthFilter, leaving the request
+        // unauthenticated; the security entry point returns 401 for this protected route.
+        mockMvc.perform(get("/api/reservas/disponibles")
+                        .param("fecha", "2025-08-01")
+                        .header("Authorization", "Bearer expired.invalid.token"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // 4.5 — fecha formato inválido → 400 VALIDATION_ERROR
+    @Test
+    @DisplayName("4.5 invalid_date_format_gets_400_validation_error")
+    @WithMockUser(roles = "USER")
+    void invalid_date_format_gets_400_validation_error() throws Exception {
+        mockMvc.perform(get("/api/reservas/disponibles").param("fecha", "15-06-2025"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("VALIDATION_ERROR"));
+    }
+
+    // 4.6 — sin parámetro fecha → 400 VALIDATION_ERROR
+    @Test
+    @DisplayName("4.6 missing_date_param_gets_400_validation_error")
+    @WithMockUser(roles = "USER")
+    void missing_date_param_gets_400_validation_error() throws Exception {
+        mockMvc.perform(get("/api/reservas/disponibles"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("VALIDATION_ERROR"));
+    }
+
+    // 4.7 — MANTENIMIENTO → 200 con tramosDisponibles: []
+    @Test
+    @DisplayName("4.7 maintenance_returns_200_with_empty_list")
+    @WithMockUser(roles = "USER")
+    void maintenance_returns_200_with_empty_list() throws Exception {
+        when(disponibilidadService.getDisponibilidad(any(LocalDate.class)))
+                .thenReturn(new DisponibilidadResponse("2025-09-01", List.of()));
+
+        mockMvc.perform(get("/api/reservas/disponibles").param("fecha", "2025-09-01"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.tramosDisponibles").isArray())
+                .andExpect(jsonPath("$.tramosDisponibles").isEmpty());
+    }
+}

--- a/openspec/changes/disponibilidad-pistas/.openspec.yaml
+++ b/openspec/changes/disponibilidad-pistas/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-13

--- a/openspec/changes/disponibilidad-pistas/design.md
+++ b/openspec/changes/disponibilidad-pistas/design.md
@@ -1,0 +1,68 @@
+## Context
+
+`disponibilidad-pistas` (US-006, #13) es la consulta de solo lectura que muestra qué tramos horarios de la pista única tienen plazas libres para una fecha. Hoy no existe ninguna tabla de reservas en la BD (Flyway va hasta `V6__create_system_config_table.sql`), por lo que esta capability **introduce el modelo de datos de reservas** además del endpoint de consulta.
+
+Restricciones y estado actual:
+- Una sola pista física en v1.0 (no hay tabla `courts`; ver `openspec/specs/pistas/spec.md`).
+- La configuración global (`system_config`, singleton) ya existe e expone `max_participants` y `pista_state` (capability `configuracion-club`, implementada).
+- El schema de `reservations` y `participants` está documentado al detalle en `docs/data-model.md` §3.3/§3.4, incluyendo el constraint anti-solapamiento.
+- Stakeholders: jugadores (consumen disponibilidad antes de reservar) y la futura capability `reservas` (Wave 3), que escribirá sobre estas tablas.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Crear la migración Flyway `V7` con `reservations` + `participants` fiel a `docs/data-model.md`, **correcta desde el primer día** (la barrera anti-solapamiento no puede cambiarse con datos en producción).
+- Implementar `GET /api/reservas/disponibles?fecha=YYYY-MM-DD` con cálculo de plazas libres por tramo (RN-RES-01, RN-RES-02) y respeto del estado MANTENIMIENTO (RN-RES-04).
+- Validación robusta del parámetro `fecha` y autorización (USER/ADMIN sí, anónimo 401).
+- Dejar las tablas listas y el constraint operativo para que Wave 3 solo tenga que escribir.
+
+**Non-Goals:**
+- Creación, confirmación o cancelación de reservas (`POST/PATCH /api/reservas`) — Wave 3.
+- Tabla `payments` y lógica de pago — Wave 3/4A.
+- Partidas joinables — Wave 4C.
+- Frontend del calendario (TICKET-005, #6).
+
+## Decisions
+
+### D1 — Schema de `reservations`: `tsrange` + `EXCLUDE USING gist` (cierra D-RES-01)
+**Decisión:** columnas explícitas `start_time`/`end_time`/`duration_minutes` **más** el constraint `excl_res_no_overlap` `EXCLUDE USING gist (reservation_date WITH =, tsrange(date+start, date+end, '[)') WITH &&) WHERE (status <> 'CANCELLED')`, previa `CREATE EXTENSION IF NOT EXISTS btree_gist`.
+**Motiva (RN-RES-01):** el anti-solapamiento de franjas debe garantizarse a nivel de BD de forma atómica; ninguna concurrencia de aplicación puede colar dos reservas activas que se pisen.
+**Alternativa considerada:** solo columnas `(start_time, duration_minutes)` con validación en lógica de aplicación. **Descartada:** sin bloqueo a nivel de motor, dos transacciones concurrentes pueden crear reservas solapadas (carrera). Cerrada por Luis y coincidente con `docs/data-model.md` §3.3.
+
+### D2 — Crear `participants` junto con `reservations` en `V7`
+**Decisión:** la migración crea ambas tablas (y enums) en la misma versión.
+**Motiva (RN-RES-02):** las plazas libres de un tramo se calculan como `max_participants − COUNT(participants activos)`. La consulta de disponibilidad necesita `participants` para los tramos con reserva parcial; no puede calcularse solo con `reservations`.
+
+### D3 — Origen de `max_participants` y estado de pista: `system_config`
+**Decisión:** el servicio de disponibilidad lee `max_participants` y `pista_state` del singleton `system_config` (capability `configuracion-club`), no de constantes.
+**Motiva (RN-RES-02, RN-RES-04):** las plazas por tramo y el bloqueo por MANTENIMIENTO son configurables por el ADMIN en runtime.
+
+### D4 — Tratamiento de estados para el cálculo
+**Decisión:** se consideran ocupantes las reservas con `status IN ('PENDING_CONFIRMATION','CONFIRMED')` (es decir, `status <> 'CANCELLED'` y `<> 'COMPLETED'` para fechas futuras); `CANCELLED` nunca cuenta.
+**Motiva (RN-RES-01):** una reserva pendiente de confirmar ya bloquea la franja; lo contrario permitiría overbooking transitorio. Alinea con el índice parcial `idx_res_date_status WHERE status <> 'CANCELLED'`.
+
+### D5 — MANTENIMIENTO devuelve lista vacía sin revelar motivo
+**Decisión:** si `pista_state = MANTENIMIENTO`, responder `200` con `tramosDisponibles: []` y sin campo que indique el motivo.
+**Motiva (RN-RES-04):** no exponer información operativa innecesaria; la UX muestra mensaje genérico.
+
+### D6 — Caché de 30 s por fecha, con hook de invalidación
+**Decisión:** cachear el resultado por clave `fecha` con TTL 30 s y exponer un punto de invalidación que Wave 3 invocará al crear/cancelar reservas.
+**Motiva:** la disponibilidad se consulta con alta frecuencia y cambia poco; 30 s acota la inconsistencia. La invalidación explícita evita mostrar franjas ya ocupadas tras una reserva.
+
+## Risks / Trade-offs
+
+- **[La extensión `btree_gist` puede no estar disponible/permitida en el entorno destino]** → La migración usa `CREATE EXTENSION IF NOT EXISTS btree_gist`; documentar en `docs/PROJECT.md`/despliegue que el rol de BD necesita privilegio para crear extensiones, o pre-crearla en el bootstrap del contenedor PostgreSQL. Verificar con Testcontainers que la migración aplica limpiamente.
+- **[Migración irreversible en la práctica]** → El constraint gist no admite cambios cómodos con datos. Mitigación: nace ya con la forma definitiva (D1) y se cubre con test de migración antes de cualquier dato de producción; rollback solo por `DROP TABLE` mientras las tablas estén vacías.
+- **[Ventana de caché de 30 s puede mostrar una franja como libre justo tras una reserva]** → Hook de invalidación por fecha desde Wave 3; mientras Wave 3 no exista, no hay escritura, así que el riesgo es nulo en esta entrega.
+- **[Desalineación entre el cálculo de tramos y el horario del club]** → El horario de apertura/cierre y la granularidad de tramos provienen de `system_config`; si esos campos no estuvieran poblados, usar los defaults de la fila inicial (`V6`) y cubrir el caso con test.
+
+## Migration Plan
+
+1. Añadir `V7__create_reservations_and_participants.sql`: `CREATE EXTENSION IF NOT EXISTS btree_gist`; enums `reservation_status`, `reservation_channel`; tablas `reservations` y `participants` con columnas, FKs, índices y constraints de `docs/data-model.md` §3.3/§3.4 (incl. `excl_res_no_overlap`).
+2. Verificar con Testcontainers que `V1..V7` aplican limpiamente sobre PostgreSQL 15 desde cero.
+3. Implementar capa de lectura (entidad, puerto, repositorio, servicio, DTOs, controlador) y el endpoint `GET /api/reservas/disponibles`.
+4. **Rollback:** mientras `reservations`/`participants` estén vacías, revertir = bajar la migración (`DROP TABLE participants; DROP TABLE reservations; DROP TYPE ...`). Tras tener datos, no hay rollback seguro del constraint gist → exige nueva migración correctiva.
+
+## Open Questions
+
+- Ninguna bloqueante. D-RES-01 resuelta (D1). Pendiente menor de confirmar al implementar: si el horario de apertura/cierre y la duración de tramo deben leerse de campos concretos de `system_config` o derivarse de defaults — se resolverá leyendo el esquema real de la fila inicial de `V6` durante `/opsx:apply`.

--- a/openspec/changes/disponibilidad-pistas/proposal.md
+++ b/openspec/changes/disponibilidad-pistas/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Los jugadores necesitan ver qué franjas horarias de la pista están libres para una fecha concreta **antes** de poder reservar (US-006, #13). Es la puerta de entrada del flujo de reserva y un prerrequisito directo de Wave 3 (`reservas`): sin consulta de disponibilidad no hay forma de elegir una franja. Además, esta capability obliga a crear por primera vez la tabla `reservations` (y `participants`), cuyo schema —en especial el constraint anti-solapamiento— es un **punto de no retorno** que debe nacer correcto.
+
+**Fase del producto:** fase-1.
+
+## What Changes
+
+- **Migración Flyway `V7`**: crea las tablas `reservations` y `participants`, los enums `reservation_status` y `reservation_channel`, los índices documentados en `docs/data-model.md` §3.3/§3.4 y el constraint de seguridad anti-solapamiento `excl_res_no_overlap` (`EXCLUDE USING gist` sobre `tsrange`, requiere `CREATE EXTENSION btree_gist`). Las tablas nacen **vacías**: la escritura de reservas llega en Wave 3.
+- **Endpoint `GET /api/reservas/disponibles?fecha=YYYY-MM-DD`**: devuelve los tramos horarios con plazas libres para la fecha, calculados a partir de (a) las reservas activas (`status <> 'CANCELLED'`) que solapan cada tramo, (b) `system_config.max_participants` para las plazas restantes y (c) el estado operativo de la pista (`system_config.pista_state`).
+- **Estado MANTENIMIENTO**: cuando la pista está en MANTENIMIENTO, la respuesta devuelve `tramosDisponibles: []` sin revelar el motivo.
+- **Validación de entrada**: `fecha` obligatoria en formato `YYYY-MM-DD`; formato inválido o ausente → `400 VALIDATION_ERROR`.
+- **Autorización**: USER y ADMIN autenticados pueden consultar; petición sin JWT → `401`.
+- **Caché 30 s** por fecha, invalidable al crearse/cancelarse reservas (el hook de invalidación queda preparado; lo consumirá Wave 3).
+
+## Capabilities
+
+### New Capabilities
+<!-- Ninguna nueva: la capability ya está documentada en openspec/specs/ desde el init. -->
+
+### Modified Capabilities
+- `disponibilidad-pistas`: se formaliza e implementa el comportamiento ya especificado (consulta de tramos libres, plazas parciales, lista vacía en MANTENIMIENTO, validación del parámetro `fecha`). El delta confirma los requisitos que pasan de "documentados" a "implementados".
+
+## Impact
+
+- **Base de datos**: nueva migración `V7__create_reservations_and_participants.sql`. Extensión `btree_gist`. El constraint `excl_res_no_overlap` es la barrera de seguridad que Wave 3 (`reservas`) usará junto con `SELECT FOR UPDATE`.
+- **Backend** (`com.padelpro.auth` / módulo de reservas): nueva entidad `Reservation` (+`Participant`), puerto de lectura, repositorio JPA, servicio de cálculo de disponibilidad, DTOs (`DisponibilidadResponse`, `TramoDisponible`) y `ReservaDisponibilidadController`.
+- **Dependencias con otras capabilities**: `configuracion-club` (lee `max_participants` y `pista_state`); `reservas` (Wave 3) consumirá estas tablas y el constraint; `partidas` reutilizará la misma consulta.
+- **Issue**: #13 (US-006). **Decisión de diseño D-RES-01**: cerrada → `tsrange + EXCLUDE USING gist` (coincide con `docs/data-model.md` §3.3).
+- **Fuera de alcance**: creación/cancelación de reservas (`POST/PATCH /api/reservas`) — Wave 3; tabla `payments` — Wave 3/4A; el frontend del calendario (TICKET-005, #6); la lógica de partidas joinables — Wave 4C.

--- a/openspec/changes/disponibilidad-pistas/specs/disponibilidad-pistas/spec.md
+++ b/openspec/changes/disponibilidad-pistas/specs/disponibilidad-pistas/spec.md
@@ -1,0 +1,81 @@
+### API Contract
+
+Endpoint `GET /api/reservas/disponibles` — ver `docs/openapi.yaml`, operationId `getDisponibilidad`, tag `Reservas`, y schemas `DisponibilidadResponse` / `TramoDisponible`. Implementado en `com.padelpro.reservas` (migración Flyway `V7`).
+
+## ADDED Requirements
+
+### Requirement: Consulta de disponibilidad de la pista
+
+El sistema SHALL devolver, para una fecha concreta solicitada por un usuario autenticado, los tramos horarios de la pista con el número de plazas libres calculado a partir de las reservas activas, el máximo de participantes configurado y el estado operativo de la pista.
+
+#### Scenario: Día sin ninguna reserva activa
+
+- **WHEN** un usuario autenticado (USER o ADMIN) envía `GET /api/reservas/disponibles?fecha=2025-08-01` y no existe ninguna reserva con `reservation_date = 2025-08-01` y `status <> 'CANCELLED'`
+- **THEN** el sistema responde `200` con la fecha y la lista `tramosDisponibles` con todos los tramos del horario del club
+- **AND** cada tramo tiene `plazasLibres` igual a `system_config.max_participants`
+
+#### Scenario: Tramo con reserva parcialmente ocupada
+
+- **WHEN** un usuario autenticado consulta una fecha en la que existe una reserva `CONFIRMED` de `start_time=10:00`, `duration_minutes=60` con 2 participantes y `system_config.max_participants = 4`
+- **THEN** el sistema responde `200`
+- **AND** el tramo `horaInicio: "10:00"`, `duracionMinutos: 60` aparece en `tramosDisponibles` con `plazasLibres: 2`
+
+#### Scenario: Múltiples reservas en distintos tramos
+
+- **WHEN** un usuario consulta una fecha con reservas `CONFIRMED` en 09:00–10:00 (3 participantes) y 11:00–12:00 (4 participantes) y el tramo 10:00–11:00 sin reserva activa
+- **THEN** el tramo 09:00 aparece con `plazasLibres: 1`
+- **AND** el tramo 10:00 aparece con `plazasLibres` igual a `system_config.max_participants`
+- **AND** el tramo 11:00 NO aparece (0 plazas libres)
+
+### Requirement: Reservas pendientes de confirmar bloquean franja
+
+El sistema SHALL contar las reservas en estado `PENDING_CONFIRMATION` igual que las `CONFIRMED` al calcular las plazas libres, y SHALL excluir siempre las reservas en estado `CANCELLED`.
+
+#### Scenario: Reserva pendiente reduce plazas libres
+
+- **WHEN** un usuario consulta una fecha con una reserva `PENDING_CONFIRMATION` de 1 participante en el tramo 18:00–19:00 y `system_config.max_participants = 4`
+- **THEN** el tramo 18:00 aparece con `plazasLibres: 3`
+
+#### Scenario: Reserva cancelada no ocupa franja
+
+- **WHEN** un usuario consulta una fecha cuyo único registro en el tramo 12:00–13:00 es una reserva con `status = 'CANCELLED'`
+- **THEN** el tramo 12:00 aparece con `plazasLibres` igual a `system_config.max_participants`
+
+### Requirement: Pista en MANTENIMIENTO devuelve disponibilidad vacía
+
+El sistema SHALL devolver `tramosDisponibles` vacío para cualquier fecha cuando la pista está en estado MANTENIMIENTO, sin revelar el motivo en la respuesta.
+
+#### Scenario: Consulta con pista en mantenimiento
+
+- **WHEN** un usuario autenticado consulta `GET /api/reservas/disponibles?fecha=2025-09-01` y `system_config.pista_state = MANTENIMIENTO`
+- **THEN** el sistema responde `200` con `tramosDisponibles: []`
+- **AND** la respuesta no incluye ningún campo que revele que el motivo es MANTENIMIENTO
+
+### Requirement: Validación del parámetro de fecha
+
+El sistema SHALL exigir el parámetro `fecha` en formato `YYYY-MM-DD` y SHALL rechazar las peticiones con formato inválido o sin el parámetro.
+
+#### Scenario: Formato de fecha inválido
+
+- **WHEN** un usuario autenticado envía `GET /api/reservas/disponibles?fecha=15-06-2025`
+- **THEN** el sistema responde `400` con `code: "VALIDATION_ERROR"`
+- **AND** el mensaje indica que el formato debe ser `YYYY-MM-DD`
+
+#### Scenario: Parámetro fecha ausente
+
+- **WHEN** un usuario autenticado envía `GET /api/reservas/disponibles` sin el parámetro `fecha`
+- **THEN** el sistema responde `400` con `code: "VALIDATION_ERROR"`
+
+### Requirement: Autenticación obligatoria para consultar disponibilidad
+
+El sistema SHALL exigir un JWT válido para consultar la disponibilidad; las peticiones no autenticadas SHALL recibir `401`.
+
+#### Scenario: Petición sin autenticación
+
+- **WHEN** se envía `GET /api/reservas/disponibles?fecha=2025-08-01` sin cabecera `Authorization`
+- **THEN** el sistema responde `401`
+
+#### Scenario: Petición con token expirado
+
+- **WHEN** se envía la consulta con un JWT expirado
+- **THEN** el sistema responde `401` y no devuelve datos de disponibilidad

--- a/openspec/changes/disponibilidad-pistas/tasks.md
+++ b/openspec/changes/disponibilidad-pistas/tasks.md
@@ -1,0 +1,69 @@
+## 1. Setup y andamiaje
+
+- [ ] 1.1 Confirmar Issue #13 (US-006) reabierto y mover el item del Project v2 a "In Progress"
+- [x] 1.2 Trabajar sobre la rama `feat/13-disponibilidad-pistas` (ya creada desde `develop`)
+- [x] 1.3 Verificar que `system_config` (V6) expone `max_participants` y `pista_state`, y localizar los campos de horario/granularidad de tramo disponibles en la fila inicial
+
+## 2. TDD — Tests de migración (RED, Testcontainers)
+
+- [x] 2.1 Test: las migraciones `V1..V7` aplican limpiamente sobre PostgreSQL 15 desde cero
+- [x] 2.2 Test: la extensión `btree_gist` queda disponible tras `V7`
+- [x] 2.3 Test: insertar dos reservas activas solapadas en la misma fecha viola `excl_res_no_overlap` (la BD rechaza la segunda)
+- [x] 2.4 Test: dos reservas solapadas pero con la segunda `CANCELLED` SÍ se permiten (constraint parcial `WHERE status <> 'CANCELLED'`)
+
+## 3. TDD — Tests unitarios del cálculo de disponibilidad (RED)
+
+- [x] 3.1 Test `should_return_all_slots_free_when_no_active_reservations` — plazasLibres = max_participants
+- [x] 3.2 Test `should_return_partial_slots_when_reservation_incomplete` — reserva CONFIRMED con 2/4 → plazasLibres = 2
+- [x] 3.3 Test `should_count_pending_confirmation_as_occupying` — PENDING_CONFIRMATION reduce plazas
+- [x] 3.4 Test `should_ignore_cancelled_reservations` — CANCELLED no ocupa
+- [x] 3.5 Test `should_hide_full_slots` — tramo con 0 plazas no aparece
+- [x] 3.6 Test `should_return_empty_list_when_pista_in_mantenimiento` — sin revelar motivo
+
+## 4. TDD — Tests de integración del endpoint (RED, MockMvc + Spring Security)
+
+- [x] 4.1 Test: `GET /api/reservas/disponibles?fecha=2025-08-01` como USER autenticado → 200 con tramos
+- [x] 4.2 Test: como ADMIN autenticado → 200
+- [x] 4.3 Test: sin `Authorization` → 401
+- [x] 4.4 Test: con JWT expirado → 401
+- [x] 4.5 Test: `fecha` en formato inválido (`15-06-2025`) → 400 `VALIDATION_ERROR`
+- [x] 4.6 Test: sin parámetro `fecha` → 400 `VALIDATION_ERROR`
+- [x] 4.7 Test: pista en MANTENIMIENTO → 200 con `tramosDisponibles: []`
+
+## 5. Migración — V7 reservations + participants
+
+- [x] 5.1 Crear `V7__create_reservations_and_participants.sql` con `CREATE EXTENSION IF NOT EXISTS btree_gist`
+- [x] 5.2 Crear enums `reservation_status` y `reservation_channel` (data-model §3.3)
+- [x] 5.3 Crear tabla `reservations` con columnas, FK `owner_id → users(id)` (ON DELETE RESTRICT), checks `chk_res_duration`/`chk_res_end_time`/`chk_res_start_minutes`
+- [x] 5.4 Crear índices `idx_res_owner_id`, `idx_res_date_status` (parcial), `idx_res_date_start`, `idx_res_owner_date`, `idx_res_owner_status` (parcial)
+- [x] 5.5 Crear constraint `excl_res_no_overlap` EXCLUDE USING gist sobre `tsrange(date+start, date+end, '[)')` parcial `WHERE status <> 'CANCELLED'`
+- [x] 5.6 Crear tabla `participants` con FKs (`reservation_id` CASCADE, `user_id` SET NULL), checks e índices (data-model §3.4)
+
+## 6. Implementación — Dominio y persistencia
+
+- [x] 6.1 Crear entidad `Reservation` (mapea `reservations`) en la capa de dominio
+- [x] 6.2 Crear entidad `Participant` (mapea `participants`)
+- [x] 6.3 Crear puerto de salida de lectura (p.ej. `ReservationQueryPort`) con consulta de reservas activas por fecha
+- [x] 6.4 Implementar repositorio Spring Data JPA del puerto, usando el índice parcial `idx_res_date_status`
+
+## 7. Implementación — Capa Application (cálculo de disponibilidad)
+
+- [x] 7.1 Crear `DisponibilidadService` que lee `system_config` (max_participants, pista_state) vía su puerto
+- [x] 7.2 Implementar el cálculo de tramos libres por fecha (RN-RES-01, RN-RES-02) considerando estados activos
+- [x] 7.3 Cortocircuitar a lista vacía cuando `pista_state = MANTENIMIENTO` (RN-RES-04)
+- [x] 7.4 Crear DTOs `DisponibilidadResponse` y `TramoDisponible` (`horaInicio`, `duracionMinutos`, `plazasLibres`) alineados con `docs/openapi.yaml`
+- [x] 7.5 Añadir caché de 30 s por `fecha` y un punto de invalidación reutilizable por Wave 3
+
+## 8. Implementación — Controlador REST
+
+- [x] 8.1 Crear `ReservaDisponibilidadController` con `GET /api/reservas/disponibles`
+- [x] 8.2 Validar `fecha` (obligatoria, formato `YYYY-MM-DD`) → 400 `VALIDATION_ERROR` vía `GlobalExceptionHandler`
+- [x] 8.3 Asegurar autorización: USER y ADMIN permitidos, anónimo 401 (SecurityConfig)
+
+## 9. Verificación final
+
+- [x] 9.1 `mvn test` — toda la suite en verde (migración + unit + integración). Nuevos tests: 18/18 verdes (4 IT de migración SKIPPED por falta de Docker local; se ejecutan en CI). Errores preexistentes de otros `*IT/*E2E` por ausencia de Docker, ajenos a este change.
+- [x] 9.2 ArchUnit: las reglas de arquitectura hexagonal siguen pasando (6/6)
+- [ ] 9.3 JaCoCo: cobertura dentro del umbral del proyecto (verificación delegada al orquestador con `mvn verify`)
+- [x] 9.4 Verificar contrato del endpoint contra `docs/openapi.yaml` (`/reservas/disponibles`)
+- [ ] 9.5 Commit y push a `feat/13-disponibilidad-pistas` (reservado al orquestador — NO commitear desde el agente)


### PR DESCRIPTION
## Resumen
Implementa la capability **disponibilidad-pistas** (US-006, Wave 2A) en TDD:
- Migración Flyway **V7**: `reservations` + `participants`, enums, índices y el constraint anti-solapamiento `excl_res_no_overlap` (`EXCLUDE USING gist` sobre `tsrange`, `btree_gist`) — **D-RES-01 Opción A**, fiel a `docs/data-model.md` §3.3/§3.4.
- Endpoint `GET /api/reservas/disponibles?fecha=YYYY-MM-DD` (USER/ADMIN): tramos libres 08:00–23:00 (60 min), plazas parciales, PENDING_CONFIRMATION ocupa, CANCELLED no, MANTENIMIENTO → `[]`, validación de fecha (400), auth obligatoria (401).
- Nuevo bounded context `com.padelpro.reservas` (hexagonal) + caché 30 s con hook de invalidación para Wave 3.

## OpenSpec
Change `openspec/changes/disponibilidad-pistas/` (proposal, design, spec delta, tasks).

## Testing
- `DisponibilidadServiceTest` 7/7 ✅ · `ReservaDisponibilidadE2ETest` 7/7 ✅ · ArchUnit 6/6 ✅
- `ReservationsMigrationIT` 4/4 ✅ validados contra **PostgreSQL 15 real** (constraint `excl_res_no_overlap` + `btree_gist`) vía Postgres por docker-compose (Vía A), por la incompatibilidad de Testcontainers/docker-java con el Docker Desktop local. En CI Linux corren vía Testcontainers (fallback incluido).

## Notas
- La suite IT completa con cobertura JaCoCo al 80 % requiere CI con Docker nativo (no existe workflow aún; ver #156 y propuesta de CI).

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/api/reservas/disponibles` endpoint to query available court time slots by date
  * Returns available slots with free seats and duration information
  * Returns empty availability when court is under maintenance

* **Chores**
  * Added caching for availability queries with 30-second refresh interval
  * Added database schema for reservation and participant data management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->