### PR TITLE
fix(auth): /actuator/** público con AntPathRequestMatcher (#169)

### DIFF
--- a/backend/src/main/java/com/padelpro/auth/infrastructure/config/SecurityConfig.java
+++ b/backend/src/main/java/com/padelpro/auth/infrastructure/config/SecurityConfig.java
@@ -12,6 +12,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 /**
  * Spring Security configuration for the auth module.
@@ -43,7 +44,7 @@ public class SecurityConfig {
                 .sessionManagement(sm ->
                         sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/actuator/health", "/actuator/health/**", "/actuator/info").permitAll()
+                        .requestMatchers(new AntPathRequestMatcher("/actuator/**")).permitAll()
                         .requestMatchers("/api/bot/telegram", "/api/pagos/webhook").permitAll()
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")


### PR DESCRIPTION
El permitAll por string de #167 no aplicaba a actuator (MvcRequestMatcher no casa rutas de actuator) → backend unhealthy en el deploy. AntPathRequestMatcher(/actuator/**) matchea por URI. Closes #169

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded access to Actuator endpoints so all `/actuator/**` routes are now available, rather than only health and info endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->