### PR TITLE
fix(auth): /actuator/health público para el healthcheck (#167)

### DIFF
--- a/backend/src/main/java/com/padelpro/auth/infrastructure/config/SecurityConfig.java
+++ b/backend/src/main/java/com/padelpro/auth/infrastructure/config/SecurityConfig.java
@@ -43,6 +43,7 @@ public class SecurityConfig {
                 .sessionManagement(sm ->
                         sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/actuator/health", "/actuator/health/**", "/actuator/info").permitAll()
                         .requestMatchers("/api/bot/telegram", "/api/pagos/webhook").permitAll()
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")


### PR DESCRIPTION
El deploy a EC2 dejaba el backend unhealthy: /actuator/health devolvía 401 (Security). permitAll en /actuator/health e /actuator/info. Closes #167