### PR TITLE
fix(auth): /actuator/health público con EndpointRequest (#171)

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -58,6 +58,10 @@
             <artifactId>spring-boot-starter-cache</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
         </dependency>

--- a/backend/src/main/java/com/padelpro/auth/infrastructure/config/SecurityConfig.java
+++ b/backend/src/main/java/com/padelpro/auth/infrastructure/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.padelpro.auth.infrastructure.config.security.CustomAccessDeniedHandle
 import com.padelpro.auth.infrastructure.config.security.CustomAuthenticationEntryPoint;
 import com.padelpro.auth.infrastructure.web.filter.JwtAuthFilter;
 import com.padelpro.auth.infrastructure.web.filter.UserStatusFilter;
+import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -12,7 +13,6 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 /**
  * Spring Security configuration for the auth module.
@@ -44,7 +44,7 @@ public class SecurityConfig {
                 .sessionManagement(sm ->
                         sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(new AntPathRequestMatcher("/actuator/**")).permitAll()
+                        .requestMatchers(EndpointRequest.to("health", "info")).permitAll()
                         .requestMatchers("/api/bot/telegram", "/api/pagos/webhook").permitAll()
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")


### PR DESCRIPTION
Backend quedaba unhealthy en el deploy: /actuator/health daba 401 porque ni string ni AntPath matchers casan rutas de actuator. Fix idiomático: spring-boot-starter-actuator + EndpointRequest.to(health,info).permitAll(). Closes #171