### PR TITLE
fix(auth): resolver app.encryption.key en prod (#165)

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -15,3 +15,5 @@ app:
   jwt:
     secret: ${JWT_SECRET}
     access-token-expiry-minutes: 15
+  encryption:
+    key: ${ENCRYPTION_KEY}


### PR DESCRIPTION
Backend no arrancaba en el primer deploy a EC2: `Could not resolve placeholder 'app.encryption.key'`. La base `application.yml` no definía `app.encryption.key` (el perfil prod usaba `encryption.key`, prefijo muerto). Añadido `app.encryption.key: ${ENCRYPTION_KEY}`.

Closes #165

🤖 orchestrator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring an application encryption key through an environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->