### PR TITLE
ci: pipeline GitHub Actions + despliegue AWS EC2 (#163)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,78 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    branches: [develop]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    name: Build y Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout del código
+        uses: actions/checkout@v4
+
+      # ---------- Backend: Spring Boot / JDK 17 / Maven ----------
+      - name: Configurar JDK 17 (Temurin) + caché Maven
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      - name: Backend — build + tests (unit + IT Testcontainers + gate JaCoCo)
+        run: mvn -B -f backend/pom.xml verify
+
+      - name: Publicar informe de cobertura JaCoCo
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-report
+          path: backend/target/site/jacoco/
+          if-no-files-found: ignore
+
+      # ---------- Frontend: React + Vite / Node 20 ----------
+      - name: Configurar Node 20 + caché npm
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Frontend — instalar dependencias
+        working-directory: ./frontend
+        run: npm ci
+
+      - name: Frontend — lint
+        working-directory: ./frontend
+        run: npm run lint
+
+      - name: Frontend — tests (vitest)
+        working-directory: ./frontend
+        run: npm run test
+
+      - name: Frontend — build
+        working-directory: ./frontend
+        run: npm run build
+
+  deploy:
+    name: Desplegar en EC2
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    # Solo despliega en push a develop. Los pull_request NUNCA despliegan.
+    if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
+    steps:
+      - name: Conectar por SSH y desplegar
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            set -e
+            cd ~/PadelPro
+            git pull origin develop
+            docker compose down
+            docker compose up -d --build

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -135,6 +135,15 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Apache HttpClient 5 — gives TestRestTemplate a request factory that supports the HTTP
+             PATCH method (the default SimpleClientHttpRequestFactory does not). Needed by E2E tests
+             that exercise PATCH /api/usuarios/me. Version managed by the Spring Boot BOM. -->
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- H2 Database — in-memory database for tests -->
         <dependency>
             <groupId>com.h2database</groupId>

--- a/backend/src/main/java/com/padelpro/auth/infrastructure/web/filter/RateLimitFilter.java
+++ b/backend/src/main/java/com/padelpro/auth/infrastructure/web/filter/RateLimitFilter.java
@@ -57,7 +57,7 @@ public class RateLimitFilter extends OncePerRequestFilter {
                                     FilterChain filterChain)
             throws ServletException, IOException {
 
-        String path = request.getServletPath();
+        String path = resolvePath(request);
         String method = request.getMethod();
 
         if (!"POST".equalsIgnoreCase(method)) {
@@ -111,6 +111,24 @@ public class RateLimitFilter extends OncePerRequestFilter {
                 .refillGreedy(capacity, REFILL_PERIOD)
                 .build();
         return Bucket.builder().addLimit(limit).build();
+    }
+
+    /**
+     * Resolves the application-relative request path in a way that is robust across both real
+     * servlet containers and Spring MockMvc.
+     *
+     * <p>{@code getServletPath()} returns the empty string under MockMvc (the path lands in the
+     * request URI instead), which silently disabled rate limiting in MockMvc-based tests. Using
+     * {@code getRequestURI()} minus the context path works identically in both environments and
+     * also survives a non-root deployment context path.
+     */
+    private String resolvePath(HttpServletRequest request) {
+        String uri = request.getRequestURI();
+        String contextPath = request.getContextPath();
+        if (contextPath != null && !contextPath.isEmpty() && uri.startsWith(contextPath)) {
+            uri = uri.substring(contextPath.length());
+        }
+        return uri;
     }
 
     private String extractClientIp(HttpServletRequest request) {

--- a/backend/src/test/java/com/padelpro/auth/infrastructure/web/AdminAuditE2ETest.java
+++ b/backend/src/test/java/com/padelpro/auth/infrastructure/web/AdminAuditE2ETest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpEntity;
@@ -22,13 +21,8 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
-import org.springframework.test.context.jdbc.Sql;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
+
+import com.padelpro.shared.PostgresIntegrationTest;
 
 import java.time.OffsetDateTime;
 import java.util.Map;
@@ -38,26 +32,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * E2E tests for the audit log — verifies that real application flows
  * (login, unauthorized access attempt) produce expected entries in the audit log.
+ *
+ * <p>Extends {@link PostgresIntegrationTest} so it runs both locally (Vía A external Postgres on
+ * :5433) and in CI (Testcontainers).
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@Testcontainers
-@ActiveProfiles("it")
-@Sql(scripts = "/sql/cleanup.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
-class AdminAuditE2ETest {
-
-    @Container
-    static final PostgreSQLContainer<?> postgres =
-            new PostgreSQLContainer<>("postgres:15-alpine")
-                    .withDatabaseName("padelpro_test")
-                    .withUsername("padelpro_test")
-                    .withPassword("padelpro_test");
-
-    @DynamicPropertySource
-    static void configureProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", postgres::getJdbcUrl);
-        registry.add("spring.datasource.username", postgres::getUsername);
-        registry.add("spring.datasource.password", postgres::getPassword);
-    }
+class AdminAuditE2ETest extends PostgresIntegrationTest {
 
     @LocalServerPort
     int port;

--- a/backend/src/test/java/com/padelpro/auth/infrastructure/web/AdminAuditIntegrationTest.java
+++ b/backend/src/test/java/com/padelpro/auth/infrastructure/web/AdminAuditIntegrationTest.java
@@ -7,21 +7,13 @@ import com.padelpro.auth.domain.model.UserRole;
 import com.padelpro.auth.domain.model.UserStatus;
 import com.padelpro.auth.infrastructure.persistence.AuditLogRepository;
 import com.padelpro.auth.infrastructure.persistence.UserRepository;
+import com.padelpro.shared.PostgresIntegrationTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
-import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.time.OffsetDateTime;
 
@@ -34,29 +26,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * Integration tests for AdminAuditController (/api/admin/audit).
  *
- * <p>Uses a real PostgreSQL 15 container and MockMvc. Cleanup is performed before
+ * <p>Uses MockMvc against a real PostgreSQL. Cleanup is performed before
  * each test via /sql/cleanup.sql.
+ *
+ * <p>Extends {@link PostgresIntegrationTest} so it runs both locally (external
+ * Postgres on :5433) and in CI (Testcontainers).
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@AutoConfigureMockMvc
-@Testcontainers
-@ActiveProfiles("it")
-@Sql(scripts = "/sql/cleanup.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
-class AdminAuditIntegrationTest {
-
-    @Container
-    static final PostgreSQLContainer<?> postgres =
-            new PostgreSQLContainer<>("postgres:15-alpine")
-                    .withDatabaseName("padelpro_test")
-                    .withUsername("padelpro_test")
-                    .withPassword("padelpro_test");
-
-    @DynamicPropertySource
-    static void configureProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", postgres::getJdbcUrl);
-        registry.add("spring.datasource.username", postgres::getUsername);
-        registry.add("spring.datasource.password", postgres::getPassword);
-    }
+class AdminAuditIntegrationTest extends PostgresIntegrationTest {
 
     @Autowired private MockMvc mockMvc;
     @Autowired private UserRepository userRepository;

--- a/backend/src/test/java/com/padelpro/auth/infrastructure/web/AuthControllerIntegrationTest.java
+++ b/backend/src/test/java/com/padelpro/auth/infrastructure/web/AuthControllerIntegrationTest.java
@@ -1,22 +1,16 @@
 package com.padelpro.auth.infrastructure.web;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.padelpro.shared.PostgresIntegrationTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
-import org.springframework.test.context.jdbc.Sql;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.web.servlet.MockMvc;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
 import java.util.Map;
 
@@ -25,33 +19,16 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 /**
- * T-024 — Integration tests for AuthController using a real PostgreSQL container.
+ * T-024 — Integration tests for AuthController against a real PostgreSQL 15.
  *
- * <p>TDD RED phase: all tests should FAIL with HTTP 500 (UnsupportedOperationException
- * propagated from the stub handlers) until Wave 3 implements the actual logic.
+ * <p>Extends {@link PostgresIntegrationTest} so it runs both locally (Vía A external
+ * Postgres on :5433) and in CI (Testcontainers). Replaces the previous direct
+ * {@code @Testcontainers} setup, which could not run on hosts where the Docker Desktop
+ * named pipe breaks the docker-java client.
  *
  * <p>Scenarios covered: R-1.1 to R-1.4 (register) and R-2.1 to R-2.4 (login).
- * Uses @Testcontainers + PostgreSQL 15 (real DB, not H2).
  */
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-@AutoConfigureMockMvc
-@Testcontainers
-@ActiveProfiles("it")
-class AuthControllerIntegrationTest {
-
-    @Container
-    static final PostgreSQLContainer<?> postgres =
-            new PostgreSQLContainer<>("postgres:15-alpine")
-                    .withDatabaseName("padelpro_test")
-                    .withUsername("padelpro_test")
-                    .withPassword("padelpro_test");
-
-    @DynamicPropertySource
-    static void configureProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", postgres::getJdbcUrl);
-        registry.add("spring.datasource.username", postgres::getUsername);
-        registry.add("spring.datasource.password", postgres::getPassword);
-    }
+class AuthControllerIntegrationTest extends PostgresIntegrationTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -59,10 +36,22 @@ class AuthControllerIntegrationTest {
     @Autowired
     private ObjectMapper objectMapper;
 
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    /**
+     * A unique client IP per test method. The RateLimitFilter keys its (singleton, context-cached)
+     * buckets by client IP, so without a fresh IP per method the 5 login / 3 register per-minute
+     * limits would leak between methods (and across IT classes sharing the Spring context),
+     * making register/login return 429 instead of the asserted status. Each method here makes few
+     * enough auth calls to stay under the limit on its own IP.
+     */
+    private String clientIp;
+
     @BeforeEach
-    @Sql("/sql/cleanup.sql")
-    void cleanUp() {
-        // @Sql annotation handles the cleanup; method body intentionally empty
+    void assignUniqueClientIp() {
+        clientIp = "10." + (int) (Math.random() * 254 + 1) + "."
+                + (int) (Math.random() * 254 + 1) + "." + (int) (Math.random() * 254 + 1);
     }
 
     // -------------------------------------------------------------------------
@@ -71,6 +60,14 @@ class AuthControllerIntegrationTest {
 
     private String json(Object obj) throws Exception {
         return objectMapper.writeValueAsString(obj);
+    }
+
+    /** POST builder for an auth endpoint, tagged with this test's unique client IP. */
+    private MockHttpServletRequestBuilder authPost(String path, String body) {
+        return post(path)
+                .header("X-Forwarded-For", clientIp)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body);
     }
 
     private Map<String, String> registerBody(String firstName, String lastName,
@@ -94,9 +91,7 @@ class AuthControllerIntegrationTest {
     @Test
     @DisplayName("R-1.1: register should return 201 with user id, email and role when valid")
     void register_should_return_201_with_user_id_email_and_role_when_valid() throws Exception {
-        mockMvc.perform(post("/api/auth/register")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(json(registerBody("Alice", "Smith", "alice@example.com", "Password1"))))
+        mockMvc.perform(authPost("/api/auth/register", json(registerBody("Alice", "Smith", "alice@example.com", "Password1"))))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id").isNumber())
                 .andExpect(jsonPath("$.email").value("alice@example.com"))
@@ -107,15 +102,11 @@ class AuthControllerIntegrationTest {
     @DisplayName("R-1.2: register should return 409 when email already exists")
     void register_should_return_409_when_email_already_exists() throws Exception {
         // First registration succeeds
-        mockMvc.perform(post("/api/auth/register")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(json(registerBody("Alice", "Smith", "dup@example.com", "Password1"))))
+        mockMvc.perform(authPost("/api/auth/register", json(registerBody("Alice", "Smith", "dup@example.com", "Password1"))))
                 .andExpect(status().isCreated());
 
         // Second registration with same email → 409
-        mockMvc.perform(post("/api/auth/register")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(json(registerBody("Alice2", "Smith", "dup@example.com", "Password1"))))
+        mockMvc.perform(authPost("/api/auth/register", json(registerBody("Alice2", "Smith", "dup@example.com", "Password1"))))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.error").value("EMAIL_ALREADY_REGISTERED"));
     }
@@ -123,9 +114,7 @@ class AuthControllerIntegrationTest {
     @Test
     @DisplayName("R-1.3a: register should return 400 when password is too short")
     void register_should_return_400_when_password_is_too_short() throws Exception {
-        mockMvc.perform(post("/api/auth/register")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(json(registerBody("Bob", "Jones", "bob@example.com", "Pass1"))))
+        mockMvc.perform(authPost("/api/auth/register", json(registerBody("Bob", "Jones", "bob@example.com", "Pass1"))))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error").value("INVALID_PASSWORD"))
                 .andExpect(jsonPath("$.details", hasItem("MIN_LENGTH_8")));
@@ -134,9 +123,7 @@ class AuthControllerIntegrationTest {
     @Test
     @DisplayName("R-1.3b: register should return 400 when password has no uppercase")
     void register_should_return_400_when_password_has_no_uppercase() throws Exception {
-        mockMvc.perform(post("/api/auth/register")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(json(registerBody("Carol", "White", "carol@example.com", "password1"))))
+        mockMvc.perform(authPost("/api/auth/register", json(registerBody("Carol", "White", "carol@example.com", "password1"))))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error").value("INVALID_PASSWORD"))
                 .andExpect(jsonPath("$.details", hasItem("REQUIRES_UPPERCASE")));
@@ -145,9 +132,7 @@ class AuthControllerIntegrationTest {
     @Test
     @DisplayName("R-1.3c: register should return 400 when password has no number")
     void register_should_return_400_when_password_has_no_number() throws Exception {
-        mockMvc.perform(post("/api/auth/register")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(json(registerBody("Dave", "Brown", "dave@example.com", "PasswordNoDigit"))))
+        mockMvc.perform(authPost("/api/auth/register", json(registerBody("Dave", "Brown", "dave@example.com", "PasswordNoDigit"))))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error").value("INVALID_PASSWORD"))
                 .andExpect(jsonPath("$.details", hasItem("REQUIRES_NUMBER")));
@@ -159,9 +144,7 @@ class AuthControllerIntegrationTest {
         // firstName is absent
         String bodyMissingFirstName = "{\"lastName\":\"Smith\",\"email\":\"frank@example.com\",\"password\":\"Password1\"}";
 
-        mockMvc.perform(post("/api/auth/register")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(bodyMissingFirstName))
+        mockMvc.perform(authPost("/api/auth/register", bodyMissingFirstName))
                 .andExpect(status().isBadRequest());
     }
 
@@ -170,23 +153,22 @@ class AuthControllerIntegrationTest {
     // =========================================================================
 
     /**
-     * Registers and activates a user, then returns its email.
-     * The activation step is done directly via SQL because the RegistrationService
-     * creates users as PENDING and Wave 3 will add the activation logic.
-     * For the login integration tests we need an ACTIVE user in the DB.
+     * Registers a user (created PENDING by RegistrationService) and then flips its status to
+     * ACTIVE directly via JDBC. Login requires an ACTIVE account (RN-AUTH-08 → 403
+     * {@code ACCOUNT_NOT_ACTIVE} otherwise), and the self-service activation flow is not part
+     * of this suite, so we activate the row out-of-band to set up the login scenarios.
      */
     private void registerAndActivateUser(String email, String password) throws Exception {
         // Register — creates PENDING user
-        mockMvc.perform(post("/api/auth/register")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(json(registerBody("Test", "User", email, password))))
+        mockMvc.perform(authPost("/api/auth/register", json(registerBody("Test", "User", email, password))))
                 .andExpect(status().isCreated());
 
-        // Activate via JDBC (bypassing the not-yet-implemented activation flow)
-        // Spring will inject the DataSource; we use @Sql for the setup query
-        // NOTE: This annotation-based approach is used at class level when needed.
-        // Here we accept that login tests may fail with ACCOUNT_NOT_ACTIVE if
-        // the registration service correctly sets PENDING — that is the TDD-red expectation.
+        // Activate via JDBC so the login path sees an ACTIVE account
+        int updated = jdbcTemplate.update(
+                "UPDATE users SET status = 'ACTIVE' WHERE email = ?", email);
+        org.assertj.core.api.Assertions.assertThat(updated)
+                .as("exactly one user row should be activated for %s", email)
+                .isEqualTo(1);
     }
 
     @Test
@@ -196,9 +178,7 @@ class AuthControllerIntegrationTest {
         registerAndActivateUser("user@example.com", "Password1");
 
         // Act & Assert
-        mockMvc.perform(post("/api/auth/login")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(json(loginBody("user@example.com", "Password1"))))
+        mockMvc.perform(authPost("/api/auth/login", json(loginBody("user@example.com", "Password1"))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.access_token").isNotEmpty())
                 .andExpect(jsonPath("$.token_type").value("Bearer"))
@@ -210,9 +190,7 @@ class AuthControllerIntegrationTest {
     @Test
     @DisplayName("R-2.2: login should return 401 when email is not found")
     void login_should_return_401_when_email_not_found() throws Exception {
-        mockMvc.perform(post("/api/auth/login")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(json(loginBody("nobody@example.com", "Password1"))))
+        mockMvc.perform(authPost("/api/auth/login", json(loginBody("nobody@example.com", "Password1"))))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.error").value("AUTH_INVALID_CREDENTIALS"));
     }
@@ -224,9 +202,7 @@ class AuthControllerIntegrationTest {
         registerAndActivateUser("wrongpw@example.com", "Password1");
 
         // Act & Assert — wrong password
-        mockMvc.perform(post("/api/auth/login")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(json(loginBody("wrongpw@example.com", "WrongPassword1"))))
+        mockMvc.perform(authPost("/api/auth/login", json(loginBody("wrongpw@example.com", "WrongPassword1"))))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.error").value("AUTH_INVALID_CREDENTIALS"));
     }
@@ -238,38 +214,39 @@ class AuthControllerIntegrationTest {
         registerAndActivateUser("anti@example.com", "Password1");
 
         // Unknown email
-        var unknownResult = mockMvc.perform(post("/api/auth/login")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(json(loginBody("unknown@example.com", "Password1"))))
+        var unknownResult = mockMvc.perform(authPost("/api/auth/login", json(loginBody("unknown@example.com", "Password1"))))
                 .andExpect(status().isUnauthorized())
                 .andReturn();
 
         // Wrong password for known email
-        var wrongPwResult = mockMvc.perform(post("/api/auth/login")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(json(loginBody("anti@example.com", "WrongPassword1"))))
+        var wrongPwResult = mockMvc.perform(authPost("/api/auth/login", json(loginBody("anti@example.com", "WrongPassword1"))))
                 .andExpect(status().isUnauthorized())
                 .andReturn();
 
-        // Response bodies must be identical (anti-enumeration)
-        String bodyUnknown = unknownResult.getResponse().getContentAsString();
-        String bodyWrongPw = wrongPwResult.getResponse().getContentAsString();
-        org.assertj.core.api.Assertions.assertThat(bodyUnknown).isEqualTo(bodyWrongPw);
+        // Response bodies must be identical for anti-enumeration purposes, EXCEPT the
+        // volatile "timestamp" field (which legitimately differs between the two calls).
+        // Compare the JSON trees with "timestamp" removed.
+        ObjectNode unknownJson = (ObjectNode) objectMapper.readTree(
+                unknownResult.getResponse().getContentAsString());
+        ObjectNode wrongPwJson = (ObjectNode) objectMapper.readTree(
+                wrongPwResult.getResponse().getContentAsString());
+        unknownJson.remove("timestamp");
+        wrongPwJson.remove("timestamp");
+
+        org.assertj.core.api.Assertions.assertThat(unknownJson)
+                .as("login error body (ignoring timestamp) must be identical for unknown email and wrong password")
+                .isEqualTo(wrongPwJson);
     }
 
     @Test
     @DisplayName("R-2.4: login should return 403 when account is PENDING")
     void login_should_return_403_when_account_is_pending() throws Exception {
         // Register creates a PENDING user — do NOT activate
-        mockMvc.perform(post("/api/auth/register")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(json(registerBody("Pending", "User", "pending@example.com", "Password1"))))
+        mockMvc.perform(authPost("/api/auth/register", json(registerBody("Pending", "User", "pending@example.com", "Password1"))))
                 .andExpect(status().isCreated());
 
         // Login attempt on PENDING account → 403
-        mockMvc.perform(post("/api/auth/login")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(json(loginBody("pending@example.com", "Password1"))))
+        mockMvc.perform(authPost("/api/auth/login", json(loginBody("pending@example.com", "Password1"))))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.error").value("ACCOUNT_NOT_ACTIVE"));
     }

--- a/backend/src/test/java/com/padelpro/auth/infrastructure/web/RateLimitIntegrationTest.java
+++ b/backend/src/test/java/com/padelpro/auth/infrastructure/web/RateLimitIntegrationTest.java
@@ -1,25 +1,16 @@
 package com.padelpro.auth.infrastructure.web;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.BeforeEach;
+import com.padelpro.shared.PostgresIntegrationTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
-import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.util.Map;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
@@ -29,32 +20,19 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * T-025 — Integration tests for rate limiting on auth endpoints.
  *
- * <p>TDD RED phase: tests should FAIL because the rate-limiting filter/interceptor
- * is not yet implemented (Wave 3). Requests will return 500 (stub) rather than
- * the expected 429.
+ * <p>Extends {@link PostgresIntegrationTest} so it runs both locally (Vía A external Postgres on
+ * :5433) and in CI (Testcontainers), replacing the previous direct {@code @Testcontainers} setup.
+ *
+ * <p>The {@link com.padelpro.auth.infrastructure.web.filter.RateLimitFilter} keys its buckets by
+ * client IP. Under MockMvc every request reports the same remote address, and the bucket store is a
+ * singleton shared across the cached Spring context — so buckets would leak between test methods.
+ * To keep each scenario independent, every method uses a distinct {@code X-Forwarded-For} IP (the
+ * filter honours that header), giving it a fresh bucket regardless of execution order.
  *
  * <p>Scenarios covered: R-4.2 (login rate limit) and R-4.3 (register rate limit).
  * Thresholds: 5 login attempts / min per IP, 3 register attempts / min per IP.
  */
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-@AutoConfigureMockMvc
-@Testcontainers
-@ActiveProfiles("it")
-class RateLimitIntegrationTest {
-
-    @Container
-    static final PostgreSQLContainer<?> postgres =
-            new PostgreSQLContainer<>("postgres:15-alpine")
-                    .withDatabaseName("padelpro_test")
-                    .withUsername("padelpro_test")
-                    .withPassword("padelpro_test");
-
-    @DynamicPropertySource
-    static void configureProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", postgres::getJdbcUrl);
-        registry.add("spring.datasource.username", postgres::getUsername);
-        registry.add("spring.datasource.password", postgres::getPassword);
-    }
+class RateLimitIntegrationTest extends PostgresIntegrationTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -62,10 +40,13 @@ class RateLimitIntegrationTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @BeforeEach
-    @Sql("/sql/cleanup.sql")
-    void cleanUp() {
-        // @Sql handles cleanup; method body intentionally empty
+    /** A unique client IP per test method so each gets its own rate-limit bucket. */
+    private String clientIp;
+
+    @org.junit.jupiter.api.BeforeEach
+    void assignUniqueClientIp() {
+        clientIp = "10." + (int) (Math.random() * 254 + 1) + "."
+                + (int) (Math.random() * 254 + 1) + "." + (int) (Math.random() * 254 + 1);
     }
 
     // -------------------------------------------------------------------------
@@ -87,14 +68,17 @@ class RateLimitIntegrationTest {
 
     private ResultActions performLogin(String email) throws Exception {
         return mockMvc.perform(post("/api/auth/login")
+                .header("X-Forwarded-For", clientIp)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(loginJson(email, "WrongPassword1")));
     }
 
     private ResultActions performRegister(String emailSuffix) throws Exception {
+        // Unique email per run so a re-run against a non-cleaned DB never hits 409 before 429.
         return mockMvc.perform(post("/api/auth/register")
+                .header("X-Forwarded-For", clientIp)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(registerJson("rate" + emailSuffix + "@example.com")));
+                .content(registerJson("rate-" + UUID.randomUUID() + "-" + emailSuffix + "@example.com")));
     }
 
     // =========================================================================
@@ -140,6 +124,7 @@ class RateLimitIntegrationTest {
 
         // The 6th request must carry Retry-After
         mockMvc.perform(post("/api/auth/login")
+                        .header("X-Forwarded-For", clientIp)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(loginJson("retryafter@example.com", "WrongPassword1")))
                 .andExpect(status().isTooManyRequests())

--- a/backend/src/test/java/com/padelpro/auth/infrastructure/web/SecurityE2ETest.java
+++ b/backend/src/test/java/com/padelpro/auth/infrastructure/web/SecurityE2ETest.java
@@ -6,11 +6,11 @@ import com.padelpro.auth.domain.model.UserRole;
 import com.padelpro.auth.domain.model.UserStatus;
 import com.padelpro.auth.infrastructure.persistence.AuditLogRepository;
 import com.padelpro.auth.infrastructure.persistence.UserRepository;
+import com.padelpro.shared.PostgresIntegrationTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -18,14 +18,8 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
-import org.springframework.test.context.jdbc.Sql;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.time.OffsetDateTime;
 import java.util.Map;
@@ -33,33 +27,22 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * TDD RED — E2E tests for security (TestRestTemplate, full HTTP stack).
- * These tests FAIL until the production components are implemented (GREEN phase).
+ * E2E tests for security across the full HTTP stack (TestRestTemplate + real Tomcat).
+ *
+ * <p>Extends {@link PostgresIntegrationTest} so it runs both locally (Vía A external Postgres on
+ * :5433) and in CI (Testcontainers), replacing the previous direct {@code @Testcontainers} setup.
+ *
+ * <p>The autowired {@link TestRestTemplate} is reconfigured with an Apache HttpClient 5 request
+ * factory in {@link #setUp()} because the default {@code SimpleClientHttpRequestFactory} (JDK
+ * {@code HttpURLConnection}) rejects the HTTP {@code PATCH} method ("Invalid HTTP method: PATCH"),
+ * which the role-escalation test below requires.
  *
  * Tests cover:
  *  - Full cycle: user deactivated mid-session → JWT still valid → 403 with JSON
  *  - Role escalation via PATCH /api/usuarios/me is silently ignored
  *  - Audit log accumulates denied accesses
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@Testcontainers
-@ActiveProfiles("it")
-@Sql(scripts = "/sql/cleanup.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
-class SecurityE2ETest {
-
-    @Container
-    static final PostgreSQLContainer<?> postgres =
-            new PostgreSQLContainer<>("postgres:15-alpine")
-                    .withDatabaseName("padelpro_test")
-                    .withUsername("padelpro_test")
-                    .withPassword("padelpro_test");
-
-    @DynamicPropertySource
-    static void configureProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", postgres::getJdbcUrl);
-        registry.add("spring.datasource.username", postgres::getUsername);
-        registry.add("spring.datasource.password", postgres::getPassword);
-    }
+class SecurityE2ETest extends PostgresIntegrationTest {
 
     @Autowired private TestRestTemplate restTemplate;
     @Autowired private UserRepository userRepository;
@@ -74,6 +57,10 @@ class SecurityE2ETest {
 
     @BeforeEach
     void setUp() {
+        // Default request factory (HttpURLConnection) cannot send PATCH — swap in HttpClient 5.
+        restTemplate.getRestTemplate()
+                .setRequestFactory(new HttpComponentsClientHttpRequestFactory());
+
         OffsetDateTime now = OffsetDateTime.now();
 
         activeUser = userRepository.saveAndFlush(new User(

--- a/backend/src/test/java/com/padelpro/auth/infrastructure/web/SecurityIntegrationTest.java
+++ b/backend/src/test/java/com/padelpro/auth/infrastructure/web/SecurityIntegrationTest.java
@@ -6,22 +6,14 @@ import com.padelpro.auth.domain.model.UserRole;
 import com.padelpro.auth.domain.model.UserStatus;
 import com.padelpro.auth.infrastructure.persistence.AuditLogRepository;
 import com.padelpro.auth.infrastructure.persistence.UserRepository;
+import com.padelpro.shared.PostgresIntegrationTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
-import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.time.OffsetDateTime;
 
@@ -41,27 +33,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  *  - Webhook routes not blocked by JWT filter
  *
  * These tests FAIL until the production components are implemented (GREEN phase).
+ *
+ * <p>Extends {@link PostgresIntegrationTest} so it runs both locally (external
+ * Postgres on :5433) and in CI (Testcontainers).
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@AutoConfigureMockMvc
-@Testcontainers
-@ActiveProfiles("it")
-@Sql(scripts = "/sql/cleanup.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
-class SecurityIntegrationTest {
-
-    @Container
-    static final PostgreSQLContainer<?> postgres =
-            new PostgreSQLContainer<>("postgres:15-alpine")
-                    .withDatabaseName("padelpro_test")
-                    .withUsername("padelpro_test")
-                    .withPassword("padelpro_test");
-
-    @DynamicPropertySource
-    static void configureProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", postgres::getJdbcUrl);
-        registry.add("spring.datasource.username", postgres::getUsername);
-        registry.add("spring.datasource.password", postgres::getPassword);
-    }
+class SecurityIntegrationTest extends PostgresIntegrationTest {
 
     @Autowired private MockMvc mockMvc;
     @Autowired private UserRepository userRepository;

--- a/backend/src/test/java/com/padelpro/usuarios/infrastructure/web/AdminUsuariosControllerIntegrationTest.java
+++ b/backend/src/test/java/com/padelpro/usuarios/infrastructure/web/AdminUsuariosControllerIntegrationTest.java
@@ -6,22 +6,14 @@ import com.padelpro.auth.domain.model.User;
 import com.padelpro.auth.domain.model.UserRole;
 import com.padelpro.auth.domain.model.UserStatus;
 import com.padelpro.auth.infrastructure.persistence.UserRepository;
+import com.padelpro.shared.PostgresIntegrationTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
-import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.time.OffsetDateTime;
 import java.util.Map;
@@ -36,27 +28,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 /**
  * Integration tests for AdminUsuariosController (/api/admin/usuarios).
+ *
+ * <p>Extends {@link PostgresIntegrationTest} so it runs both locally (external
+ * Postgres on :5433) and in CI (Testcontainers).
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@AutoConfigureMockMvc
-@Testcontainers
-@ActiveProfiles("it")
-@Sql(scripts = "/sql/cleanup.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
-class AdminUsuariosControllerIntegrationTest {
-
-    @Container
-    static final PostgreSQLContainer<?> postgres =
-            new PostgreSQLContainer<>("postgres:15-alpine")
-                    .withDatabaseName("padelpro_test")
-                    .withUsername("padelpro_test")
-                    .withPassword("padelpro_test");
-
-    @DynamicPropertySource
-    static void configureProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", postgres::getJdbcUrl);
-        registry.add("spring.datasource.username", postgres::getUsername);
-        registry.add("spring.datasource.password", postgres::getPassword);
-    }
+class AdminUsuariosControllerIntegrationTest extends PostgresIntegrationTest {
 
     @Autowired private MockMvc mockMvc;
     @Autowired private ObjectMapper objectMapper;

--- a/backend/src/test/java/com/padelpro/usuarios/infrastructure/web/UsuariosMeControllerIntegrationTest.java
+++ b/backend/src/test/java/com/padelpro/usuarios/infrastructure/web/UsuariosMeControllerIntegrationTest.java
@@ -6,22 +6,14 @@ import com.padelpro.auth.domain.model.User;
 import com.padelpro.auth.domain.model.UserRole;
 import com.padelpro.auth.domain.model.UserStatus;
 import com.padelpro.auth.infrastructure.persistence.UserRepository;
+import com.padelpro.shared.PostgresIntegrationTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
-import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.time.OffsetDateTime;
 import java.util.Map;
@@ -35,27 +27,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 /**
  * Integration tests for UsuariosMeController (GET/PATCH /api/usuarios/me).
+ *
+ * <p>Extends {@link PostgresIntegrationTest} so it runs both locally (external
+ * Postgres on :5433) and in CI (Testcontainers).
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@AutoConfigureMockMvc
-@Testcontainers
-@ActiveProfiles("it")
-@Sql(scripts = "/sql/cleanup.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
-class UsuariosMeControllerIntegrationTest {
-
-    @Container
-    static final PostgreSQLContainer<?> postgres =
-            new PostgreSQLContainer<>("postgres:15-alpine")
-                    .withDatabaseName("padelpro_test")
-                    .withUsername("padelpro_test")
-                    .withPassword("padelpro_test");
-
-    @DynamicPropertySource
-    static void configureProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", postgres::getJdbcUrl);
-        registry.add("spring.datasource.username", postgres::getUsername);
-        registry.add("spring.datasource.password", postgres::getPassword);
-    }
+class UsuariosMeControllerIntegrationTest extends PostgresIntegrationTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   # PostgreSQL 15 — Base de datos
   db:
@@ -8,7 +6,9 @@ services:
     environment:
       POSTGRES_DB: padelpro
       POSTGRES_USER: padelpro
-      POSTGRES_PASSWORD: padelpro_dev
+      # En producción el password se inyecta desde el .env del EC2 (D4).
+      # Fallback solo para desarrollo local.
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-padelpro_dev}
     ports:
       - "5432:5432"
     volumes:
@@ -32,7 +32,7 @@ services:
       # Database
       SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/padelpro
       SPRING_DATASOURCE_USERNAME: padelpro
-      SPRING_DATASOURCE_PASSWORD: padelpro_dev
+      SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD:-padelpro_dev}
       SPRING_JPA_HIBERNATE_DDL_AUTO: validate
       SPRING_FLYWAY_ENABLED: 'true'
       SPRING_FLYWAY_LOCATIONS: classpath:db/migration
@@ -69,8 +69,9 @@ services:
       dockerfile: Dockerfile
     container_name: padelpro-frontend
     environment:
-      # Vite proxy config: /api → http://backend:8080/api
-      VITE_API_BASE_URL: http://backend:8080
+      # El bundle se sirve como build estático (D6). Las llamadas a /api se
+      # enrutan al backend vía el proxy de `vite preview` (ver vite.config.ts).
+      VITE_API_BASE_URL: ${VITE_API_BASE_URL:-http://backend:8080}
       NODE_ENV: production
     ports:
       - "5173:5173"
@@ -85,8 +86,6 @@ services:
     networks:
       - padelpro-network
     restart: unless-stopped
-    volumes:
-      - ./frontend/src:/app/src
 
 networks:
   padelpro-network:

--- a/docs/DEPLOYMENT-RUNBOOK.md
+++ b/docs/DEPLOYMENT-RUNBOOK.md
@@ -1,0 +1,278 @@
+# Runbook de despliegue — PadelPro (CI/CD a AWS EC2)
+
+Capability: `ci-cd-deploy` (Issue #163). Replica el modelo del proyecto de referencia
+`AI4Devs-pipeline-202602-ro`: un único workflow de GitHub Actions
+(`.github/workflows/ci.yml`) que construye + testea y, en `push` a `develop`,
+despliega por SSH a una instancia EC2 con `docker compose`.
+
+> Decisiones de diseño en `openspec/changes/ci-cd-aws-deploy/design.md` (D1–D6).
+
+---
+
+## 1. Arquitectura del pipeline
+
+```
+push a develop ─┐
+pull_request ───┼─► build-and-test (ubuntu-latest)
+workflow_dispatch┘        │  backend: mvn verify (unit + IT Testcontainers + gate JaCoCo 80%)
+                          │  frontend: npm ci → lint → test → build
+                          ▼
+                  ¿push a develop?  ── sí ──► deploy (SSH a EC2)
+                          │                      git pull + docker compose down + up -d --build
+                          └── pull_request ──► (NO despliega)
+```
+
+- **`build-and-test`** corre siempre (push, PR, dispatch). El runner de GitHub tiene
+  Docker, así que los IT con `@Testcontainers` se ejecutan de verdad.
+- **`deploy`** solo corre con `if: github.ref == 'refs/heads/develop' && github.event_name == 'push'`.
+  Los pull requests **nunca** despliegan.
+- **BD** = contenedor postgres del compose con volumen persistente (D2). No RDS.
+- **Flyway** se aplica al arrancar el backend (`ddl-auto=validate`, `depends_on: db healthy`) (D3).
+- **Frontend en producción** = build estático servido por `vite preview` (D6), no `vite dev`.
+- **Exposición** = IP:puerto directa, sin TLS en v1 (D5).
+
+---
+
+## 2. Provisión AWS (MANUAL — pendiente para el usuario)
+
+> Estos pasos **no** los ejecuta el pipeline ni este change (no hay credenciales AWS
+> disponibles). Hazlos una sola vez.
+
+### 2.1 Crear el par de claves SSH
+
+```bash
+# En tu máquina local
+ssh-keygen -t ed25519 -f ~/.ssh/padelpro_ec2 -C "padelpro-deploy"
+# Genera ~/.ssh/padelpro_ec2 (privada) y ~/.ssh/padelpro_ec2.pub (pública)
+```
+
+En la consola de AWS EC2 → **Key Pairs** → importa la clave **pública**
+(`padelpro_ec2.pub`), o crea el par y descarga el `.pem`.
+
+### 2.2 Lanzar la instancia EC2
+
+- AMI: **Ubuntu Server 22.04 LTS** (o Amazon Linux 2023).
+- Tipo: **t3.small** mínimo recomendado (backend Spring Boot + postgres + build de imágenes
+  necesitan RAM; `t2.micro` puede quedarse corto al compilar). Ajustar según presupuesto.
+- Almacenamiento: 30 GB gp3 (imágenes Docker + volumen postgres).
+- Asocia el par de claves del paso 2.1.
+
+### 2.3 Security Group
+
+| Tipo       | Puerto | Origen            | Motivo                          |
+|------------|--------|-------------------|---------------------------------|
+| SSH        | 22     | tu IP / IP runner | acceso administración + deploy  |
+| Custom TCP | 8080   | 0.0.0.0/0         | backend (API + `/actuator/health`) |
+| Custom TCP | 5173   | 0.0.0.0/0         | frontend (build estático)       |
+
+> ⚠️ Restringir SSH (22) a tu IP. GitHub Actions usa rangos de IP dinámicos; si quieres
+> restringir el deploy por IP, considera un self-hosted runner o un bastion. En v1 se
+> acepta SSH abierto a tu IP de administración (el deploy usa la clave privada en Secrets).
+> 🔒 8080/5173 abiertos al mundo porque no hay TLS/proxy en v1 (D5). Endurecer en evolución.
+
+### 2.4 Instalar Docker + Docker Compose en el EC2
+
+```bash
+ssh -i ~/.ssh/padelpro_ec2 ubuntu@<EC2_PUBLIC_IP>
+
+# Docker Engine + plugin compose (Ubuntu)
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl git
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+# Permitir docker sin sudo al usuario de deploy
+sudo usermod -aG docker $USER
+newgrp docker   # o reconecta la sesión SSH
+
+docker --version && docker compose version
+```
+
+### 2.5 Clonar el repositorio en el EC2
+
+El script de deploy hace `cd ~/PadelPro && git pull origin develop`. La ruta debe ser
+`~/PadelPro` (home del usuario de deploy). Si usas otra ruta, ajústala en el `script:`
+del job `deploy` en `.github/workflows/ci.yml`.
+
+```bash
+cd ~
+git clone https://github.com/<ORG>/<REPO>.git PadelPro
+cd PadelPro
+git checkout develop
+```
+
+> Para repos privados, configura un deploy key o un PAT de solo lectura en el remoto del
+> EC2 (`git remote set-url origin git@github.com:...` + deploy key), de modo que
+> `git pull origin develop` funcione sin credenciales interactivas.
+
+### 2.6 Crear el `.env` en el EC2 (NUNCA se commitea — D4)
+
+```bash
+cd ~/PadelPro
+cp .env.example .env
+nano .env
+```
+
+Rellena con valores **fuertes y aleatorios** de producción:
+
+```dotenv
+# ≥ 32 caracteres, aleatorio
+JWT_SECRET=<openssl rand -base64 48>
+JWT_EXPIRATION=3600
+JWT_REFRESH_EXPIRATION=604800
+
+# ≥ 32 caracteres, aleatorio
+ENCRYPTION_KEY=<openssl rand -base64 48>
+
+POSTGRES_DB=padelpro
+POSTGRES_USER=padelpro
+POSTGRES_PASSWORD=<password fuerte>
+
+SPRING_PROFILES_ACTIVE=prod
+
+# IP/DNS público del EC2 con el puerto del backend
+VITE_API_BASE_URL=http://<EC2_PUBLIC_IP>:8080
+```
+
+Genera secretos con `openssl rand -base64 48`. El `.env` está cubierto por `.gitignore`.
+
+### 2.7 Alta de los GitHub Repo Secrets
+
+Repo → **Settings → Secrets and variables → Actions → New repository secret**:
+
+| Secret        | Valor                                                       |
+|---------------|------------------------------------------------------------|
+| `EC2_HOST`    | IP pública (o DNS) del EC2                                  |
+| `EC2_USER`    | usuario SSH (`ubuntu` en Ubuntu AMI; `ec2-user` en Amazon Linux) |
+| `EC2_SSH_KEY` | **contenido completo** de la clave privada `~/.ssh/padelpro_ec2` (incluye `-----BEGIN/END-----`) |
+
+> 🔒 Los secretos de la app (`JWT_SECRET`, etc.) **no** se dan de alta en GitHub: viven solo
+> en el `.env` del EC2. El workflow solo necesita las credenciales SSH.
+
+---
+
+## 3. Primer deploy
+
+1. Asegúrate de que los 3 Secrets están dados de alta (2.7) y el `.env` existe en el EC2 (2.6).
+2. Haz merge de este change a `develop` (o un `push` a `develop`).
+3. En la pestaña **Actions** del repo verás `CI/CD Pipeline`:
+   - `build-and-test` debe quedar verde.
+   - `deploy` se conecta por SSH y ejecuta el script.
+4. Verifica (sección 5).
+
+También puedes lanzarlo manualmente con **workflow_dispatch** (botón *Run workflow*) — pero
+ojo: `workflow_dispatch` solo dispara `deploy` si la rama seleccionada es `develop` y el
+evento se evalúa como push (el `if` exige `github.event_name == 'push'`, así que el dispatch
+ejecuta build+test pero **no** deploy; para desplegar a mano usa el procedimiento de la
+sección 6).
+
+---
+
+## 4. Operación manual en el EC2
+
+```bash
+cd ~/PadelPro
+
+# Ver estado y salud
+docker compose ps
+docker compose logs -f backend     # logs en vivo
+docker compose logs db | tail
+
+# Reconstruir y levantar (lo que hace el deploy)
+git pull origin develop
+docker compose down
+docker compose up -d --build
+```
+
+---
+
+## 5. Verificación post-deploy (checklist)
+
+- [ ] `docker compose ps` muestra `db`, `backend`, `frontend` en estado `running (healthy)`.
+- [ ] Backend: `curl http://<EC2_PUBLIC_IP>:8080/actuator/health` → `{"status":"UP"}`.
+- [ ] Flyway aplicado: `docker compose logs backend | grep -i flyway` muestra las migraciones
+      aplicadas y `Successfully validated`/`Migrating`.
+- [ ] Frontend: abrir `http://<EC2_PUBLIC_IP>:5173` carga la SPA.
+- [ ] Login / llamada a `/api/...` desde el frontend responde (proxy de `vite preview`).
+- [ ] (CI) El run de Actions quedó verde y el artefacto `jacoco-report` está disponible.
+
+---
+
+## 6. Rollback
+
+El workflow es additivo: revertirlo = borrar/revertir `.github/workflows/ci.yml`.
+
+Para revertir un **deploy concreto** en el EC2:
+
+```bash
+cd ~/PadelPro
+git log --oneline -10                  # localiza el commit estable anterior
+git checkout <commit-anterior>
+docker compose up -d --build
+# Cuando se corrija en develop:
+git checkout develop && git pull && docker compose up -d --build
+```
+
+> El volumen `padelpro_postgres_data` persiste entre `down`/`up`, así que un rollback de
+> código **no** borra datos. Cuidado con rollbacks que crucen una migración Flyway destructiva
+> (Flyway no hace down-migrations): restaura desde backup (sección 7) si una migración cambió
+> el esquema de forma incompatible.
+
+---
+
+## 7. Backup de la base de datos (postgres en contenedor — D2)
+
+Como la BD vive en un contenedor (no RDS), **programa backups**. Volumen:
+`padelpro_postgres_data`.
+
+### Backup manual / por cron
+
+```bash
+# Dump comprimido con timestamp
+docker compose exec -T db pg_dump -U padelpro padelpro | gzip > ~/backups/padelpro_$(date +%F_%H%M).sql.gz
+```
+
+Cron diario (en el EC2):
+
+```bash
+mkdir -p ~/backups
+crontab -e
+# Añade (backup diario a las 03:00, retiene 14 días):
+0 3 * * * cd ~/PadelPro && docker compose exec -T db pg_dump -U padelpro padelpro | gzip > ~/backups/padelpro_$(date +\%F).sql.gz && find ~/backups -name 'padelpro_*.sql.gz' -mtime +14 -delete
+```
+
+> Recomendado: sincronizar `~/backups` a S3 (`aws s3 sync ~/backups s3://<bucket>/padelpro/`)
+> para no perder los backups si se pierde la instancia.
+
+### Restore
+
+```bash
+gunzip -c ~/backups/padelpro_<fecha>.sql.gz | docker compose exec -T db psql -U padelpro -d padelpro
+```
+
+### Evolución a RDS (futuro)
+
+D2 fija postgres en contenedor para v1 (paridad con la referencia). Migración a **AWS RDS**
+recomendada cuando los datos sean críticos (fiscales: reservas/pagos): aporta backups
+automáticos, point-in-time recovery y HA. La migración consistiría en: provisionar RDS,
+`pg_dump`/`pg_restore` del volumen actual, y apuntar `SPRING_DATASOURCE_URL` al endpoint RDS
+en el `.env` (eliminando el servicio `db` del compose).
+
+---
+
+## 8. Resumen de variables y secretos
+
+| Dónde            | Variable                                   | Uso                                   |
+|------------------|--------------------------------------------|---------------------------------------|
+| GitHub Secrets   | `EC2_HOST`, `EC2_USER`, `EC2_SSH_KEY`      | conexión SSH del job `deploy`         |
+| `.env` del EC2   | `JWT_SECRET`, `ENCRYPTION_KEY`             | seguridad de la app                   |
+| `.env` del EC2   | `POSTGRES_PASSWORD`, `POSTGRES_DB/USER`    | credenciales BD (db + datasource)     |
+| `.env` del EC2   | `SPRING_PROFILES_ACTIVE=prod`              | perfil productivo (Flyway validate)   |
+| `.env` del EC2   | `VITE_API_BASE_URL`                        | URL del backend para el frontend      |
+
+🔒 Ningún secreto vive en el repositorio ni viaja por el workflow (D4). `.gitignore` cubre
+`.env`, `.env.*`, `*.env`, `*.pem`, `*.key`.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,44 +1,40 @@
-# Multi-stage build: build + serve
+# Multi-stage build: compila el bundle y sirve el BUILD ESTÁTICO (producción).
+# D6 (design.md): en producción NO se usa `vite dev`. Se sirve el contenido de
+# `dist/` con `vite preview` (sin dependencias nuevas; `vite` ya está en devDeps).
+# Para desarrollo con HMR, los desarrolladores usan `npm run dev` en local.
+
 FROM node:20-alpine AS builder
 
 WORKDIR /app
 
-# Copy package files
+# Instalar dependencias (capa cacheable)
 COPY package*.json ./
-
-# Install dependencies
 RUN npm ci --quiet
 
-# Copy source
+# Copiar fuentes y construir el bundle estático
 COPY . .
-
-# Build
 RUN npm run build
 
-# Runtime stage
+# ---------- Runtime: sirve el build estático ----------
 FROM node:20-alpine
 
 WORKDIR /app
 
-# Create non-root user
+# Crear usuario no-root
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 
-# Install serve to run the app in dev mode (with HMR support via proxy)
-RUN npm install -g vite
+# Solo lo necesario para servir el bundle: dist/, vite y su config
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/vite.config.ts ./vite.config.ts
 
-# Copy everything (for Vite dev server with hot reload)
-COPY . .
-
-# Install dependencies again for runtime
-RUN npm ci --quiet
-
-# Set ownership to non-root user
 RUN chown -R appuser:appgroup /app
 
 EXPOSE 5173
 
-# Run as non-root user
 USER appuser
 
-# Run Vite dev server (permite hot reload)
-CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]
+# `vite preview` sirve el contenido estático de dist/ (no es el dev server).
+# Se fuerza host 0.0.0.0 y puerto 5173 para mantener paridad con el compose.
+CMD ["npx", "vite", "preview", "--host", "0.0.0.0", "--port", "5173"]

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -13,4 +13,19 @@ export default defineConfig({
       },
     },
   },
+  // `vite preview` sirve el build estático en producción (D6). Tiene su propia
+  // config de proxy/host independiente del dev server.
+  preview: {
+    port: 5173,
+    host: true,
+    // Permite acceso por IP pública o DNS del EC2 (D5: exposición IP:puerto directa).
+    allowedHosts: true,
+    proxy: {
+      '/api': {
+        // En el contenedor de producción el backend es accesible vía la red del compose.
+        target: 'http://backend:8080',
+        changeOrigin: true,
+      },
+    },
+  },
 });

--- a/openspec/changes/ci-cd-aws-deploy/.openspec.yaml
+++ b/openspec/changes/ci-cd-aws-deploy/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-20

--- a/openspec/changes/ci-cd-aws-deploy/design.md
+++ b/openspec/changes/ci-cd-aws-deploy/design.md
@@ -1,0 +1,66 @@
+## Context
+
+PadelPro carece de CI/CD. El stack: backend Spring Boot 3 / JDK 17 / Maven con suite JUnit + Testcontainers y gate JaCoCo (80% líneas); frontend React + Vite (scripts `lint` eslint, `test` vitest, `build` tsc+vite); orquestación con `docker-compose.yml` (postgres + backend:8080 + frontend:5173, con healthchecks) y Dockerfiles multistage ya existentes. `BASE_BRANCH` del repo es `develop`. Identidad de operaciones git/gh: `orquestadoria`.
+
+El proyecto de referencia `AI4Devs-pipeline-202602-ro` resuelve esto con un único `ci.yml`: un job de build+test y un job de deploy que entra por SSH a una EC2 y hace `git pull` + `docker compose down` + `docker compose up -d --build`. Este change replica ese modelo adaptándolo al stack de PadelPro.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Ejecutar build + test de backend (incluidos IT con Testcontainers) y frontend en cada push/PR.
+- Validar el gate de cobertura JaCoCo en CI.
+- Desplegar automáticamente a una EC2 vía `docker compose` por SSH tras pasar los tests, solo en la rama de release.
+- Gestionar secretos sin commitearlos.
+
+**Non-Goals:**
+- IaC, ECS/EKS, autoescalado, zero-downtime, RDS gestionado, TLS gestionado por la nube (más allá de lo mínimo), observabilidad avanzada.
+
+## Decisions
+
+### D1 — Rama que dispara el deploy: `develop`
+Se despliega desde `develop` (rama base y entorno único de demo del proyecto). `pull_request` ejecuta solo build+test; el `push` a `develop` ejecuta build+test y, si pasan, deploy.
+- **Alternativa:** `main` con git-flow de promoción → más ceremonia, innecesaria para el entorno único actual.
+- **Razón:** el repo trabaja sobre `develop`; un solo entorno desplegado simplifica el MVP.
+
+### D2 — Base de datos en producción: contenedor postgres del compose
+Se mantiene el servicio `db` del `docker-compose.yml` (datos en volumen Docker), igual que la referencia.
+- **Alternativa:** AWS RDS gestionado → más robusto (backups, HA) pero se sale del "de la misma forma" y añade coste/configuración.
+- **Razón:** replicar el modelo de referencia; RDS queda como evolución futura documentada. **Riesgo de pérdida de datos** mitigado abajo.
+
+### D3 — Migraciones Flyway en el deploy: automáticas al arrancar
+El backend ejecuta Flyway en el arranque (`ddl-auto=validate`); `docker compose up -d --build` levanta el backend que aplica las migraciones pendientes contra el `db`. No hay paso manual.
+- **Razón:** el flujo ya está integrado en la app; el deploy solo reconstruye y reinicia. El `depends_on: db healthy` del compose garantiza el orden.
+
+### D4 — Gestión de secretos: GitHub Secrets (SSH) + `.env` en el EC2 (app)
+`EC2_HOST`/`EC2_USER`/`EC2_SSH_KEY` viven como GitHub repo secrets y solo los usa el job de deploy. Los secretos de la app (`JWT_SECRET`, `ENCRYPTION_KEY`, `POSTGRES_PASSWORD`, …) viven en un `.env` creado a mano en el EC2 y leído por `docker compose`; nunca se commitean ni viajan por el workflow.
+- **Razón:** mínima superficie de exposición; el workflow solo necesita credenciales SSH, no los secretos de la app.
+
+### D5 — Exposición: IP:puerto directo en v1 (TLS como evolución)
+Se expone el frontend (5173) y el backend (8080) directamente vía el security group, como la referencia. TLS/dominio con reverse proxy (Caddy/nginx) se anota como mejora futura.
+- **Razón:** paridad con la referencia y simplicidad del MVP; el endurecimiento (TLS, proxy) es un segundo paso.
+
+### D6 — Frontend servido como build estático (ajuste vs dev)
+El `frontend/Dockerfile` actual arranca `vite dev` (`--host`). Para producción conviene servir el build estático (p.ej. `vite preview` o nginx sirviendo `dist/`). Se evalúa como ajuste deploy-ready dentro de este change.
+- **Razón:** `vite dev` no es apto para producción; pero el cambio debe ser mínimo y no romper el `docker-compose` de desarrollo.
+
+## Risks / Trade-offs
+
+- **Pérdida de datos del postgres en contenedor (D2)** → si el volumen se borra, se pierden reservas/pagos (datos fiscales). **Mitigación:** volumen Docker nombrado persistente (ya en el compose), documentar backup periódico de `pg_dump` en el runbook; marcar RDS como evolución.
+- **`docker compose down` provoca downtime** en cada deploy → ventana de indisponibilidad breve. **Mitigación:** aceptable para un entorno de demo; el deploy reconstruye en segundos/minutos; zero-downtime queda fuera de alcance.
+- **Secretos mal gestionados** → fuga de credenciales. **Mitigación:** D4 (nunca en repo ni en logs del workflow); `.gitignore` cubre `.env`; los secrets SSH solo en el job de deploy.
+- **IT de Testcontainers lentos/flaky en CI** → builds largos. **Mitigación:** caché de Maven y de imágenes; si la suite IT es muy lenta, separar en job aparte (evolución).
+- **Migración Flyway fallida en deploy (D3)** → backend no arranca, healthcheck falla. **Mitigación:** el job build-and-test ya ejecuta las migraciones contra Postgres real (Testcontainers), detectando fallos antes del deploy; el `healthcheck` del compose evidencia el fallo.
+- **`vite dev` en producción (D6)** → rendimiento/seguridad pobres si no se ajusta. **Mitigación:** servir build estático en el Dockerfile de deploy.
+
+## Migration Plan
+
+1. Provisión manual del EC2 (Docker instalado, repo clonado, `.env` creado, security group con puertos) — documentado en el runbook.
+2. Alta de los GitHub Secrets `EC2_HOST`/`EC2_USER`/`EC2_SSH_KEY`.
+3. Merge del workflow a `develop` → primer build+test; si pasa, primer deploy automático.
+4. **Rollback:** el workflow es additivo (un fichero + secrets); revertir = borrar `ci.yml`. Un deploy fallido se revierte en el EC2 con `git checkout <commit-anterior> && docker compose up -d --build`.
+
+## Open Questions
+
+- ¿Una sola EC2 para todo (db+back+front) o separar la BD desde el principio? (v1: todo junto, D2.)
+- ¿Región AWS y tipo de instancia? (lo fija el runbook; no afecta al workflow.)
+- ¿Se quiere también un job que publique el informe de cobertura como artefacto/PR comment?

--- a/openspec/changes/ci-cd-aws-deploy/proposal.md
+++ b/openspec/changes/ci-cd-aws-deploy/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+PadelPro no tiene integración continua: los tests no se ejecutan automáticamente en ningún sitio (solo actúa el revisor CodeRabbit). Como consecuencia, 8 IT de auth/usuarios que usan `@Testcontainers` nunca se validan (el host de desarrollo no tiene Docker accesible), y cada merge depende de ejecuciones locales manuales. Tampoco existe despliegue automatizado. Se quiere replicar el modelo probado del proyecto de referencia `AI4Devs-pipeline-202602-ro`: un único workflow de GitHub Actions que construye, testea y despliega a una instancia AWS EC2 vía `docker compose` por SSH.
+
+Fase del producto: **fase-1** (infraestructura transversal).
+
+## What Changes
+
+- **Workflow `.github/workflows/ci.yml`** (nuevo):
+  - **Triggers**: `push` a la rama de release, `pull_request` (solo build+test, sin deploy) y `workflow_dispatch`.
+  - **Job `build-and-test`** (ubuntu-latest):
+    - Backend: `setup-java` JDK 17 (Temurin) + caché Maven; `mvn -f backend/pom.xml verify` (unit + IT). El runner de GitHub **tiene Docker**, así que los IT con `@Testcontainers` (los 8 de auth/usuarios y los de reservas) **sí se ejecutan** — cerrando el hueco actual. Respeta el gate JaCoCo (`jacoco-check`, 80% líneas).
+    - Frontend: `setup-node` 20 + `npm ci` + `npm run lint` + `npm run test` (vitest) + `npm run build` en `./frontend`.
+  - **Job `deploy`**: `needs: build-and-test`, condicionado a la rama de release; `appleboy/ssh-action` con secrets `EC2_HOST`/`EC2_USER`/`EC2_SSH_KEY`; script: `cd <repo>` → `git pull` → `docker compose down` → `docker compose up -d --build`.
+- **Reutilización de la infra existente**: `docker-compose.yml` + Dockerfiles (db postgres + backend Spring Boot 8080 + frontend Vite 5173, con healthchecks). Verificar que son deploy-ready y que las variables de producción (`JWT_SECRET`, `ENCRYPTION_KEY`, `POSTGRES_PASSWORD`, `SPRING_PROFILES_ACTIVE=prod`, `VITE_API_BASE_URL`) se inyectan desde un `.env` presente en el EC2 (nunca commiteado).
+- **Runbook de despliegue** en `docs/`: provisión del EC2, instalación de Docker, clonado del repo, creación del `.env`, y lista de GitHub Secrets.
+
+## Capabilities
+
+### New Capabilities
+- `ci-cd-deploy`: pipeline de integración continua (build + test de backend y frontend con cobertura) y despliegue continuo a AWS EC2 vía `docker compose` por SSH, gated tras los tests y limitado a la rama de release.
+
+### Modified Capabilities
+_(ninguna — no cambia comportamiento de capabilities de producto existentes)_
+
+## Impact
+
+- **Nuevo**: `.github/workflows/ci.yml`.
+- **Ajustes posibles**: `docker-compose.yml` / Dockerfiles para ser deploy-ready (p.ej. servir el frontend en modo build en vez de `vite dev`, inyección de `.env`).
+- **GitHub repo secrets** (nuevos): `EC2_HOST`, `EC2_USER`, `EC2_SSH_KEY` (y, si se decide inyectar por workflow, los de la app).
+- **Infraestructura AWS** (provisión manual, documentada): 1 instancia EC2 con Docker, security group con los puertos necesarios, par de claves SSH.
+- **docs/**: runbook de despliegue + lista de secrets.
+- **Sin cambios** en el código de aplicación (backend/frontend).
+
+## Fuera de alcance
+
+- IaC (Terraform/CloudFormation): la referencia provisiona el EC2 a mano; este change replica ese modelo.
+- AWS ECS/EKS, autoescalado, balanceador de carga, despliegue blue-green / zero-downtime.
+- Migración a base de datos gestionada (AWS RDS) — anotada como evolución futura (decisión D2).
+- Configuración productiva de Redsys y Telegram (pertenecen a otras capabilities).
+- Observabilidad/alertas avanzadas (existe `AI4Devs-monitoring-202602-ro` aparte).

--- a/openspec/changes/ci-cd-aws-deploy/specs/ci-cd-deploy/spec.md
+++ b/openspec/changes/ci-cd-aws-deploy/specs/ci-cd-deploy/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: Build y test automáticos de backend y frontend
+
+El pipeline SHALL ejecutar, en cada `push` y `pull_request`, el build y los tests del backend (unit + integración con Testcontainers) y del frontend (lint, test, build), y SHALL fallar si cualquiera de ellos falla.
+
+#### Scenario: Push con backend y frontend correctos
+- **WHEN** se hace `push` de un commit cuyo backend y frontend compilan y todos los tests pasan
+- **THEN** el job `build-and-test` termina en verde
+- **AND** los IT del backend con `@Testcontainers` se ejecutan realmente (el runner dispone de Docker)
+
+#### Scenario: Test de backend fallido bloquea el pipeline
+- **WHEN** un commit introduce un test de backend que falla
+- **THEN** el job `build-and-test` termina en rojo
+- **AND** el job de deploy NO se ejecuta
+
+#### Scenario: Build de frontend fallido bloquea el pipeline
+- **WHEN** un commit rompe la compilación del frontend (`npm run build`)
+- **THEN** el job `build-and-test` termina en rojo
+
+### Requirement: Gate de cobertura de código
+
+El pipeline SHALL hacer fallar el build cuando la cobertura de líneas del backend esté por debajo del umbral del proyecto (`jacoco-check`, 80%).
+
+#### Scenario: Cobertura por debajo del umbral
+- **WHEN** la cobertura de líneas del backend cae por debajo del 80%
+- **THEN** `mvn verify` falla en el job `build-and-test` por el gate de JaCoCo
+
+### Requirement: Despliegue continuo a AWS EC2 tras pasar los tests
+
+El pipeline SHALL desplegar la aplicación a la instancia EC2 únicamente cuando el job de build y test ha pasado y el evento es un `push` a la rama de release; el despliegue SHALL hacerse por SSH ejecutando `git pull` y reconstruyendo los servicios con `docker compose`.
+
+#### Scenario: Push a la rama de release con tests en verde
+- **WHEN** se hace `push` a la rama de release y `build-and-test` termina en verde
+- **THEN** el job `deploy` entra por SSH al EC2 y ejecuta `git pull` + `docker compose down` + `docker compose up -d --build`
+- **AND** los servicios (db, backend, frontend) quedan levantados con sus healthchecks en verde
+
+#### Scenario: Tests en rojo no despliegan
+- **WHEN** `build-and-test` termina en rojo
+- **THEN** el job `deploy` no se ejecuta y el estado del EC2 no cambia
+
+#### Scenario: Migraciones Flyway aplicadas en el arranque
+- **WHEN** el deploy levanta el backend con `docker compose up`
+- **THEN** Flyway aplica automáticamente las migraciones pendientes contra el postgres antes de aceptar tráfico, sin pasos manuales
+
+### Requirement: Los pull requests no despliegan
+
+El pipeline SHALL ejecutar solo build y test (nunca deploy) para eventos `pull_request`.
+
+#### Scenario: PR abierto contra la rama de release
+- **WHEN** se abre o actualiza un `pull_request`
+- **THEN** se ejecuta `build-and-test`
+- **AND** el job `deploy` no se ejecuta
+
+### Requirement: Aislamiento de secretos
+
+El pipeline SHALL obtener las credenciales SSH desde GitHub Secrets y SHALL NOT contener secretos en el repositorio ni exponerlos en los logs; los secretos de la aplicación SHALL residir en un `.env` presente en el EC2, fuera del control de versiones.
+
+#### Scenario: Credenciales SSH desde GitHub Secrets
+- **WHEN** el job `deploy` se conecta al EC2
+- **THEN** usa `EC2_HOST`, `EC2_USER` y `EC2_SSH_KEY` desde GitHub Secrets
+- **AND** ningún secreto aparece en el fichero del workflow ni en los logs de ejecución
+
+#### Scenario: Secretos de la aplicación no versionados
+- **WHEN** se inspecciona el repositorio
+- **THEN** no existe ningún `.env` con secretos commiteado (está cubierto por `.gitignore`)
+- **AND** la app en el EC2 lee sus secretos del `.env` local de la instancia

--- a/openspec/changes/ci-cd-aws-deploy/tasks.md
+++ b/openspec/changes/ci-cd-aws-deploy/tasks.md
@@ -1,50 +1,56 @@
 ## 0. Gestión y arranque (orquestador)
 
-- [ ] 0.1 Crear/identificar Issue en GitHub y obtener su número
-- [ ] 0.2 Crear rama `feat/<id>-ci-cd-aws-deploy` desde `develop` y push
+- [x] 0.1 Crear/identificar Issue en GitHub y obtener su número (#163)
+- [x] 0.2 Crear rama `feat/163-ci-cd-aws-deploy` desde `develop` y push
 - [ ] 0.3 Mover el item del Project v2 a "In Progress"
 
 ## 1. Workflow de CI — build y test
 
-- [ ] 1.1 Crear `.github/workflows/ci.yml` con triggers `push` a `develop`, `pull_request` y `workflow_dispatch`
-- [ ] 1.2 Job `build-and-test` (ubuntu-latest): checkout
-- [ ] 1.3 Backend: `actions/setup-java@v4` JDK 17 (Temurin) + caché Maven; `mvn -f backend/pom.xml verify` (unit + IT con Testcontainers + gate JaCoCo)
-- [ ] 1.4 Frontend: `actions/setup-node@v4` Node 20 + caché npm; `npm ci` + `npm run lint` + `npm run test` + `npm run build` en `./frontend`
-- [ ] 1.5 (Opcional) Publicar informe de cobertura JaCoCo como artefacto del workflow
+- [x] 1.1 Crear `.github/workflows/ci.yml` con triggers `push` a `develop`, `pull_request` y `workflow_dispatch`
+- [x] 1.2 Job `build-and-test` (ubuntu-latest): checkout
+- [x] 1.3 Backend: `actions/setup-java@v4` JDK 17 (Temurin) + caché Maven; `mvn -f backend/pom.xml verify` (unit + IT con Testcontainers + gate JaCoCo)
+- [x] 1.4 Frontend: `actions/setup-node@v4` Node 20 + caché npm; `npm ci` + `npm run lint` + `npm run test` + `npm run build` en `./frontend`
+- [x] 1.5 (Opcional) Publicar informe de cobertura JaCoCo como artefacto del workflow
 
 ## 2. Workflow de CD — deploy a EC2
 
-- [ ] 2.1 Job `deploy`: `needs: build-and-test`, `if` rama de release (`develop`) y evento `push`
-- [ ] 2.2 Usar `appleboy/ssh-action` con secrets `EC2_HOST` / `EC2_USER` / `EC2_SSH_KEY`
-- [ ] 2.3 Script remoto: `cd <repo>` → `git pull origin develop` → `docker compose down` → `docker compose up -d --build`
-- [ ] 2.4 Verificar que `pull_request` NO dispara `deploy` (solo `build-and-test`)
+- [x] 2.1 Job `deploy`: `needs: build-and-test`, `if` rama de release (`develop`) y evento `push`
+- [x] 2.2 Usar `appleboy/ssh-action` con secrets `EC2_HOST` / `EC2_USER` / `EC2_SSH_KEY`
+- [x] 2.3 Script remoto: `cd <repo>` → `git pull origin develop` → `docker compose down` → `docker compose up -d --build`
+- [x] 2.4 Verificar que `pull_request` NO dispara `deploy` (solo `build-and-test`)
 
 ## 3. Infra deploy-ready (docker)
 
-- [ ] 3.1 Revisar `docker-compose.yml`: inyección de `.env`, `restart: unless-stopped`, healthchecks, volumen persistente del postgres
-- [ ] 3.2 Ajustar `frontend/Dockerfile` para servir el build estático en producción (en vez de `vite dev`), sin romper el compose de desarrollo
-- [ ] 3.3 Confirmar que el backend aplica Flyway al arrancar con `SPRING_PROFILES_ACTIVE=prod` y que `depends_on: db healthy` ordena el arranque
-- [ ] 3.4 Verificar que `.gitignore` cubre `.env` y que no hay secretos commiteados
+- [x] 3.1 Revisar `docker-compose.yml`: inyección de `.env`, `restart: unless-stopped`, healthchecks, volumen persistente del postgres
+- [x] 3.2 Ajustar `frontend/Dockerfile` para servir el build estático en producción (en vez de `vite dev`), sin romper el compose de desarrollo
+- [x] 3.3 Confirmar que el backend aplica Flyway al arrancar con `SPRING_PROFILES_ACTIVE=prod` y que `depends_on: db healthy` ordena el arranque
+- [x] 3.4 Verificar que `.gitignore` cubre `.env` y que no hay secretos commiteados
 
 ## 4. Provisión AWS (manual, documentada)
 
-- [ ] 4.1 Crear instancia EC2 + par de claves SSH + security group (puertos backend/frontend/SSH)
-- [ ] 4.2 Instalar Docker + Docker Compose en el EC2
-- [ ] 4.3 Clonar el repo en el EC2 y crear el `.env` con los secretos de la app (`JWT_SECRET`, `ENCRYPTION_KEY`, `POSTGRES_PASSWORD`, `SPRING_PROFILES_ACTIVE=prod`, `VITE_API_BASE_URL`)
-- [ ] 4.4 Alta de los GitHub repo secrets `EC2_HOST`, `EC2_USER`, `EC2_SSH_KEY`
+> Pendiente — manual. Sin credenciales AWS; documentado paso a paso en `docs/DEPLOYMENT-RUNBOOK.md` §2.
+
+- [ ] 4.1 Crear instancia EC2 + par de claves SSH + security group (puertos backend/frontend/SSH) — pendiente, manual (runbook §2.1–2.3)
+- [ ] 4.2 Instalar Docker + Docker Compose en el EC2 — pendiente, manual (runbook §2.4)
+- [ ] 4.3 Clonar el repo en el EC2 y crear el `.env` con los secretos de la app — pendiente, manual (runbook §2.5–2.6)
+- [ ] 4.4 Alta de los GitHub repo secrets `EC2_HOST`, `EC2_USER`, `EC2_SSH_KEY` — pendiente, manual (runbook §2.7)
 
 ## 5. Documentación
 
-- [ ] 5.1 Runbook de despliegue en `docs/` (provisión EC2, Docker, clonado, `.env`, secrets, primer deploy)
-- [ ] 5.2 Documentar backup del postgres (`pg_dump`) y nota de evolución a RDS
-- [ ] 5.3 Documentar rollback (checkout commit anterior + `docker compose up -d --build`)
+- [x] 5.1 Runbook de despliegue en `docs/` (provisión EC2, Docker, clonado, `.env`, secrets, primer deploy)
+- [x] 5.2 Documentar backup del postgres (`pg_dump`) y nota de evolución a RDS
+- [x] 5.3 Documentar rollback (checkout commit anterior + `docker compose up -d --build`)
 
 ## 6. Verificación
 
-- [ ] 6.1 Abrir un PR de prueba → confirmar que corre `build-and-test` y NO `deploy`
-- [ ] 6.2 Forzar un test rojo → confirmar que el pipeline falla y no despliega
-- [ ] 6.3 Merge a `develop` → confirmar build+test verde y deploy automático
-- [ ] 6.4 Comprobar en el EC2: contenedores arriba, healthchecks verdes, Flyway aplicado, app accesible (backend `/actuator/health`, frontend cargando)
+> Pendiente — manual. No se puede ejecutar el workflow real ni el EC2 desde aquí.
+> Validación local realizada: YAML del workflow OK (PyYAML), `docker compose config` OK.
+> Checklist de verificación en vivo en `docs/DEPLOYMENT-RUNBOOK.md` §5.
+
+- [ ] 6.1 Abrir un PR de prueba → confirmar que corre `build-and-test` y NO `deploy` — pendiente, manual
+- [ ] 6.2 Forzar un test rojo → confirmar que el pipeline falla y no despliega — pendiente, manual
+- [ ] 6.3 Merge a `develop` → confirmar build+test verde y deploy automático — pendiente, manual
+- [ ] 6.4 Comprobar en el EC2: contenedores arriba, healthchecks verdes, Flyway aplicado, app accesible — pendiente, manual (runbook §5)
 
 ## 7. Cierre
 

--- a/openspec/changes/ci-cd-aws-deploy/tasks.md
+++ b/openspec/changes/ci-cd-aws-deploy/tasks.md
@@ -1,0 +1,52 @@
+## 0. Gestión y arranque (orquestador)
+
+- [ ] 0.1 Crear/identificar Issue en GitHub y obtener su número
+- [ ] 0.2 Crear rama `feat/<id>-ci-cd-aws-deploy` desde `develop` y push
+- [ ] 0.3 Mover el item del Project v2 a "In Progress"
+
+## 1. Workflow de CI — build y test
+
+- [ ] 1.1 Crear `.github/workflows/ci.yml` con triggers `push` a `develop`, `pull_request` y `workflow_dispatch`
+- [ ] 1.2 Job `build-and-test` (ubuntu-latest): checkout
+- [ ] 1.3 Backend: `actions/setup-java@v4` JDK 17 (Temurin) + caché Maven; `mvn -f backend/pom.xml verify` (unit + IT con Testcontainers + gate JaCoCo)
+- [ ] 1.4 Frontend: `actions/setup-node@v4` Node 20 + caché npm; `npm ci` + `npm run lint` + `npm run test` + `npm run build` en `./frontend`
+- [ ] 1.5 (Opcional) Publicar informe de cobertura JaCoCo como artefacto del workflow
+
+## 2. Workflow de CD — deploy a EC2
+
+- [ ] 2.1 Job `deploy`: `needs: build-and-test`, `if` rama de release (`develop`) y evento `push`
+- [ ] 2.2 Usar `appleboy/ssh-action` con secrets `EC2_HOST` / `EC2_USER` / `EC2_SSH_KEY`
+- [ ] 2.3 Script remoto: `cd <repo>` → `git pull origin develop` → `docker compose down` → `docker compose up -d --build`
+- [ ] 2.4 Verificar que `pull_request` NO dispara `deploy` (solo `build-and-test`)
+
+## 3. Infra deploy-ready (docker)
+
+- [ ] 3.1 Revisar `docker-compose.yml`: inyección de `.env`, `restart: unless-stopped`, healthchecks, volumen persistente del postgres
+- [ ] 3.2 Ajustar `frontend/Dockerfile` para servir el build estático en producción (en vez de `vite dev`), sin romper el compose de desarrollo
+- [ ] 3.3 Confirmar que el backend aplica Flyway al arrancar con `SPRING_PROFILES_ACTIVE=prod` y que `depends_on: db healthy` ordena el arranque
+- [ ] 3.4 Verificar que `.gitignore` cubre `.env` y que no hay secretos commiteados
+
+## 4. Provisión AWS (manual, documentada)
+
+- [ ] 4.1 Crear instancia EC2 + par de claves SSH + security group (puertos backend/frontend/SSH)
+- [ ] 4.2 Instalar Docker + Docker Compose en el EC2
+- [ ] 4.3 Clonar el repo en el EC2 y crear el `.env` con los secretos de la app (`JWT_SECRET`, `ENCRYPTION_KEY`, `POSTGRES_PASSWORD`, `SPRING_PROFILES_ACTIVE=prod`, `VITE_API_BASE_URL`)
+- [ ] 4.4 Alta de los GitHub repo secrets `EC2_HOST`, `EC2_USER`, `EC2_SSH_KEY`
+
+## 5. Documentación
+
+- [ ] 5.1 Runbook de despliegue en `docs/` (provisión EC2, Docker, clonado, `.env`, secrets, primer deploy)
+- [ ] 5.2 Documentar backup del postgres (`pg_dump`) y nota de evolución a RDS
+- [ ] 5.3 Documentar rollback (checkout commit anterior + `docker compose up -d --build`)
+
+## 6. Verificación
+
+- [ ] 6.1 Abrir un PR de prueba → confirmar que corre `build-and-test` y NO `deploy`
+- [ ] 6.2 Forzar un test rojo → confirmar que el pipeline falla y no despliega
+- [ ] 6.3 Merge a `develop` → confirmar build+test verde y deploy automático
+- [ ] 6.4 Comprobar en el EC2: contenedores arriba, healthchecks verdes, Flyway aplicado, app accesible (backend `/actuator/health`, frontend cargando)
+
+## 7. Cierre
+
+- [ ] 7.1 PR con `Closes #<id>` y CI en verde sobre sí mismo
+- [ ] 7.2 Merge y verificación del primer despliegue real

--- a/openspec/changes/ci-cd-aws-deploy/tasks.md
+++ b/openspec/changes/ci-cd-aws-deploy/tasks.md
@@ -43,16 +43,16 @@
 
 ## 6. Verificación
 
-> Pendiente — manual. No se puede ejecutar el workflow real ni el EC2 desde aquí.
-> Validación local realizada: YAML del workflow OK (PyYAML), `docker compose config` OK.
-> Checklist de verificación en vivo en `docs/DEPLOYMENT-RUNBOOK.md` §5.
+> Validación REAL en GitHub Actions sobre la PR #164 (runs 27877583908 y 28017208805).
+> El primer run destapó 6 IT preexistentes rotos (auth/usuarios) + 1 bug real de producción
+> (`RateLimitFilter` usaba `getServletPath()`); corregidos. Segundo run: build+test VERDE (2m27s).
 
-- [ ] 6.1 Abrir un PR de prueba → confirmar que corre `build-and-test` y NO `deploy` — pendiente, manual
-- [ ] 6.2 Forzar un test rojo → confirmar que el pipeline falla y no despliega — pendiente, manual
-- [ ] 6.3 Merge a `develop` → confirmar build+test verde y deploy automático — pendiente, manual
+- [x] 6.1 PR #164 → corre `build-and-test` y el job `deploy` aparece como `skipping` (no se ejecuta en PR)
+- [x] 6.2 Tests rojos (primer run) → pipeline en rojo y `deploy` saltado. Confirmado.
+- [ ] 6.3 Merge a `develop` → deploy automático — pendiente, manual (requiere EC2 + secrets)
 - [ ] 6.4 Comprobar en el EC2: contenedores arriba, healthchecks verdes, Flyway aplicado, app accesible — pendiente, manual (runbook §5)
 
 ## 7. Cierre
 
-- [ ] 7.1 PR con `Closes #<id>` y CI en verde sobre sí mismo
-- [ ] 7.2 Merge y verificación del primer despliegue real
+- [x] 7.1 PR #164 con `Closes #163`; CI (`build-and-test`) en VERDE sobre sí mismo
+- [ ] 7.2 Merge y verificación del primer despliegue real — pendiente, manual (tras provisión AWS)


### PR DESCRIPTION
## Resumen

Pipeline CI/CD replicando el modelo de `AI4Devs-pipeline-202602-ro`: un workflow `ci.yml` con job `build-and-test` (backend Maven/JDK17 con IT Testcontainers + gate JaCoCo; frontend Vite lint/test/build) y job `deploy` (SSH a EC2 → `git pull` + `docker compose up -d --build`), gated tras tests y solo en `push` a `develop`.

- `.github/workflows/ci.yml` (nuevo)
- `frontend/Dockerfile` sirve build estático en prod (`vite preview`) — antes `vite dev`
- `docker-compose.yml` deploy-ready (`.env`, sin bind-mount dev, sin `version` obsoleto) + `vite.config.ts` (preview proxy `/api`)
- `docs/DEPLOYMENT-RUNBOOK.md` (provisión EC2, secrets, primer deploy, backup, rollback)

## Issues vinculados
Closes #163

## Spec / Docs
Change OpenSpec: `openspec/changes/ci-cd-aws-deploy/` · Runbook: `docs/DEPLOYMENT-RUNBOOK.md`

## Validación
- [x] YAML del workflow OK; `docker compose config` OK (local)
- [ ] **CI real**: este PR ejecuta `build-and-test` en GitHub Actions (el `deploy` NO corre en PRs)
- [ ] Provisión AWS + GitHub Secrets + primer deploy: **manual** (runbook §2, §5)

## Notas
- BD en contenedor postgres (volumen persistente); evolución a RDS documentada.
- `VITE_API_BASE_URL` es build-time: mitigado con proxy `/api` de `vite preview`; verificar en vivo.

🤖 Generado con Claude Code (orchestrator agent)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a full CI workflow (backend build/test + coverage, frontend lint/test/build) and automated deployments to AWS EC2 on pushes to `develop`.
* **Bug Fixes**
  * Improved request path handling in the rate-limiting logic for more reliable behavior across environments and test setups.
* **Chores**
  * Updated environment-driven configuration for PostgreSQL and API base URL.
  * Updated frontend container to serve a production static build and expanded preview server support.
  * Added deployment runbook and expanded CI/CD documentation.
* **Tests**
  * Refactored integration/E2E tests to share PostgreSQL setup and stabilize request metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->