### PR TITLE
chore(infra): bump Testcontainers 1.19.7 → 1.21.3 (#156)

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -24,7 +24,7 @@
         <java.version>17</java.version>
         <jjwt.version>0.12.5</jjwt.version>
         <bucket4j.version>8.9.0</bucket4j.version>
-        <testcontainers.version>1.19.7</testcontainers.version>
+        <testcontainers.version>1.21.3</testcontainers.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Resumen
Sube `testcontainers.version` 1.19.7 → **1.21.3** (docker-java 3.4.x) en `backend/pom.xml`.

## Motivación
Modernización para compatibilidad con Docker Engine recientes. Nota: en el Docker Desktop local (29.2.1) persiste un `400` de docker-java independiente de la versión; el valor de este bump se materializa en **CI Linux con Docker nativo**, donde Testcontainers corre la suite IT completa.

## Alcance
Cambio de infra aislado, sin tocar código de features. No rompe la suite existente (mismos resultados que antes del bump en local).

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)