### PR TITLE
feat(#173): acceso de cuenta en prod — admin inicial, panel admin, acceso provisional 2d y reset por admin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,13 @@ POSTGRES_DB=padelpro
 POSTGRES_USER=padelpro
 POSTGRES_PASSWORD=padelpro_dev
 
+# Bootstrap admin (acceso-cuenta-prod D1)
+# On first start with NO existing ADMIN, the backend creates an ACTIVE admin from these
+# credentials (BCrypt-hashed at runtime). Idempotent: ignored once an admin exists.
+# Leave empty to skip seeding. Use a strong password; rotate after first login.
+ADMIN_EMAIL=admin@yourclub.local
+ADMIN_PASSWORD=change-this-strong-admin-password
+
 # Spring Boot Profile
 SPRING_PROFILES_ACTIVE=prod
 

--- a/backend/src/main/java/com/padelpro/auth/application/dto/TokenPair.java
+++ b/backend/src/main/java/com/padelpro/auth/application/dto/TokenPair.java
@@ -10,22 +10,25 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * It is used only by the controller to set the HttpOnly refresh-token cookie.
  * The hash of the refresh token is persisted in the database (never the raw value).
  *
- * @param accessToken     signed JWT access token
- * @param tokenType       always {@code "Bearer"}
- * @param expiresIn       access token lifetime in seconds
- * @param rawRefreshToken raw refresh token for cookie — NOT included in JSON response
+ * @param accessToken         signed JWT access token
+ * @param tokenType           always {@code "Bearer"}
+ * @param expiresIn           access token lifetime in seconds
+ * @param mustChangePassword  whether the user must set a new password before normal use (D9)
+ * @param rawRefreshToken     raw refresh token for cookie — NOT included in JSON response
  */
 public record TokenPair(
-        @JsonProperty("access_token")  String accessToken,
-        @JsonProperty("token_type")    String tokenType,
-        @JsonProperty("expires_in")    int expiresIn,
-        @JsonIgnore                     String rawRefreshToken
+        @JsonProperty("access_token")          String accessToken,
+        @JsonProperty("token_type")            String tokenType,
+        @JsonProperty("expires_in")            int expiresIn,
+        @JsonProperty("must_change_password")  boolean mustChangePassword,
+        @JsonIgnore                             String rawRefreshToken
 ) {
 
     /**
-     * Convenience constructor for tests and callers that don't need the refresh token.
+     * Convenience constructor for tests and callers that don't need the refresh token
+     * (defaults {@code mustChangePassword} to {@code false}).
      */
     public TokenPair(String accessToken, String tokenType, int expiresIn) {
-        this(accessToken, tokenType, expiresIn, null);
+        this(accessToken, tokenType, expiresIn, false, null);
     }
 }

--- a/backend/src/main/java/com/padelpro/auth/application/service/AdminSeedService.java
+++ b/backend/src/main/java/com/padelpro/auth/application/service/AdminSeedService.java
@@ -1,0 +1,68 @@
+package com.padelpro.auth.application.service;
+
+import com.padelpro.auth.domain.model.User;
+import com.padelpro.auth.domain.model.UserRole;
+import com.padelpro.auth.domain.model.UserStatus;
+import com.padelpro.auth.domain.port.out.UserRepositoryPort;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+
+/**
+ * Bootstrap of the first administrator (D1, RN-AUTH-07).
+ *
+ * <p>Idempotent: an ADMIN is created only when none exists yet and both credentials are
+ * provided. The password is hashed with BCrypt at runtime — no credential is ever stored in
+ * the repository or in logs. If the credentials are missing/blank, nothing happens and the
+ * application boots normally.
+ */
+@Service
+public class AdminSeedService {
+
+    private final UserRepositoryPort userRepository;
+    private final BCryptPasswordEncoder passwordEncoder;
+
+    public AdminSeedService(UserRepositoryPort userRepository, BCryptPasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    /**
+     * Create an ACTIVE ADMIN with a BCrypt-hashed password if, and only if, no ADMIN exists yet
+     * and both {@code email} and {@code rawPassword} are non-blank.
+     *
+     * @return {@code true} if an admin was created, {@code false} otherwise (already present or
+     * credentials absent).
+     */
+    @Transactional
+    public boolean seedIfAbsent(String email, String rawPassword) {
+        if (isBlank(email) || isBlank(rawPassword)) {
+            return false;
+        }
+        if (userRepository.existsByRole(UserRole.ADMIN)) {
+            return false;
+        }
+
+        String normalizedEmail = email.trim().toLowerCase();
+        OffsetDateTime now = OffsetDateTime.now();
+        User admin = new User(
+                normalizedEmail,                       // login = email (bootstrap convention)
+                passwordEncoder.encode(rawPassword),
+                "Admin",
+                "PadelPro",
+                normalizedEmail,
+                UserRole.ADMIN,
+                UserStatus.ACTIVE,
+                now,
+                now
+        );
+        userRepository.save(admin);
+        return true;
+    }
+
+    private static boolean isBlank(String s) {
+        return s == null || s.isBlank();
+    }
+}

--- a/backend/src/main/java/com/padelpro/auth/application/service/AuthService.java
+++ b/backend/src/main/java/com/padelpro/auth/application/service/AuthService.java
@@ -5,10 +5,10 @@ import com.padelpro.auth.application.dto.TokenPair;
 import com.padelpro.auth.application.port.in.LoginUseCase;
 import com.padelpro.auth.domain.exception.AccountNotActiveException;
 import com.padelpro.auth.domain.exception.AuthenticationException;
+import com.padelpro.auth.domain.model.AccountAccessPolicy;
 import com.padelpro.auth.domain.model.AuditLog;
 import com.padelpro.auth.domain.model.RefreshToken;
 import com.padelpro.auth.domain.model.User;
-import com.padelpro.auth.domain.model.UserStatus;
 import com.padelpro.auth.domain.port.out.AuditLogRepositoryPort;
 import com.padelpro.auth.domain.port.out.RefreshTokenRepositoryPort;
 import com.padelpro.auth.domain.port.out.UserRepositoryPort;
@@ -20,6 +20,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.Base64;
 import java.util.Optional;
@@ -58,6 +59,10 @@ public class AuthService implements LoginUseCase {
     // Optional ports — null in unit-test context (no Spring context).
     private AuditLogRepositoryPort auditLogRepository;
     private RefreshTokenRepositoryPort refreshTokenRepository;
+
+    // Provisional-access policy (D8). Eagerly initialised with the default 48h grace window so
+    // unit tests without a Spring context still apply the rule; Spring overrides via setter.
+    private AccountAccessPolicy accessPolicy = new AccountAccessPolicy(Duration.ofHours(48));
 
     // Real BCrypt(12) hash of "__dummy_anti_timing__" — used when email is not found
     // to keep timing indistinguishable from a real password check (RN-AUTH-06).
@@ -98,6 +103,13 @@ public class AuthService implements LoginUseCase {
         this.refreshTokenRepository = refreshTokenRepository;
     }
 
+    @Autowired(required = false)
+    public void setAccessPolicy(AccountAccessPolicy accessPolicy) {
+        if (accessPolicy != null) {
+            this.accessPolicy = accessPolicy;
+        }
+    }
+
     // -------------------------------------------------------------------------
     // LoginUseCase
     // -------------------------------------------------------------------------
@@ -118,8 +130,9 @@ public class AuthService implements LoginUseCase {
 
         User user = userOpt.get();
 
-        // PENDING / INACTIVE accounts → 403
-        if (user.getStatus() != UserStatus.ACTIVE) {
+        // Provisional-access policy (D8): ACTIVE always; PENDING only within the 48h grace
+        // window from registration; INACTIVE never. Otherwise → 403 ACCOUNT_NOT_ACTIVE.
+        if (!accessPolicy.isAccessAllowed(user.getStatus(), user.getRegisteredAt(), OffsetDateTime.now())) {
             throw new AccountNotActiveException();
         }
 

--- a/backend/src/main/java/com/padelpro/auth/application/service/AuthService.java
+++ b/backend/src/main/java/com/padelpro/auth/application/service/AuthService.java
@@ -155,7 +155,8 @@ public class AuthService implements LoginUseCase {
 
         saveAuditLog("LOGIN_SUCCESS", user, null);
 
-        return new TokenPair(accessToken, "Bearer", jwtService.getExpirySeconds(), rawRefreshToken);
+        return new TokenPair(accessToken, "Bearer", jwtService.getExpirySeconds(),
+                user.isMustChangePassword(), rawRefreshToken);
     }
 
     // -------------------------------------------------------------------------

--- a/backend/src/main/java/com/padelpro/auth/application/service/RegistrationService.java
+++ b/backend/src/main/java/com/padelpro/auth/application/service/RegistrationService.java
@@ -16,8 +16,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Application service implementing the {@link RegisterUseCase} inbound port.
@@ -141,17 +139,12 @@ public class RegistrationService implements RegisterUseCase {
     }
 
     /**
-     * Enforces password policy (RN-AUTH-08):
-     * 8–128 characters, at least one uppercase letter, at least one digit.
+     * Enforces password policy (RN-AUTH-08) via the shared {@link
+     * com.padelpro.auth.domain.model.PasswordPolicy} domain object.
      *
      * @throws InvalidPasswordException listing all violated rule codes
      */
     private void validatePassword(String password) {
-        List<String> violations = new ArrayList<>();
-        if (password.length() < 8)                              violations.add("MIN_LENGTH_8");
-        if (password.length() > 128)                            violations.add("MAX_LENGTH_128");
-        if (password.chars().noneMatch(Character::isUpperCase)) violations.add("REQUIRES_UPPERCASE");
-        if (password.chars().noneMatch(Character::isDigit))     violations.add("REQUIRES_NUMBER");
-        if (!violations.isEmpty()) throw new InvalidPasswordException(violations);
+        com.padelpro.auth.domain.model.PasswordPolicy.validate(password);
     }
 }

--- a/backend/src/main/java/com/padelpro/auth/domain/model/AccountAccessPolicy.java
+++ b/backend/src/main/java/com/padelpro/auth/domain/model/AccountAccessPolicy.java
@@ -1,0 +1,45 @@
+package com.padelpro.auth.domain.model;
+
+import java.time.Duration;
+import java.time.OffsetDateTime;
+
+/**
+ * Domain policy deciding whether an account may access the app (D8 — provisional access).
+ *
+ * <ul>
+ *   <li>{@code ACTIVE} → always allowed.</li>
+ *   <li>{@code PENDING} → allowed only while within the grace window
+ *       ({@code registeredAt + graceWindow >= now}); a freshly registered user thus gets
+ *       provisional access for the configured window (48h by default).</li>
+ *   <li>{@code INACTIVE} → always denied (deactivated by an admin; no grace).</li>
+ * </ul>
+ *
+ * <p>Pure domain object: no Spring, no persistence. The grace window is injected so it can be
+ * configured and exercised at the boundaries in isolation.
+ */
+public class AccountAccessPolicy {
+
+    private final Duration graceWindow;
+
+    public AccountAccessPolicy(Duration graceWindow) {
+        this.graceWindow = graceWindow;
+    }
+
+    /**
+     * @param status       the account status
+     * @param registeredAt when the account was registered (basis of the grace window)
+     * @param now          the reference instant
+     * @return {@code true} if access is permitted
+     */
+    public boolean isAccessAllowed(UserStatus status, OffsetDateTime registeredAt, OffsetDateTime now) {
+        if (status == UserStatus.ACTIVE) {
+            return true;
+        }
+        if (status == UserStatus.PENDING) {
+            OffsetDateTime deadline = registeredAt.plus(graceWindow);
+            return !now.isAfter(deadline);
+        }
+        // INACTIVE (and any other non-active state) → no access, no grace.
+        return false;
+    }
+}

--- a/backend/src/main/java/com/padelpro/auth/domain/model/PasswordPolicy.java
+++ b/backend/src/main/java/com/padelpro/auth/domain/model/PasswordPolicy.java
@@ -1,0 +1,38 @@
+package com.padelpro.auth.domain.model;
+
+import com.padelpro.auth.domain.exception.InvalidPasswordException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Password policy (RN-AUTH-08): 8–128 characters, at least one uppercase letter and one digit.
+ *
+ * <p>Pure domain object with no dependencies, reused by registration and by the user's own
+ * password change (D9) so the rule is defined in exactly one place.
+ */
+public final class PasswordPolicy {
+
+    private PasswordPolicy() {
+    }
+
+    /**
+     * Validate a raw password against the policy.
+     *
+     * @throws InvalidPasswordException listing every violated rule code
+     * @throws IllegalArgumentException if the password is {@code null}
+     */
+    public static void validate(String password) {
+        if (password == null) {
+            throw new IllegalArgumentException("MISSING_REQUIRED_FIELD: password");
+        }
+        List<String> violations = new ArrayList<>();
+        if (password.length() < 8)                              violations.add("MIN_LENGTH_8");
+        if (password.length() > 128)                            violations.add("MAX_LENGTH_128");
+        if (password.chars().noneMatch(Character::isUpperCase)) violations.add("REQUIRES_UPPERCASE");
+        if (password.chars().noneMatch(Character::isDigit))     violations.add("REQUIRES_NUMBER");
+        if (!violations.isEmpty()) {
+            throw new InvalidPasswordException(violations);
+        }
+    }
+}

--- a/backend/src/main/java/com/padelpro/auth/domain/model/User.java
+++ b/backend/src/main/java/com/padelpro/auth/domain/model/User.java
@@ -52,6 +52,9 @@ public class User {
     @Column(name = "last_login_at")
     private OffsetDateTime lastLoginAt;
 
+    @Column(name = "must_change_password", nullable = false)
+    private boolean mustChangePassword = false;
+
     @Column(length = 20)
     private String phone;
 
@@ -118,6 +121,9 @@ public class User {
 
     public OffsetDateTime getLastLoginAt() { return lastLoginAt; }
     public void setLastLoginAt(OffsetDateTime lastLoginAt) { this.lastLoginAt = lastLoginAt; }
+
+    public boolean isMustChangePassword() { return mustChangePassword; }
+    public void setMustChangePassword(boolean mustChangePassword) { this.mustChangePassword = mustChangePassword; }
 
     public String getPhone() { return phone; }
     public void setPhone(String phone) { this.phone = phone; }

--- a/backend/src/main/java/com/padelpro/auth/domain/port/out/UserRepositoryPort.java
+++ b/backend/src/main/java/com/padelpro/auth/domain/port/out/UserRepositoryPort.java
@@ -68,4 +68,10 @@ public interface UserRepositoryPort {
      * Return a page of all users (no status filter).
      */
     Page<User> findAll(Pageable pageable);
+
+    /**
+     * Check whether at least one user with the given role exists.
+     * Used by the admin-seed bootstrap (D1) to stay idempotent.
+     */
+    boolean existsByRole(com.padelpro.auth.domain.model.UserRole role);
 }

--- a/backend/src/main/java/com/padelpro/auth/infrastructure/config/AdminSeedRunner.java
+++ b/backend/src/main/java/com/padelpro/auth/infrastructure/config/AdminSeedRunner.java
@@ -1,0 +1,44 @@
+package com.padelpro.auth.infrastructure.config;
+
+import com.padelpro.auth.application.service.AdminSeedService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+/**
+ * Bootstraps the first administrator on application start (D1).
+ *
+ * <p>Reads {@code ADMIN_EMAIL} / {@code ADMIN_PASSWORD} from the environment and delegates the
+ * idempotent decision to {@link AdminSeedService}. Never logs the credentials (RN-RGPD-04);
+ * only whether an admin was created.
+ */
+@Component
+public class AdminSeedRunner implements ApplicationRunner {
+
+    private static final Logger log = LoggerFactory.getLogger(AdminSeedRunner.class);
+
+    private final AdminSeedService adminSeedService;
+    private final String adminEmail;
+    private final String adminPassword;
+
+    public AdminSeedRunner(AdminSeedService adminSeedService,
+                           @Value("${ADMIN_EMAIL:}") String adminEmail,
+                           @Value("${ADMIN_PASSWORD:}") String adminPassword) {
+        this.adminSeedService = adminSeedService;
+        this.adminEmail = adminEmail;
+        this.adminPassword = adminPassword;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        boolean created = adminSeedService.seedIfAbsent(adminEmail, adminPassword);
+        if (created) {
+            log.info("Bootstrap admin created (email taken from ADMIN_EMAIL).");
+        } else {
+            log.debug("Bootstrap admin not created (already present or credentials absent).");
+        }
+    }
+}

--- a/backend/src/main/java/com/padelpro/auth/infrastructure/config/SecurityConfig.java
+++ b/backend/src/main/java/com/padelpro/auth/infrastructure/config/SecurityConfig.java
@@ -68,4 +68,15 @@ public class SecurityConfig {
     public BCryptPasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder(12);
     }
+
+    /**
+     * Provisional-access policy (D8). The grace window for PENDING accounts is 48h by default,
+     * configurable via {@code app.access.provisional-grace-hours}.
+     */
+    @Bean
+    public com.padelpro.auth.domain.model.AccountAccessPolicy accountAccessPolicy(
+            @org.springframework.beans.factory.annotation.Value("${app.access.provisional-grace-hours:48}") long graceHours) {
+        return new com.padelpro.auth.domain.model.AccountAccessPolicy(
+                java.time.Duration.ofHours(graceHours));
+    }
 }

--- a/backend/src/main/java/com/padelpro/auth/infrastructure/web/filter/UserStatusFilter.java
+++ b/backend/src/main/java/com/padelpro/auth/infrastructure/web/filter/UserStatusFilter.java
@@ -1,9 +1,9 @@
 package com.padelpro.auth.infrastructure.web.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.padelpro.auth.domain.model.AccountAccessPolicy;
 import com.padelpro.auth.domain.model.AuditLog;
 import com.padelpro.auth.domain.model.User;
-import com.padelpro.auth.domain.model.UserStatus;
 import com.padelpro.auth.domain.port.out.AuditLogRepositoryPort;
 import com.padelpro.auth.domain.port.out.UserRepositoryPort;
 import com.padelpro.auth.infrastructure.web.dto.ErrorResponse;
@@ -40,13 +40,16 @@ public class UserStatusFilter extends OncePerRequestFilter {
     private final UserRepositoryPort userRepositoryPort;
     private final AuditLogRepositoryPort auditLogRepositoryPort;
     private final ObjectMapper objectMapper;
+    private final AccountAccessPolicy accessPolicy;
 
     public UserStatusFilter(UserRepositoryPort userRepositoryPort,
                             AuditLogRepositoryPort auditLogRepositoryPort,
-                            ObjectMapper objectMapper) {
+                            ObjectMapper objectMapper,
+                            AccountAccessPolicy accessPolicy) {
         this.userRepositoryPort = userRepositoryPort;
         this.auditLogRepositoryPort = auditLogRepositoryPort;
         this.objectMapper = objectMapper;
+        this.accessPolicy = accessPolicy;
     }
 
     @Override
@@ -73,7 +76,11 @@ public class UserStatusFilter extends OncePerRequestFilter {
         }
 
         User user = userRepositoryPort.findById(userId).orElse(null);
-        if (user == null || user.getStatus() != UserStatus.ACTIVE) {
+        // Provisional-access policy (D8): allow ACTIVE always and PENDING within the 48h grace
+        // window; block INACTIVE and grace-expired PENDING. Keeps the filter consistent with login.
+        if (user == null
+                || !accessPolicy.isAccessAllowed(
+                        user.getStatus(), user.getRegisteredAt(), OffsetDateTime.now())) {
             SecurityContextHolder.clearContext();
 
             // Record the denied access in the audit log

--- a/backend/src/main/java/com/padelpro/usuarios/application/dto/ChangeMyPasswordRequest.java
+++ b/backend/src/main/java/com/padelpro/usuarios/application/dto/ChangeMyPasswordRequest.java
@@ -1,0 +1,17 @@
+package com.padelpro.usuarios.application.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Request body for {@code POST /api/usuarios/me/password} — the user's own password change (D9).
+ *
+ * <p>Never logged (RN-RGPD-04).
+ *
+ * @param currentPassword the user's current password (verified before the change)
+ * @param newPassword     the new password (must satisfy the password policy)
+ */
+public record ChangeMyPasswordRequest(
+        @JsonProperty("current_password") String currentPassword,
+        @JsonProperty("new_password")     String newPassword
+) {
+}

--- a/backend/src/main/java/com/padelpro/usuarios/application/dto/ResetPasswordResult.java
+++ b/backend/src/main/java/com/padelpro/usuarios/application/dto/ResetPasswordResult.java
@@ -1,0 +1,20 @@
+package com.padelpro.usuarios.application.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Result of an admin password reset (D3/D4).
+ *
+ * <p>Carries the generated temporary password in clear — returned to the admin exactly once so
+ * they can communicate it to the user. It is never persisted in clear nor logged (RN-RGPD-04).
+ *
+ * @param userId               the id of the user whose password was reset
+ * @param temporaryPassword    the one-time temporary password in clear
+ * @param mustChangePassword   always {@code true} — the user must change it on next login
+ */
+public record ResetPasswordResult(
+        @JsonProperty("user_id")              Long userId,
+        @JsonProperty("temporary_password")   String temporaryPassword,
+        @JsonProperty("must_change_password") boolean mustChangePassword
+) {
+}

--- a/backend/src/main/java/com/padelpro/usuarios/application/service/ChangeMyPasswordService.java
+++ b/backend/src/main/java/com/padelpro/usuarios/application/service/ChangeMyPasswordService.java
@@ -1,0 +1,63 @@
+package com.padelpro.usuarios.application.service;
+
+import com.padelpro.auth.domain.exception.AuthenticationException;
+import com.padelpro.auth.domain.model.AuditLog;
+import com.padelpro.auth.domain.model.PasswordPolicy;
+import com.padelpro.auth.domain.model.User;
+import com.padelpro.auth.domain.port.out.AuditLogRepositoryPort;
+import com.padelpro.auth.domain.port.out.UserRepositoryPort;
+import com.padelpro.usuarios.domain.exception.UserNotFoundException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+
+/**
+ * Lets an authenticated user change their own password (D9).
+ *
+ * <p>Validates the current password, enforces the shared {@link PasswordPolicy} on the new one,
+ * persists the new BCrypt hash and clears {@code must_change_password}. The passwords are never
+ * logged (RN-RGPD-04): only a neutral audit action is recorded.
+ */
+@Service
+public class ChangeMyPasswordService {
+
+    private final UserRepositoryPort userRepository;
+    private final AuditLogRepositoryPort auditLogRepository;
+    private final BCryptPasswordEncoder passwordEncoder;
+
+    public ChangeMyPasswordService(UserRepositoryPort userRepository,
+                                   AuditLogRepositoryPort auditLogRepository,
+                                   BCryptPasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.auditLogRepository = auditLogRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    /**
+     * @throws UserNotFoundException          if the user does not exist
+     * @throws AuthenticationException        if the current password is wrong
+     * @throws com.padelpro.auth.domain.exception.InvalidPasswordException if the new password
+     *                                        violates the policy
+     */
+    @Transactional
+    public void changePassword(Long userId, String currentPassword, String newPassword) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(userId));
+
+        if (currentPassword == null || !passwordEncoder.matches(currentPassword, user.getPasswordHash())) {
+            throw new AuthenticationException();
+        }
+
+        // Enforce policy before touching persistence.
+        PasswordPolicy.validate(newPassword);
+
+        user.setPasswordHash(passwordEncoder.encode(newPassword));
+        user.setMustChangePassword(false);
+        userRepository.save(user);
+
+        auditLogRepository.save(new AuditLog(
+                "PASSWORD_CHANGED", user, null, "self-service", OffsetDateTime.now()));
+    }
+}

--- a/backend/src/main/java/com/padelpro/usuarios/application/service/TemporaryPasswordGenerator.java
+++ b/backend/src/main/java/com/padelpro/usuarios/application/service/TemporaryPasswordGenerator.java
@@ -1,0 +1,50 @@
+package com.padelpro.usuarios.application.service;
+
+import org.springframework.stereotype.Component;
+
+import java.security.SecureRandom;
+
+/**
+ * Generates cryptographically-random temporary passwords for admin resets (D3/D4).
+ *
+ * <p>Every generated value satisfies the password policy (length ≥ 8, at least one uppercase and
+ * one digit) by construction. Symbols that are ambiguous when read aloud/copied (0/O, 1/l/I) are
+ * excluded so the admin can reliably communicate the value to the user.
+ */
+@Component
+public class TemporaryPasswordGenerator {
+
+    private static final String UPPER = "ABCDEFGHJKLMNPQRSTUVWXYZ";  // no I, O
+    private static final String LOWER = "abcdefghijkmnpqrstuvwxyz";  // no l, o
+    private static final String DIGITS = "23456789";                 // no 0, 1
+    private static final String ALL = UPPER + LOWER + DIGITS;
+    private static final int LENGTH = 12;
+
+    private final SecureRandom random = new SecureRandom();
+
+    /**
+     * @return a new 12-character temporary password guaranteed to meet the policy.
+     */
+    public String generate() {
+        StringBuilder sb = new StringBuilder(LENGTH);
+        // Guarantee at least one uppercase and one digit.
+        sb.append(UPPER.charAt(random.nextInt(UPPER.length())));
+        sb.append(DIGITS.charAt(random.nextInt(DIGITS.length())));
+        for (int i = sb.length(); i < LENGTH; i++) {
+            sb.append(ALL.charAt(random.nextInt(ALL.length())));
+        }
+        // Shuffle so the guaranteed chars are not always in fixed positions.
+        return shuffle(sb.toString());
+    }
+
+    private String shuffle(String s) {
+        char[] chars = s.toCharArray();
+        for (int i = chars.length - 1; i > 0; i--) {
+            int j = random.nextInt(i + 1);
+            char tmp = chars[i];
+            chars[i] = chars[j];
+            chars[j] = tmp;
+        }
+        return new String(chars);
+    }
+}

--- a/backend/src/main/java/com/padelpro/usuarios/application/service/UserAdminService.java
+++ b/backend/src/main/java/com/padelpro/usuarios/application/service/UserAdminService.java
@@ -8,6 +8,7 @@ import com.padelpro.auth.domain.port.out.AuditLogRepositoryPort;
 import com.padelpro.auth.domain.port.out.UserRepositoryPort;
 import com.padelpro.usuarios.application.dto.CreateUserAdminCommand;
 import com.padelpro.usuarios.application.dto.PagedUsersResponse;
+import com.padelpro.usuarios.application.dto.ResetPasswordResult;
 import com.padelpro.usuarios.application.dto.UpdateUserAdminCommand;
 import com.padelpro.usuarios.application.dto.UserAdminResponse;
 import com.padelpro.usuarios.domain.audit.AuditActions;
@@ -37,13 +38,16 @@ public class UserAdminService {
     private final UserRepositoryPort userRepositoryPort;
     private final AuditLogRepositoryPort auditLogRepositoryPort;
     private final BCryptPasswordEncoder passwordEncoder;
+    private final TemporaryPasswordGenerator temporaryPasswordGenerator;
 
     public UserAdminService(UserRepositoryPort userRepositoryPort,
                             AuditLogRepositoryPort auditLogRepositoryPort,
-                            BCryptPasswordEncoder passwordEncoder) {
+                            BCryptPasswordEncoder passwordEncoder,
+                            TemporaryPasswordGenerator temporaryPasswordGenerator) {
         this.userRepositoryPort   = userRepositoryPort;
         this.auditLogRepositoryPort = auditLogRepositoryPort;
         this.passwordEncoder      = passwordEncoder;
+        this.temporaryPasswordGenerator = temporaryPasswordGenerator;
     }
 
     /**
@@ -212,6 +216,40 @@ public class UserAdminService {
         auditLogRepositoryPort.save(new AuditLog(
                 AuditActions.USER_DEACTIVATED, saved, null,
                 "deactivatedBy=" + adminId, OffsetDateTime.now()));
+    }
+
+    /**
+     * Reset a user's password (D3/D4/D9): generate a temporary password, persist its BCrypt hash,
+     * mark {@code must_change_password = true}, and return the temporary password in clear exactly
+     * once so the admin can communicate it. The temporary password is never persisted in clear nor
+     * written to the audit log (RN-RGPD-04).
+     *
+     * <p>An admin cannot reset their own account through this flow — protecting the ADMIN identity
+     * (RN-AUTH-05), consistent with the self-deactivation guard.
+     *
+     * @param targetId the id of the user whose password is reset
+     * @param adminId  the id of the requesting admin
+     * @throws AdminSelfDeactivationException if {@code targetId == adminId}
+     * @throws UserNotFoundException          if the target user does not exist
+     */
+    @Transactional
+    public ResetPasswordResult resetPassword(Long targetId, Long adminId) {
+        if (targetId.equals(adminId)) {
+            throw new AdminSelfDeactivationException();
+        }
+        User user = requireUser(targetId);
+
+        String temporaryPassword = temporaryPasswordGenerator.generate();
+        user.setPasswordHash(passwordEncoder.encode(temporaryPassword));
+        user.setMustChangePassword(true);
+        userRepositoryPort.save(user);
+
+        // RN-RGPD-04: never include the temporary password in the audit details.
+        auditLogRepositoryPort.save(new AuditLog(
+                AuditActions.PASSWORD_RESET_BY_ADMIN, user, null,
+                "resetBy=" + adminId, OffsetDateTime.now()));
+
+        return new ResetPasswordResult(user.getId(), temporaryPassword, true);
     }
 
     // -------------------------------------------------------------------------

--- a/backend/src/main/java/com/padelpro/usuarios/domain/audit/AuditActions.java
+++ b/backend/src/main/java/com/padelpro/usuarios/domain/audit/AuditActions.java
@@ -8,10 +8,11 @@ package com.padelpro.usuarios.domain.audit;
  */
 public final class AuditActions {
 
-    public static final String USER_CREATED_BY_ADMIN = "USER_CREATED_BY_ADMIN";
-    public static final String USER_APPROVED         = "USER_APPROVED";
-    public static final String USER_DEACTIVATED      = "USER_DEACTIVATED";
-    public static final String USER_ROLE_CHANGED     = "USER_ROLE_CHANGED";
+    public static final String USER_CREATED_BY_ADMIN   = "USER_CREATED_BY_ADMIN";
+    public static final String USER_APPROVED           = "USER_APPROVED";
+    public static final String USER_DEACTIVATED        = "USER_DEACTIVATED";
+    public static final String USER_ROLE_CHANGED       = "USER_ROLE_CHANGED";
+    public static final String PASSWORD_RESET_BY_ADMIN = "PASSWORD_RESET_BY_ADMIN";
 
     private AuditActions() {
         // Utility class — not instantiable

--- a/backend/src/main/java/com/padelpro/usuarios/infrastructure/web/AdminUsuariosController.java
+++ b/backend/src/main/java/com/padelpro/usuarios/infrastructure/web/AdminUsuariosController.java
@@ -3,6 +3,7 @@ package com.padelpro.usuarios.infrastructure.web;
 import com.padelpro.auth.domain.model.UserStatus;
 import com.padelpro.usuarios.application.dto.CreateUserAdminCommand;
 import com.padelpro.usuarios.application.dto.PagedUsersResponse;
+import com.padelpro.usuarios.application.dto.ResetPasswordResult;
 import com.padelpro.usuarios.application.dto.UpdateUserAdminCommand;
 import com.padelpro.usuarios.application.dto.UserAdminResponse;
 import com.padelpro.usuarios.application.service.UserAdminService;
@@ -108,6 +109,18 @@ public class AdminUsuariosController {
         Long adminId = resolveAdminId();
         userAdminService.deactivateUser(id, adminId);
         return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * PATCH /api/admin/usuarios/{id}/reset-password
+     * Generates a temporary password for the target user, persists it as BCrypt, marks the
+     * account with {@code must_change_password=true}, and returns the temporary password in clear
+     * exactly once (D3/D4). An admin cannot reset their own account (RN-AUTH-05).
+     */
+    @PatchMapping("/{id}/reset-password")
+    public ResponseEntity<ResetPasswordResult> resetPassword(@PathVariable Long id) {
+        Long adminId = resolveAdminId();
+        return ResponseEntity.ok(userAdminService.resetPassword(id, adminId));
     }
 
     // -------------------------------------------------------------------------

--- a/backend/src/main/java/com/padelpro/usuarios/infrastructure/web/UsuariosMeController.java
+++ b/backend/src/main/java/com/padelpro/usuarios/infrastructure/web/UsuariosMeController.java
@@ -1,13 +1,16 @@
 package com.padelpro.usuarios.infrastructure.web;
 
+import com.padelpro.usuarios.application.dto.ChangeMyPasswordRequest;
 import com.padelpro.usuarios.application.dto.UpdateMyProfileCommand;
 import com.padelpro.usuarios.application.dto.UserProfileResponse;
+import com.padelpro.usuarios.application.service.ChangeMyPasswordService;
 import com.padelpro.usuarios.application.service.UserProfileService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,9 +30,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class UsuariosMeController {
 
     private final UserProfileService userProfileService;
+    private final ChangeMyPasswordService changeMyPasswordService;
 
-    public UsuariosMeController(UserProfileService userProfileService) {
+    public UsuariosMeController(UserProfileService userProfileService,
+                                ChangeMyPasswordService changeMyPasswordService) {
         this.userProfileService = userProfileService;
+        this.changeMyPasswordService = changeMyPasswordService;
     }
 
     /**
@@ -53,6 +59,20 @@ public class UsuariosMeController {
             @RequestBody UpdateMyProfileCommand command) {
         Long userId = resolveUserId();
         return ResponseEntity.ok(userProfileService.updateMyProfile(userId, command));
+    }
+
+    /**
+     * POST /api/usuarios/me/password
+     * Changes the authenticated user's own password (D9): validates the current password and the
+     * new-password policy, persists the new BCrypt hash and clears {@code must_change_password}.
+     * Returns 204 on success.
+     */
+    @PostMapping("/me/password")
+    public ResponseEntity<Void> changeMyPassword(@RequestBody ChangeMyPasswordRequest request) {
+        Long userId = resolveUserId();
+        changeMyPasswordService.changePassword(
+                userId, request.currentPassword(), request.newPassword());
+        return ResponseEntity.noContent().build();
     }
 
     // -------------------------------------------------------------------------

--- a/backend/src/main/resources/db/migration/V11__add_must_change_password_to_users.sql
+++ b/backend/src/main/resources/db/migration/V11__add_must_change_password_to_users.sql
@@ -1,0 +1,13 @@
+-- =============================================================================
+-- V11__add_must_change_password_to_users.sql
+-- capability: auth-local · change: acceso-cuenta-prod (D9)
+--
+-- Adds the must_change_password flag. When TRUE (set by an admin password reset),
+-- the next login forces the user to set a new password before normal use; the flag
+-- is cleared once the password is changed.
+--
+-- Additive, backwards-compatible: existing rows default to FALSE.
+-- =============================================================================
+
+ALTER TABLE users
+    ADD COLUMN must_change_password BOOLEAN NOT NULL DEFAULT false;

--- a/backend/src/test/java/com/padelpro/auth/application/service/AdminSeedServiceTest.java
+++ b/backend/src/test/java/com/padelpro/auth/application/service/AdminSeedServiceTest.java
@@ -1,0 +1,85 @@
+package com.padelpro.auth.application.service;
+
+import com.padelpro.auth.domain.model.User;
+import com.padelpro.auth.domain.model.UserRole;
+import com.padelpro.auth.domain.model.UserStatus;
+import com.padelpro.auth.domain.port.out.UserRepositoryPort;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link AdminSeedService} — bootstrap of the first ADMIN (D1, RN-AUTH-07).
+ *
+ * <p>Pure domain/application logic; the repository and encoder are mocked. The
+ * {@code ApplicationRunner} wiring is tested separately by the integration test.
+ */
+@ExtendWith(MockitoExtension.class)
+class AdminSeedServiceTest {
+
+    @Mock
+    private UserRepositoryPort userRepository;
+
+    private final BCryptPasswordEncoder encoder = new BCryptPasswordEncoder(4); // cheap for tests
+
+    // 2.1 — no ADMIN + email/password present → creates an ACTIVE ADMIN with a BCrypt hash
+    @Test
+    void should_create_active_admin_with_bcrypt_hash_when_no_admin_and_env_present() {
+        when(userRepository.existsByRole(UserRole.ADMIN)).thenReturn(false);
+
+        AdminSeedService service = new AdminSeedService(userRepository, encoder);
+        boolean created = service.seedIfAbsent("boss@club.local", "S3cretPass!");
+
+        assertThat(created).isTrue();
+        ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(captor.capture());
+        User saved = captor.getValue();
+        assertThat(saved.getRole()).isEqualTo(UserRole.ADMIN);
+        assertThat(saved.getStatus()).isEqualTo(UserStatus.ACTIVE);
+        assertThat(saved.getEmail()).isEqualTo("boss@club.local");
+        assertThat(saved.getLogin()).isEqualTo("boss@club.local");
+        // password is hashed, never stored in clear
+        assertThat(saved.getPasswordHash()).isNotEqualTo("S3cretPass!");
+        assertThat(encoder.matches("S3cretPass!", saved.getPasswordHash())).isTrue();
+    }
+
+    // 2.3 — an ADMIN already exists → no second admin created (idempotent)
+    @Test
+    void should_not_create_admin_when_one_already_exists() {
+        when(userRepository.existsByRole(UserRole.ADMIN)).thenReturn(true);
+
+        AdminSeedService service = new AdminSeedService(userRepository, encoder);
+        boolean created = service.seedIfAbsent("boss@club.local", "S3cretPass!");
+
+        assertThat(created).isFalse();
+        verify(userRepository, never()).save(org.mockito.ArgumentMatchers.any());
+    }
+
+    // 2.4 — env vars missing/blank → no admin created, no failure (does not even query)
+    @Test
+    void should_not_create_admin_when_email_blank() {
+        AdminSeedService service = new AdminSeedService(userRepository, encoder);
+
+        assertThat(service.seedIfAbsent("", "S3cretPass!")).isFalse();
+        assertThat(service.seedIfAbsent("  ", "S3cretPass!")).isFalse();
+        assertThat(service.seedIfAbsent(null, "S3cretPass!")).isFalse();
+        verify(userRepository, never()).save(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void should_not_create_admin_when_password_blank() {
+        AdminSeedService service = new AdminSeedService(userRepository, encoder);
+
+        assertThat(service.seedIfAbsent("boss@club.local", "")).isFalse();
+        assertThat(service.seedIfAbsent("boss@club.local", null)).isFalse();
+        verify(userRepository, never()).save(org.mockito.ArgumentMatchers.any());
+    }
+}

--- a/backend/src/test/java/com/padelpro/auth/application/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/padelpro/auth/application/service/AuthServiceTest.java
@@ -78,6 +78,10 @@ class AuthServiceTest {
     }
 
     private User buildUserWithStatus(String email, UserStatus status) {
+        return buildUserWithStatus(email, status, OffsetDateTime.now());
+    }
+
+    private User buildUserWithStatus(String email, UserStatus status, OffsetDateTime registeredAt) {
         return new User(
                 email,
                 // BCrypt(12) hash of "Password1" — generated for Wave 3 Green phase
@@ -87,7 +91,7 @@ class AuthServiceTest {
                 email,
                 UserRole.USER,
                 status,
-                OffsetDateTime.now(),
+                registeredAt,
                 OffsetDateTime.now()
         );
     }
@@ -199,15 +203,17 @@ class AuthServiceTest {
     }
 
     // -------------------------------------------------------------------------
-    // R-2.4 — PENDING account is rejected with ACCOUNT_NOT_ACTIVE
+    // R-2.4 / D8 — PENDING beyond the 48h grace window → ACCOUNT_NOT_ACTIVE;
+    // PENDING within the window → provisional access allowed (login succeeds).
     // -------------------------------------------------------------------------
 
     @Test
-    @DisplayName("R-2.4: should throw account not active when status is PENDING")
-    void should_throw_account_not_active_when_status_is_pending() {
-        // Arrange — lenient() for RED phase
+    @DisplayName("D8: should throw account not active when PENDING is past the 48h grace window")
+    void should_throw_account_not_active_when_pending_past_grace() {
+        // Arrange — registered 49h ago → past grace
         String email = "pending@example.com";
-        User pendingUser = buildUserWithStatus(email, UserStatus.PENDING);
+        User pendingUser = buildUserWithStatus(email, UserStatus.PENDING,
+                OffsetDateTime.now().minusHours(49));
         org.mockito.Mockito.lenient()
                 .when(userRepository.findByEmail(email))
                 .thenReturn(Optional.of(pendingUser));
@@ -219,7 +225,26 @@ class AuthServiceTest {
                 .isNotInstanceOf(UnsupportedOperationException.class)
                 .satisfies(ex -> assertThat(ex.getMessage())
                         .containsIgnoringCase("ACCOUNT_NOT_ACTIVE")
-                        .withFailMessage("PENDING account must throw ACCOUNT_NOT_ACTIVE"));
+                        .withFailMessage("PENDING past grace must throw ACCOUNT_NOT_ACTIVE"));
+    }
+
+    @Test
+    @DisplayName("D8: should allow login when PENDING is within the 48h grace window")
+    void should_allow_login_when_pending_within_grace() {
+        // Arrange — registered 1h ago → within grace
+        String email = "fresh-pending@example.com";
+        User pendingUser = buildUserWithStatus(email, UserStatus.PENDING,
+                OffsetDateTime.now().minusHours(1));
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(pendingUser));
+
+        LoginCommand command = new LoginCommand(email, "Password1");
+
+        // Act — should NOT throw; returns a token pair
+        TokenPair result = authService.login(command);
+
+        // Assert
+        assertThat(result).isNotNull();
+        assertThat(result.accessToken()).isNotBlank();
     }
 
     // -------------------------------------------------------------------------

--- a/backend/src/test/java/com/padelpro/auth/domain/model/AccountAccessPolicyTest.java
+++ b/backend/src/test/java/com/padelpro/auth/domain/model/AccountAccessPolicyTest.java
@@ -1,0 +1,63 @@
+package com.padelpro.auth.domain.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.OffsetDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link AccountAccessPolicy} — the 48h provisional-access rule (D8),
+ * tested in isolation from persistence and HTTP.
+ *
+ * <p>Rules:
+ * <ul>
+ *   <li>ACTIVE → always allowed.</li>
+ *   <li>PENDING within the grace window (registeredAt + 48h) → allowed (provisional).</li>
+ *   <li>PENDING past the grace window → denied.</li>
+ *   <li>INACTIVE → always denied (no grace, regardless of age).</li>
+ * </ul>
+ */
+class AccountAccessPolicyTest {
+
+    private static final Duration GRACE = Duration.ofHours(48);
+    private final AccountAccessPolicy policy = new AccountAccessPolicy(GRACE);
+
+    private final OffsetDateTime now = OffsetDateTime.parse("2026-06-30T12:00:00Z");
+
+    // 3.4 — ACTIVE → allowed regardless of age
+    @Test
+    void active_is_always_allowed() {
+        assertThat(policy.isAccessAllowed(UserStatus.ACTIVE, now.minusYears(2), now)).isTrue();
+        assertThat(policy.isAccessAllowed(UserStatus.ACTIVE, now, now)).isTrue();
+    }
+
+    // 3.1 — PENDING registered < 48h ago → allowed (provisional)
+    @Test
+    void pending_within_grace_is_allowed() {
+        assertThat(policy.isAccessAllowed(UserStatus.PENDING, now.minusHours(1), now)).isTrue();
+        assertThat(policy.isAccessAllowed(UserStatus.PENDING, now.minusHours(47), now)).isTrue();
+    }
+
+    // 3.1 boundary — exactly at the edge (registeredAt + 48h == now) is still allowed
+    @Test
+    void pending_at_exact_grace_boundary_is_allowed() {
+        assertThat(policy.isAccessAllowed(UserStatus.PENDING, now.minusHours(48), now)).isTrue();
+    }
+
+    // 3.3 — PENDING registered > 48h ago → denied
+    @Test
+    void pending_past_grace_is_denied() {
+        assertThat(policy.isAccessAllowed(UserStatus.PENDING, now.minusHours(48).minusSeconds(1), now)).isFalse();
+        assertThat(policy.isAccessAllowed(UserStatus.PENDING, now.minusHours(72), now)).isFalse();
+    }
+
+    // 3.4 — INACTIVE → always denied, no grace even if just registered
+    @Test
+    void inactive_is_always_denied() {
+        assertThat(policy.isAccessAllowed(UserStatus.INACTIVE, now, now)).isFalse();
+        assertThat(policy.isAccessAllowed(UserStatus.INACTIVE, now.minusHours(1), now)).isFalse();
+        assertThat(policy.isAccessAllowed(UserStatus.INACTIVE, now.minusYears(1), now)).isFalse();
+    }
+}

--- a/backend/src/test/java/com/padelpro/auth/infrastructure/config/AdminSeedRunnerIntegrationTest.java
+++ b/backend/src/test/java/com/padelpro/auth/infrastructure/config/AdminSeedRunnerIntegrationTest.java
@@ -1,0 +1,81 @@
+package com.padelpro.auth.infrastructure.config;
+
+import com.padelpro.auth.application.service.AdminSeedService;
+import com.padelpro.auth.domain.model.User;
+import com.padelpro.auth.domain.model.UserRole;
+import com.padelpro.auth.domain.model.UserStatus;
+import com.padelpro.auth.infrastructure.persistence.UserRepository;
+import com.padelpro.shared.PostgresIntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test for the admin-seed bootstrap (D1) wired through Spring against a real
+ * PostgreSQL. Verifies the seed creates an ACTIVE ADMIN with a BCrypt hash, is idempotent,
+ * and that absent credentials create nothing.
+ *
+ * <p>The {@code @Sql cleanup.sql} (inherited) deletes all users {@code @BeforeEach}, so each
+ * method starts from an empty {@code users} table regardless of the runner having executed at
+ * context startup. The {@link AdminSeedService} is re-invoked explicitly inside each test to
+ * exercise the seed decision deterministically.
+ */
+@TestPropertySource(properties = {
+        "ADMIN_EMAIL=boss@club.local",
+        "ADMIN_PASSWORD=S3cretBootstrap1"
+})
+class AdminSeedRunnerIntegrationTest extends PostgresIntegrationTest {
+
+    @Autowired
+    private AdminSeedService adminSeedService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private BCryptPasswordEncoder passwordEncoder;
+
+    @Test
+    @DisplayName("2.1 seeds an ACTIVE ADMIN with a BCrypt hash when none exists")
+    void seeds_active_admin_with_bcrypt_when_none_exists() {
+        boolean created = adminSeedService.seedIfAbsent("boss@club.local", "S3cretBootstrap1");
+
+        assertThat(created).isTrue();
+        List<User> admins = userRepository.findAll().stream()
+                .filter(u -> u.getRole() == UserRole.ADMIN)
+                .toList();
+        assertThat(admins).hasSize(1);
+        User admin = admins.get(0);
+        assertThat(admin.getStatus()).isEqualTo(UserStatus.ACTIVE);
+        assertThat(admin.getEmail()).isEqualTo("boss@club.local");
+        assertThat(passwordEncoder.matches("S3cretBootstrap1", admin.getPasswordHash())).isTrue();
+        assertThat(admin.getPasswordHash()).isNotEqualTo("S3cretBootstrap1");
+    }
+
+    @Test
+    @DisplayName("2.3 is idempotent — a second run creates no additional admin")
+    void is_idempotent_when_admin_already_exists() {
+        assertThat(adminSeedService.seedIfAbsent("boss@club.local", "S3cretBootstrap1")).isTrue();
+        boolean secondRun = adminSeedService.seedIfAbsent("other@club.local", "Another1Pass");
+
+        assertThat(secondRun).isFalse();
+        long adminCount = userRepository.findAll().stream()
+                .filter(u -> u.getRole() == UserRole.ADMIN)
+                .count();
+        assertThat(adminCount).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("2.4 creates nothing when credentials are absent (no failure)")
+    void creates_nothing_when_credentials_absent() {
+        assertThat(adminSeedService.seedIfAbsent("", "")).isFalse();
+        assertThat(adminSeedService.seedIfAbsent(null, null)).isFalse();
+        assertThat(userRepository.findAll()).isEmpty();
+    }
+}

--- a/backend/src/test/java/com/padelpro/auth/infrastructure/persistence/MustChangePasswordMigrationIT.java
+++ b/backend/src/test/java/com/padelpro/auth/infrastructure/persistence/MustChangePasswordMigrationIT.java
@@ -1,0 +1,129 @@
+package com.padelpro.auth.infrastructure.persistence;
+
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Migration integration test for V11 (acceso-cuenta-prod, group 1, task 1.1):
+ * adds {@code users.must_change_password BOOLEAN NOT NULL DEFAULT false}.
+ *
+ * <p>Runs the full Flyway chain V1..V11 on a real PostgreSQL 15 and verifies the new column
+ * exists, is NOT NULL, and defaults to {@code false}. Mirrors {@link
+ * com.padelpro.reservas.infrastructure.persistence.ReservationsMigrationIT} (Vía A vs
+ * Testcontainers) so it runs both locally and in CI.
+ */
+@DisplayName("Migración V11 — users.must_change_password (Postgres real)")
+class MustChangePasswordMigrationIT {
+
+    private static String jdbcUrl;
+    private static String username;
+    private static String password;
+    private static PostgreSQLContainer<?> container;
+
+    @BeforeAll
+    static void migrate() {
+        String externalUrl = System.getProperty("it.postgres.url");
+        if (externalUrl != null && !externalUrl.isBlank()) {
+            jdbcUrl = externalUrl;
+            username = System.getProperty("it.postgres.user", "padelpro");
+            password = System.getProperty("it.postgres.password", "padelpro_dev");
+        } else {
+            boolean dockerAvailable;
+            try {
+                dockerAvailable = org.testcontainers.DockerClientFactory.instance().isDockerAvailable();
+            } catch (Throwable t) {
+                dockerAvailable = false;
+            }
+            assumeTrue(dockerAvailable,
+                    "Skipping migration ITs: no external it.postgres.url and Docker not reachable by Testcontainers");
+            container = new PostgreSQLContainer<>("postgres:15-alpine");
+            container.start();
+            jdbcUrl = container.getJdbcUrl();
+            username = container.getUsername();
+            password = container.getPassword();
+        }
+
+        Flyway.configure()
+                .dataSource(jdbcUrl, username, password)
+                .locations("classpath:db/migration")
+                .cleanDisabled(false)
+                .load()
+                .migrate();
+    }
+
+    @org.junit.jupiter.api.AfterAll
+    static void stopContainer() {
+        if (container != null) {
+            container.stop();
+        }
+    }
+
+    private Connection connection() throws SQLException {
+        return java.sql.DriverManager.getConnection(jdbcUrl, username, password);
+    }
+
+    // 1.1a — column exists, is boolean, NOT NULL, default false
+    @Test
+    @DisplayName("1.1a must_change_password column exists with NOT NULL default false")
+    void must_change_password_column_exists_with_not_null_default_false() throws SQLException {
+        try (Connection c = connection();
+             Statement st = c.createStatement();
+             ResultSet rs = st.executeQuery(
+                     "SELECT data_type, is_nullable, column_default "
+                             + "FROM information_schema.columns "
+                             + "WHERE table_name = 'users' AND column_name = 'must_change_password'")) {
+            assertThat(rs.next()).as("column must_change_password should exist").isTrue();
+            assertThat(rs.getString("data_type")).isEqualTo("boolean");
+            assertThat(rs.getString("is_nullable")).isEqualTo("NO");
+            assertThat(rs.getString("column_default")).contains("false");
+        }
+    }
+
+    // 1.1b — a fresh insert without specifying the column defaults to false
+    @Test
+    @DisplayName("1.1b new user row defaults must_change_password to false")
+    void new_user_row_defaults_must_change_password_to_false() throws SQLException {
+        try (Connection c = connection()) {
+            long id;
+            try (PreparedStatement ps = c.prepareStatement(
+                    "INSERT INTO users (login, password_hash, first_name, last_name, email, status, role) "
+                            + "VALUES (?, ?, ?, ?, ?, 'ACTIVE', 'USER') RETURNING id")) {
+                String unique = String.valueOf(System.nanoTime());
+                ps.setString(1, "mcp" + unique.substring(unique.length() - 6));
+                ps.setString(2, "$2a$12$abcdefghijklmnopqrstuv");
+                ps.setString(3, "Must");
+                ps.setString(4, "Change");
+                ps.setString(5, "mcp" + unique + "@padelpro.local");
+                try (ResultSet rs = ps.executeQuery()) {
+                    rs.next();
+                    id = rs.getLong(1);
+                }
+            }
+            try (PreparedStatement ps = c.prepareStatement(
+                    "SELECT must_change_password FROM users WHERE id = ?")) {
+                ps.setLong(1, id);
+                try (ResultSet rs = ps.executeQuery()) {
+                    rs.next();
+                    assertThat(rs.getBoolean("must_change_password")).isFalse();
+                }
+            } finally {
+                try (PreparedStatement ps = c.prepareStatement("DELETE FROM users WHERE id = ?")) {
+                    ps.setLong(1, id);
+                    ps.executeUpdate();
+                }
+            }
+        }
+    }
+}

--- a/backend/src/test/java/com/padelpro/auth/infrastructure/web/AuthControllerIntegrationTest.java
+++ b/backend/src/test/java/com/padelpro/auth/infrastructure/web/AuthControllerIntegrationTest.java
@@ -183,8 +183,22 @@ class AuthControllerIntegrationTest extends PostgresIntegrationTest {
                 .andExpect(jsonPath("$.access_token").isNotEmpty())
                 .andExpect(jsonPath("$.token_type").value("Bearer"))
                 .andExpect(jsonPath("$.expires_in").value(900))
+                .andExpect(jsonPath("$.must_change_password").value(false))
                 .andExpect(cookie().httpOnly("refresh_token", true))
                 .andExpect(cookie().exists("refresh_token"));
+    }
+
+    @Test
+    @DisplayName("D9: login exposes must_change_password=true when the flag is set")
+    void login_should_expose_must_change_password_flag_when_set() throws Exception {
+        registerAndActivateUser("mcp@example.com", "Password1");
+        // Simulate an admin reset having set the flag
+        jdbcTemplate.update("UPDATE users SET must_change_password = true WHERE email = ?", "mcp@example.com");
+
+        mockMvc.perform(authPost("/api/auth/login", json(loginBody("mcp@example.com", "Password1"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.access_token").isNotEmpty())
+                .andExpect(jsonPath("$.must_change_password").value(true));
     }
 
     @Test

--- a/backend/src/test/java/com/padelpro/auth/infrastructure/web/AuthControllerIntegrationTest.java
+++ b/backend/src/test/java/com/padelpro/auth/infrastructure/web/AuthControllerIntegrationTest.java
@@ -238,15 +238,56 @@ class AuthControllerIntegrationTest extends PostgresIntegrationTest {
                 .isEqualTo(wrongPwJson);
     }
 
-    @Test
-    @DisplayName("R-2.4: login should return 403 when account is PENDING")
-    void login_should_return_403_when_account_is_pending() throws Exception {
-        // Register creates a PENDING user — do NOT activate
-        mockMvc.perform(authPost("/api/auth/register", json(registerBody("Pending", "User", "pending@example.com", "Password1"))))
-                .andExpect(status().isCreated());
+    // =========================================================================
+    // PROVISIONAL ACCESS (D8) — PENDING grace window of 48h
+    // =========================================================================
 
-        // Login attempt on PENDING account → 403
-        mockMvc.perform(authPost("/api/auth/login", json(loginBody("pending@example.com", "Password1"))))
+    /**
+     * Sets the registered_at of a user to a specific age (relative to now) via JDBC,
+     * so the 48h grace boundary can be exercised deterministically.
+     */
+    private void setRegisteredAgeHours(String email, long hoursAgo) {
+        int updated = jdbcTemplate.update(
+                "UPDATE users SET registered_at = NOW() - (? * INTERVAL '1 hour') WHERE email = ?",
+                hoursAgo, email);
+        org.assertj.core.api.Assertions.assertThat(updated).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("R-2.4a: PENDING within 48h grace → 200 (provisional access)")
+    void login_should_return_200_when_pending_within_grace() throws Exception {
+        // Register creates a PENDING user — do NOT activate
+        mockMvc.perform(authPost("/api/auth/register", json(registerBody("Fresh", "Pending", "fresh@example.com", "Password1"))))
+                .andExpect(status().isCreated());
+        setRegisteredAgeHours("fresh@example.com", 1); // 1h ago, well within grace
+
+        mockMvc.perform(authPost("/api/auth/login", json(loginBody("fresh@example.com", "Password1"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.access_token").isNotEmpty());
+    }
+
+    @Test
+    @DisplayName("R-2.4b: PENDING past 48h grace → 403 ACCOUNT_NOT_ACTIVE")
+    void login_should_return_403_when_pending_past_grace() throws Exception {
+        mockMvc.perform(authPost("/api/auth/register", json(registerBody("Old", "Pending", "oldpending@example.com", "Password1"))))
+                .andExpect(status().isCreated());
+        setRegisteredAgeHours("oldpending@example.com", 49); // past the 48h window
+
+        mockMvc.perform(authPost("/api/auth/login", json(loginBody("oldpending@example.com", "Password1"))))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error").value("ACCOUNT_NOT_ACTIVE"));
+    }
+
+    @Test
+    @DisplayName("R-2.4c: INACTIVE → 403 ACCOUNT_NOT_ACTIVE regardless of age (no grace)")
+    void login_should_return_403_when_inactive_even_if_recent() throws Exception {
+        mockMvc.perform(authPost("/api/auth/register", json(registerBody("Inact", "User", "inactive@example.com", "Password1"))))
+                .andExpect(status().isCreated());
+        // Recently registered but deactivated → no grace
+        jdbcTemplate.update("UPDATE users SET status = 'INACTIVE' WHERE email = ?", "inactive@example.com");
+        setRegisteredAgeHours("inactive@example.com", 1);
+
+        mockMvc.perform(authPost("/api/auth/login", json(loginBody("inactive@example.com", "Password1"))))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.error").value("ACCOUNT_NOT_ACTIVE"));
     }

--- a/backend/src/test/java/com/padelpro/auth/infrastructure/web/SecurityIntegrationTest.java
+++ b/backend/src/test/java/com/padelpro/auth/infrastructure/web/SecurityIntegrationTest.java
@@ -87,10 +87,11 @@ class SecurityIntegrationTest extends PostgresIntegrationTest {
     }
 
     @Test
-    @DisplayName("user_with_pending_status_receives_403_on_authenticated_endpoint")
-    void user_with_pending_status_receives_403_on_authenticated_endpoint() throws Exception {
-        // Change user to PENDING in DB after token was issued
+    @DisplayName("user_with_pending_status_past_grace_receives_403_on_authenticated_endpoint (D8)")
+    void user_with_pending_status_past_grace_receives_403_on_authenticated_endpoint() throws Exception {
+        // Change user to PENDING and age the registration beyond the 48h provisional grace window.
         activeUser.setStatus(UserStatus.PENDING);
+        activeUser.setRegisteredAt(OffsetDateTime.now().minusHours(49));
         userRepository.saveAndFlush(activeUser);
 
         mockMvc.perform(get("/api/usuarios/me")
@@ -98,6 +99,19 @@ class SecurityIntegrationTest extends PostgresIntegrationTest {
                 .andExpect(status().isForbidden())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.error").value("ACCOUNT_NOT_ACTIVE"));
+    }
+
+    @Test
+    @DisplayName("user_with_pending_status_within_grace_can_access_authenticated_endpoint (D8)")
+    void user_with_pending_status_within_grace_can_access_authenticated_endpoint() throws Exception {
+        // PENDING but registered recently → provisional access within the 48h window.
+        activeUser.setStatus(UserStatus.PENDING);
+        activeUser.setRegisteredAt(OffsetDateTime.now().minusHours(1));
+        userRepository.saveAndFlush(activeUser);
+
+        mockMvc.perform(get("/api/usuarios/me")
+                        .header("Authorization", "Bearer " + activeUserToken))
+                .andExpect(status().isOk());
     }
 
     // =========================================================================

--- a/backend/src/test/java/com/padelpro/auth/infrastructure/web/filter/UserStatusFilterTest.java
+++ b/backend/src/test/java/com/padelpro/auth/infrastructure/web/filter/UserStatusFilterTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -67,7 +66,8 @@ class UserStatusFilterTest {
     @BeforeEach
     void setUp() throws Exception {
         SecurityContextHolder.clearContext();
-        userStatusFilter = new UserStatusFilter(userRepositoryPort, auditLogRepositoryPort, objectMapper);
+        userStatusFilter = new UserStatusFilter(userRepositoryPort, auditLogRepositoryPort, objectMapper,
+                new com.padelpro.auth.domain.model.AccountAccessPolicy(java.time.Duration.ofHours(48)));
         responseWriter = new StringWriter();
     }
 
@@ -77,6 +77,10 @@ class UserStatusFilterTest {
     }
 
     private User buildUser(Long id, UserStatus status) {
+        return buildUser(id, status, OffsetDateTime.now());
+    }
+
+    private User buildUser(Long id, UserStatus status, OffsetDateTime registeredAt) {
         User user = new User(
                 "testuser",
                 "hash",
@@ -85,7 +89,7 @@ class UserStatusFilterTest {
                 "user@example.com",
                 UserRole.USER,
                 status,
-                OffsetDateTime.now(),
+                registeredAt,
                 OffsetDateTime.now()
         );
         // Reflectively set the id since User.id is managed by JPA
@@ -125,10 +129,11 @@ class UserStatusFilterTest {
     }
 
     @Test
-    @DisplayName("should_return_403_when_user_is_pending_despite_valid_jwt")
-    void should_return_403_when_user_is_pending_despite_valid_jwt() throws Exception {
+    @DisplayName("should_return_403_when_user_is_pending_past_grace_window (D8)")
+    void should_return_403_when_user_is_pending_past_grace_window() throws Exception {
         setAuthContext("42");
-        User pendingUser = buildUser(42L, UserStatus.PENDING);
+        // Registered 49h ago → past the 48h provisional grace window
+        User pendingUser = buildUser(42L, UserStatus.PENDING, OffsetDateTime.now().minusHours(49));
         when(userRepositoryPort.findById(42L)).thenReturn(Optional.of(pendingUser));
         when(response.getWriter()).thenReturn(new PrintWriter(responseWriter));
         when(request.getRemoteAddr()).thenReturn("127.0.0.1");
@@ -139,6 +144,20 @@ class UserStatusFilterTest {
         verify(response).setStatus(403);
         verify(filterChain, never()).doFilter(any(), any());
         verify(auditLogRepositoryPort).save(any(AuditLog.class));
+    }
+
+    @Test
+    @DisplayName("should_pass_through_when_user_is_pending_within_grace_window (D8)")
+    void should_pass_through_when_user_is_pending_within_grace_window() throws Exception {
+        setAuthContext("42");
+        // Registered 1h ago → within the 48h provisional grace window
+        User pendingUser = buildUser(42L, UserStatus.PENDING, OffsetDateTime.now().minusHours(1));
+        when(userRepositoryPort.findById(42L)).thenReturn(Optional.of(pendingUser));
+
+        userStatusFilter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+        verify(response, never()).setStatus(403);
     }
 
     @Test

--- a/backend/src/test/java/com/padelpro/usuarios/application/service/ChangeMyPasswordServiceTest.java
+++ b/backend/src/test/java/com/padelpro/usuarios/application/service/ChangeMyPasswordServiceTest.java
@@ -1,0 +1,84 @@
+package com.padelpro.usuarios.application.service;
+
+import com.padelpro.auth.domain.exception.AuthenticationException;
+import com.padelpro.auth.domain.exception.InvalidPasswordException;
+import com.padelpro.auth.domain.model.User;
+import com.padelpro.auth.domain.model.UserRole;
+import com.padelpro.auth.domain.model.UserStatus;
+import com.padelpro.auth.domain.port.out.AuditLogRepositoryPort;
+import com.padelpro.auth.domain.port.out.UserRepositoryPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link ChangeMyPasswordService} — the user's own forced/normal password change
+ * (D9). Verifies policy enforcement, BCrypt persistence and the clearing of must_change_password.
+ */
+@ExtendWith(MockitoExtension.class)
+class ChangeMyPasswordServiceTest {
+
+    @Mock
+    private UserRepositoryPort userRepository;
+
+    @Mock
+    private AuditLogRepositoryPort auditLogRepository;
+
+    private final BCryptPasswordEncoder encoder = new BCryptPasswordEncoder(4);
+
+    private ChangeMyPasswordService service;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        service = new ChangeMyPasswordService(userRepository, auditLogRepository, encoder);
+        user = new User(
+                "u@example.com", encoder.encode("OldPass1"), "U", "Ser", "u@example.com",
+                UserRole.USER, UserStatus.ACTIVE, OffsetDateTime.now(), OffsetDateTime.now());
+        user.setMustChangePassword(true);
+        lenient().when(userRepository.findById(7L)).thenReturn(Optional.of(user));
+        lenient().when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    @Test
+    void should_change_password_and_clear_flag_when_valid() {
+        service.changePassword(7L, "OldPass1", "NewPass1");
+
+        assertThat(user.isMustChangePassword()).isFalse();
+        assertThat(encoder.matches("NewPass1", user.getPasswordHash())).isTrue();
+        verify(userRepository).save(user);
+        verify(auditLogRepository).save(any());
+    }
+
+    @Test
+    void should_reject_when_current_password_wrong() {
+        assertThatThrownBy(() -> service.changePassword(7L, "WrongOld1", "NewPass1"))
+                .isInstanceOf(AuthenticationException.class);
+
+        assertThat(user.isMustChangePassword()).isTrue(); // unchanged
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    void should_reject_when_new_password_violates_policy() {
+        assertThatThrownBy(() -> service.changePassword(7L, "OldPass1", "weak"))
+                .isInstanceOf(InvalidPasswordException.class);
+
+        verify(userRepository, never()).save(any());
+    }
+}

--- a/backend/src/test/java/com/padelpro/usuarios/application/service/TemporaryPasswordGeneratorTest.java
+++ b/backend/src/test/java/com/padelpro/usuarios/application/service/TemporaryPasswordGeneratorTest.java
@@ -1,0 +1,38 @@
+package com.padelpro.usuarios.application.service;
+
+import com.padelpro.auth.domain.model.PasswordPolicy;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link TemporaryPasswordGenerator} (group 5.5) — an isolated generator that
+ * produces random passwords which always satisfy the {@link PasswordPolicy}.
+ */
+class TemporaryPasswordGeneratorTest {
+
+    private final TemporaryPasswordGenerator generator = new TemporaryPasswordGenerator();
+
+    @Test
+    void generated_password_satisfies_policy() {
+        for (int i = 0; i < 100; i++) {
+            String pwd = generator.generate();
+            // Must not throw
+            PasswordPolicy.validate(pwd);
+            assertThat(pwd).hasSizeGreaterThanOrEqualTo(8);
+        }
+    }
+
+    @Test
+    void generated_passwords_are_random_and_unique() {
+        Set<String> seen = new HashSet<>();
+        for (int i = 0; i < 100; i++) {
+            seen.add(generator.generate());
+        }
+        // Overwhelmingly likely all-distinct; allow a tiny margin against flakiness.
+        assertThat(seen).hasSizeGreaterThan(95);
+    }
+}

--- a/backend/src/test/java/com/padelpro/usuarios/application/service/UserAdminServiceTest.java
+++ b/backend/src/test/java/com/padelpro/usuarios/application/service/UserAdminServiceTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -48,6 +49,9 @@ class UserAdminServiceTest {
 
     @Mock
     private BCryptPasswordEncoder passwordEncoder;
+
+    @Mock
+    private TemporaryPasswordGenerator temporaryPasswordGenerator;
 
     @InjectMocks
     private UserAdminService userAdminService;
@@ -183,6 +187,53 @@ class UserAdminServiceTest {
     void should_throw_admin_self_deactivation_exception() {
         assertThatThrownBy(() -> userAdminService.deactivateUser(3L, 3L))
                 .isInstanceOf(AdminSelfDeactivationException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // resetPassword (D3/D4/D9)
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("should_reset_password_generate_temp_bcrypt_and_flag")
+    void should_reset_password_generate_temp_bcrypt_and_flag() {
+        when(userRepositoryPort.findById(2L)).thenReturn(Optional.of(activeUser));
+        when(temporaryPasswordGenerator.generate()).thenReturn("Temp0rary9");
+        when(passwordEncoder.encode("Temp0rary9")).thenReturn("$2a$12$tempHash");
+        when(userRepositoryPort.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(auditLogRepositoryPort.save(any(AuditLog.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        var result = userAdminService.resetPassword(2L, 3L);
+
+        // temporary password returned in clear exactly once
+        assertThat(result.temporaryPassword()).isEqualTo("Temp0rary9");
+        // persisted as BCrypt, flag set
+        assertThat(activeUser.getPasswordHash()).isEqualTo("$2a$12$tempHash");
+        assertThat(activeUser.isMustChangePassword()).isTrue();
+        verify(userRepositoryPort).save(activeUser);
+
+        // audit must NOT contain the temporary password (RN-RGPD-04)
+        ArgumentCaptor<AuditLog> captor = ArgumentCaptor.forClass(AuditLog.class);
+        verify(auditLogRepositoryPort).save(captor.capture());
+        AuditLog audit = captor.getValue();
+        String details = audit.getDetails() == null ? "" : audit.getDetails();
+        assertThat(details).doesNotContain("Temp0rary9");
+    }
+
+    @Test
+    @DisplayName("should_reject_admin_resetting_own_password (RN-AUTH-05)")
+    void should_reject_admin_resetting_own_password() {
+        assertThatThrownBy(() -> userAdminService.resetPassword(3L, 3L))
+                .isInstanceOf(AdminSelfDeactivationException.class);
+        verify(userRepositoryPort, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("should_throw_not_found_when_resetting_missing_user")
+    void should_throw_not_found_when_resetting_missing_user() {
+        when(userRepositoryPort.findById(999L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userAdminService.resetPassword(999L, 3L))
+                .isInstanceOf(UserNotFoundException.class);
     }
 
     // -------------------------------------------------------------------------

--- a/backend/src/test/java/com/padelpro/usuarios/infrastructure/web/AdminUsuariosControllerIntegrationTest.java
+++ b/backend/src/test/java/com/padelpro/usuarios/infrastructure/web/AdminUsuariosControllerIntegrationTest.java
@@ -197,4 +197,64 @@ class AdminUsuariosControllerIntegrationTest extends PostgresIntegrationTest {
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.error", is("USUARIO_NOT_FOUND")));
     }
+
+    // -------------------------------------------------------------------------
+    // PATCH /api/admin/usuarios/{id}/reset-password (D3/D4/D9)
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("PATCH /{id}/reset-password by ADMIN → 200, temp password once, BCrypt + flag")
+    void reset_password_by_admin_returns_temp_and_sets_flag() throws Exception {
+        String tempPassword = mockMvc.perform(patch("/api/admin/usuarios/{id}/reset-password", regularUser.getId())
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.user_id", is(regularUser.getId().intValue())))
+                .andExpect(jsonPath("$.temporary_password").isNotEmpty())
+                .andExpect(jsonPath("$.must_change_password", is(true)))
+                .andReturn().getResponse().getContentAsString();
+
+        String temp = objectMapper.readTree(tempPassword).get("temporary_password").asText();
+
+        User reloaded = userRepository.findByLogin(regularUser.getLogin()).orElseThrow();
+        assert reloaded.isMustChangePassword();
+        assert passwordEncoder.matches(temp, reloaded.getPasswordHash());
+        // never persisted in clear
+        assert !reloaded.getPasswordHash().equals(temp);
+    }
+
+    @Test
+    @DisplayName("After reset, login with the temp password succeeds and requires change")
+    void login_with_temp_password_requires_change() throws Exception {
+        String body = mockMvc.perform(patch("/api/admin/usuarios/{id}/reset-password", regularUser.getId())
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        String temp = objectMapper.readTree(body).get("temporary_password").asText();
+
+        // regularUser is ACTIVE, so login is allowed; response must flag must_change_password
+        mockMvc.perform(post("/api/auth/login")
+                        .header("X-Forwarded-For", "10.9.9.9")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("email", regularUser.getEmail(), "password", temp))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.must_change_password", is(true)));
+    }
+
+    @Test
+    @DisplayName("PATCH /{id}/reset-password with role USER → 403")
+    void reset_password_with_user_role_returns_403() throws Exception {
+        mockMvc.perform(patch("/api/admin/usuarios/{id}/reset-password", pendingUser.getId())
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("PATCH /{self}/reset-password → 422 (RN-AUTH-05 identity protection)")
+    void reset_own_password_returns_422() throws Exception {
+        mockMvc.perform(patch("/api/admin/usuarios/{id}/reset-password", adminUser.getId())
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.error", is("ADMIN_SELF_DEACTIVATION")));
+    }
 }

--- a/backend/src/test/java/com/padelpro/usuarios/infrastructure/web/UsuariosMeControllerIntegrationTest.java
+++ b/backend/src/test/java/com/padelpro/usuarios/infrastructure/web/UsuariosMeControllerIntegrationTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -131,6 +132,72 @@ class UsuariosMeControllerIntegrationTest extends PostgresIntegrationTest {
                         .content(objectMapper.writeValueAsString(body)))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.error", is("USUARIOS_EMAIL_CONFLICT")));
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /api/usuarios/me/password (D9 — forced/own password change)
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("POST /api/usuarios/me/password valid → 204, hash changes and flag cleared")
+    void change_password_valid_returns_204_and_clears_flag() throws Exception {
+        // Simulate a prior admin reset
+        testUser.setMustChangePassword(true);
+        userRepository.saveAndFlush(testUser);
+
+        Map<String, String> body = Map.of(
+                "current_password", "Password1",
+                "new_password", "BrandNew2");
+        mockMvc.perform(post("/api/usuarios/me/password")
+                        .header("Authorization", "Bearer " + userToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isNoContent());
+
+        User reloaded = userRepository.findByLogin("me.user").orElseThrow();
+        assert !reloaded.isMustChangePassword();
+        assert passwordEncoder.matches("BrandNew2", reloaded.getPasswordHash());
+        assert !passwordEncoder.matches("Password1", reloaded.getPasswordHash());
+    }
+
+    @Test
+    @DisplayName("POST /api/usuarios/me/password wrong current password → 401")
+    void change_password_wrong_current_returns_401() throws Exception {
+        Map<String, String> body = Map.of(
+                "current_password", "WrongOne1",
+                "new_password", "BrandNew2");
+        mockMvc.perform(post("/api/usuarios/me/password")
+                        .header("Authorization", "Bearer " + userToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error", is("AUTH_INVALID_CREDENTIALS")));
+    }
+
+    @Test
+    @DisplayName("POST /api/usuarios/me/password weak new password → 400 INVALID_PASSWORD")
+    void change_password_weak_new_returns_400() throws Exception {
+        Map<String, String> body = Map.of(
+                "current_password", "Password1",
+                "new_password", "weak");
+        mockMvc.perform(post("/api/usuarios/me/password")
+                        .header("Authorization", "Bearer " + userToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error", is("INVALID_PASSWORD")));
+    }
+
+    @Test
+    @DisplayName("POST /api/usuarios/me/password without JWT → 401")
+    void change_password_without_jwt_returns_401() throws Exception {
+        Map<String, String> body = Map.of(
+                "current_password", "Password1",
+                "new_password", "BrandNew2");
+        mockMvc.perform(post("/api/usuarios/me/password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isUnauthorized());
     }
 
     @Test

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -145,6 +145,7 @@ paths:
                     accessToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
                     refreshToken: "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4..."
                     expiresIn: 900
+                    mustChangePassword: false
         '400':
           $ref: '#/components/responses/ValidationError'
         '401':
@@ -328,6 +329,41 @@ paths:
         '409':
           $ref: '#/components/responses/Conflict'
 
+  /usuarios/me/password:
+    post:
+      tags: [Usuarios]
+      operationId: cambiarMiPassword
+      summary: Cambiar la contraseña propia
+      description: |
+        Cambia la contraseña del usuario autenticado. Requiere la contraseña actual.
+        Al completarse, se limpia el flag `mustChangePassword` de la cuenta (usado tras
+        un reset del administrador — ver `resetPasswordUsuario`).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [currentPassword, newPassword]
+              properties:
+                currentPassword:
+                  type: string
+                  format: password
+                  description: Contraseña actual (o la temporal recibida del admin)
+                newPassword:
+                  type: string
+                  format: password
+                  description: Nueva contraseña (debe cumplir la política de contraseñas)
+      responses:
+        '204':
+          description: Contraseña cambiada correctamente
+        '400':
+          description: La nueva contraseña no cumple la política (código `INVALID_PASSWORD`, con `details`)
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          description: No autenticado o contraseña actual incorrecta (`AUTH_INVALID_CREDENTIALS`)
+          $ref: '#/components/responses/Unauthorized'
+
   # ─── Usuarios — administración ─────────────────────────────────────────────
 
   /admin/usuarios:
@@ -492,6 +528,52 @@ paths:
           $ref: '#/components/responses/NotFound'
         '422':
           description: El usuario no estaba en estado PENDING
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /admin/usuarios/{id}/reset-password:
+    patch:
+      tags: [Usuarios]
+      operationId: resetPasswordUsuario
+      summary: Restablecer la contraseña de un usuario (ADMIN)
+      description: |
+        Genera una contraseña temporal para el usuario indicado, la persiste cifrada
+        (BCrypt) y marca la cuenta con `mustChangePassword = true`. La contraseña temporal
+        se devuelve en claro **una sola vez** en la respuesta para que el administrador la
+        comunique; nunca se registra en logs ni se vuelve a exponer. Requiere ROLE_ADMIN.
+        Un administrador no puede resetearse a sí mismo (RN-AUTH-05).
+      parameters:
+        - $ref: '#/components/parameters/UserIdParam'
+      responses:
+        '200':
+          description: Contraseña restablecida; contraseña temporal devuelta una sola vez
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [userId, temporaryPassword, mustChangePassword]
+                properties:
+                  userId:
+                    type: integer
+                    format: int64
+                    example: 42
+                  temporaryPassword:
+                    type: string
+                    description: Contraseña temporal en claro (mostrada una sola vez)
+                    example: "Xa7-tR9-Qm2"
+                  mustChangePassword:
+                    type: boolean
+                    example: true
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          description: El administrador intentó resetearse a sí mismo (`ADMIN_SELF_DEACTIVATION`)
           content:
             application/json:
               schema:
@@ -1363,6 +1445,13 @@ components:
           type: integer
           description: Segundos hasta la expiración del access token
           example: 900
+        mustChangePassword:
+          type: boolean
+          description: |
+            `true` si la cuenta debe cambiar la contraseña antes de usar la app
+            (p. ej. tras un reset del administrador). El cliente debe redirigir al
+            cambio obligatorio de contraseña.
+          example: false
 
     RefreshRequest:
       type: object

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,11 +1,15 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { AuthProvider } from './context/AuthContext';
 import { PrivateRoute } from './guards/PrivateRoute';
+import { AdminRoute } from './guards/AdminRoute';
 import { SplashPage } from './pages/SplashPage';
 import { LoginPage } from './pages/LoginPage';
 import { RegisterPage } from './pages/RegisterPage';
+import { ForgotPasswordPage } from './pages/ForgotPasswordPage';
+import { ChangePasswordPage } from './pages/ChangePasswordPage';
 import { HomePage } from './pages/HomePage';
 import { MiPerfilPage } from './pages/MiPerfilPage';
+import { AdminUsuariosPage } from './pages/AdminUsuariosPage';
 
 function App() {
   return (
@@ -16,11 +20,19 @@ function App() {
           <Route path="/" element={<SplashPage />} />
           <Route path="/login" element={<LoginPage />} />
           <Route path="/register" element={<RegisterPage />} />
+          <Route path="/forgot-password" element={<ForgotPasswordPage />} />
 
           {/* Rutas privadas */}
           <Route element={<PrivateRoute />}>
             <Route path="/home" element={<HomePage />} />
             <Route path="/perfil" element={<MiPerfilPage />} />
+            {/* Cambio de contraseña forzado (D9) — accesible a cualquier autenticado */}
+            <Route path="/cambiar-password" element={<ChangePasswordPage />} />
+          </Route>
+
+          {/* Rutas de administración — guard de rol ADMIN (D6) */}
+          <Route element={<AdminRoute />}>
+            <Route path="/admin/usuarios" element={<AdminUsuariosPage />} />
           </Route>
         </Routes>
       </BrowserRouter>

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,22 +1,68 @@
 // T-029 — AuthContext
 // El access token JWT vive SOLO en memoria React.
 // NUNCA se persiste en localStorage ni sessionStorage (RN-AUTH-09).
+//
+// acceso-cuenta-prod: además del token, la sesión guarda el `role` (para el
+// guard de rol AdminRoute — D6) y el flag `mustChangePassword` (D9), ambos
+// devueltos por POST /api/auth/login. Nada de esto se persiste.
 import React, { createContext, useContext, useState } from 'react';
+
+export interface Session {
+  accessToken: string;
+  role: string | null;
+  mustChangePassword: boolean;
+}
 
 interface AuthContextValue {
   accessToken: string | null;
-  setAccessToken: (token: string | null) => void;
+  role: string | null;
+  mustChangePassword: boolean;
   isAuthenticated: boolean;
+  /** Legacy setter — usado por HomePage/logout y tests existentes. */
+  setAccessToken: (token: string | null) => void;
+  /** Establece la sesión completa (token + role + mustChangePassword) tras el login. */
+  setSession: (session: Session) => void;
+  /** Limpia el flag de cambio forzado tras un cambio de contraseña correcto. */
+  clearMustChangePassword: () => void;
 }
 
 export const AuthContext = createContext<AuthContextValue | null>(null);
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
-  const [accessToken, setAccessToken] = useState<string | null>(null);
+  const [accessToken, setAccessTokenState] = useState<string | null>(null);
+  const [role, setRole] = useState<string | null>(null);
+  const [mustChangePassword, setMustChangePassword] = useState(false);
+
+  function setAccessToken(token: string | null) {
+    setAccessTokenState(token);
+    if (token === null) {
+      // Logout — limpiar toda la sesión.
+      setRole(null);
+      setMustChangePassword(false);
+    }
+  }
+
+  function setSession(session: Session) {
+    setAccessTokenState(session.accessToken);
+    setRole(session.role);
+    setMustChangePassword(session.mustChangePassword);
+  }
+
+  function clearMustChangePassword() {
+    setMustChangePassword(false);
+  }
 
   return (
     <AuthContext.Provider
-      value={{ accessToken, setAccessToken, isAuthenticated: !!accessToken }}
+      value={{
+        accessToken,
+        role,
+        mustChangePassword,
+        isAuthenticated: !!accessToken,
+        setAccessToken,
+        setSession,
+        clearMustChangePassword,
+      }}
     >
       {children}
     </AuthContext.Provider>

--- a/frontend/src/guards/AdminRoute.tsx
+++ b/frontend/src/guards/AdminRoute.tsx
@@ -1,0 +1,20 @@
+// 6.1 — AdminRoute: guard para rutas que requieren rol ADMIN (D6).
+// La autorización efectiva la impone el backend (/api/admin/** = ROLE_ADMIN);
+// este guard es defensa en profundidad / UX: evita que un USER vea el panel.
+// - No autenticado  → /login
+// - Autenticado sin rol ADMIN → /home
+// - ADMIN → renderiza la ruta anidada
+import { Navigate, Outlet } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+export function AdminRoute() {
+  const { isAuthenticated, role } = useAuth();
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
+  if (role !== 'ADMIN') {
+    return <Navigate to="/home" replace />;
+  }
+  return <Outlet />;
+}

--- a/frontend/src/pages/AdminUsuariosPage.module.css
+++ b/frontend/src/pages/AdminUsuariosPage.module.css
@@ -1,0 +1,264 @@
+/* AdminUsuariosPage — panel de administración de usuarios (acceso-cuenta-prod) */
+
+.adminPage {
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  background: var(--cream);
+  max-width: 720px;
+  margin: 0 auto;
+  width: 100%;
+  padding: 20px 24px 48px;
+  gap: 4px;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.header .p-logo {
+  text-decoration: none;
+  color: var(--ink);
+}
+
+.badge {
+  font-family: var(--font-body);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--lime);
+  background: var(--ink);
+  padding: 4px 10px;
+  border-radius: 999px;
+}
+
+.titleBlock {
+  padding: 24px 0 8px;
+}
+
+.eyebrow {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.titleBlock h1 {
+  font-family: var(--font-display);
+  font-size: 40px;
+  line-height: 0.95;
+  letter-spacing: -0.03em;
+  margin: 4px 0 0;
+  color: var(--ink);
+}
+
+.titleBlock em {
+  font-style: italic;
+  color: var(--olive);
+}
+
+.filterRow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 0;
+}
+
+.filterLabel {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.select {
+  border: 1.5px solid rgba(13, 13, 13, 0.2);
+  border-radius: 10px;
+  padding: 8px 12px;
+  font-size: 14px;
+  font-family: var(--font-body);
+  color: var(--ink);
+  background: var(--cream);
+  cursor: pointer;
+}
+
+.select:focus {
+  outline: none;
+  border-color: var(--ink);
+}
+
+/* --- Temporary reset password box (shown once) --- */
+.tempReset {
+  border: 2px solid var(--olive);
+  border-radius: 14px;
+  padding: 16px;
+  margin: 8px 0 16px;
+  background: rgba(107, 122, 63, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.tempTitle {
+  font-weight: 700;
+  font-size: 15px;
+  color: var(--ink);
+  margin: 0;
+}
+
+.tempFor {
+  font-size: 13px;
+  color: var(--muted);
+  margin: 0;
+}
+
+.tempCode {
+  font-family: monospace;
+  font-size: 20px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--ink);
+  background: var(--cream);
+  border: 1.5px dashed var(--olive);
+  border-radius: 8px;
+  padding: 10px 14px;
+  user-select: all;
+}
+
+.tempWarning {
+  font-size: 13px;
+  color: var(--error);
+  margin: 0;
+}
+
+/* --- Table --- */
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.table th {
+  text-align: left;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+  padding: 8px 8px;
+  border-bottom: 2px solid rgba(13, 13, 13, 0.12);
+}
+
+.table td {
+  padding: 14px 8px;
+  border-bottom: 1px solid rgba(13, 13, 13, 0.08);
+  vertical-align: top;
+}
+
+.userName {
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.userEmail {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.statusPill {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  padding: 3px 10px;
+  border-radius: 999px;
+  background: rgba(13, 13, 13, 0.08);
+  color: var(--ink);
+}
+
+.status_ACTIVE {
+  background: var(--lime);
+  color: var(--ink);
+}
+
+.status_PENDING {
+  background: rgba(224, 168, 0, 0.18);
+  color: #8a6500;
+}
+
+.status_INACTIVE {
+  background: rgba(221, 68, 68, 0.14);
+  color: var(--error);
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.actionBtn {
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 600;
+  padding: 6px 12px;
+  border-radius: 8px;
+  border: 1.5px solid rgba(13, 13, 13, 0.25);
+  background: transparent;
+  color: var(--ink);
+  cursor: pointer;
+  transition: border-color 0.15s ease, opacity 0.15s ease;
+}
+
+.actionBtn:hover:not(:disabled) {
+  border-color: var(--ink);
+}
+
+.actionBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.actionDanger {
+  color: var(--error);
+  border-color: rgba(221, 68, 68, 0.4);
+}
+
+.actionDanger:hover:not(:disabled) {
+  border-color: var(--error);
+}
+
+.empty {
+  padding: 32px 0;
+  text-align: center;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+/* --- Loading spinner --- */
+.loadingWrapper {
+  display: flex;
+  justify-content: center;
+  padding: 48px 0;
+}
+
+.spinner {
+  width: 32px;
+  height: 32px;
+  border: 3px solid rgba(13, 13, 13, 0.15);
+  border-top-color: var(--olive);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/frontend/src/pages/AdminUsuariosPage.tsx
+++ b/frontend/src/pages/AdminUsuariosPage.tsx
@@ -1,0 +1,257 @@
+// 6.3 + 6.4 — AdminUsuariosPage — panel de administración de usuarios (D7).
+// Lista usuarios, filtra por estado, aprueba pendientes, activa/desactiva y
+// resetea contraseñas (la temporal se muestra una sola vez — D3/D4).
+// Autorización real en backend (/api/admin/** = ROLE_ADMIN); el guard AdminRoute
+// es defensa en profundidad (D6).
+import { useCallback, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+import {
+  listUsuariosApi,
+  aprobarUsuarioApi,
+  updateUsuarioEstadoApi,
+  desactivarUsuarioApi,
+  resetPasswordApi,
+  AdminUsuario,
+} from '../services/adminUsuariosApi';
+import './pages.css';
+import styles from './AdminUsuariosPage.module.css';
+
+const STATUS_FILTERS = [
+  { value: '', label: 'Todos' },
+  { value: 'PENDING', label: 'Pendientes' },
+  { value: 'ACTIVE', label: 'Activos' },
+  { value: 'INACTIVE', label: 'Inactivos' },
+];
+
+export function AdminUsuariosPage() {
+  const { accessToken } = useAuth();
+
+  const [usuarios, setUsuarios] = useState<AdminUsuario[]>([]);
+  const [statusFilter, setStatusFilter] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<number | null>(null);
+
+  // Contraseña temporal mostrada una sola vez tras un reset (D4).
+  const [tempReset, setTempReset] = useState<{ email: string; password: string } | null>(null);
+
+  const load = useCallback(async () => {
+    if (!accessToken) return;
+    setLoading(true);
+    setErrorMsg(null);
+    try {
+      const page = await listUsuariosApi(accessToken, {
+        status: statusFilter || undefined,
+        page: 0,
+        size: 50,
+      });
+      setUsuarios(page.content);
+    } catch {
+      setErrorMsg('No se pudo cargar la lista de usuarios. Inténtalo de nuevo.');
+    } finally {
+      setLoading(false);
+    }
+  }, [accessToken, statusFilter]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function handleAprobar(id: number) {
+    if (!accessToken) return;
+    setBusyId(id);
+    setErrorMsg(null);
+    try {
+      await aprobarUsuarioApi(accessToken, id);
+      await load();
+    } catch {
+      setErrorMsg('No se pudo aprobar el usuario.');
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function handleDesactivar(id: number) {
+    if (!accessToken) return;
+    setBusyId(id);
+    setErrorMsg(null);
+    try {
+      await desactivarUsuarioApi(accessToken, id);
+      await load();
+    } catch {
+      setErrorMsg('No se pudo desactivar el usuario.');
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function handleActivar(id: number) {
+    if (!accessToken) return;
+    setBusyId(id);
+    setErrorMsg(null);
+    try {
+      await updateUsuarioEstadoApi(accessToken, id, 'ACTIVE');
+      await load();
+    } catch {
+      setErrorMsg('No se pudo activar el usuario.');
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function handleReset(usuario: AdminUsuario) {
+    if (!accessToken) return;
+    setBusyId(usuario.id);
+    setErrorMsg(null);
+    try {
+      const res = await resetPasswordApi(accessToken, usuario.id);
+      setTempReset({ email: usuario.email, password: res.temporary_password });
+    } catch {
+      setErrorMsg('No se pudo restablecer la contraseña.');
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  return (
+    <div className={styles.adminPage}>
+      <header className={styles.header}>
+        <Link to="/home" className="p-logo" aria-label="Volver al inicio">
+          <span className="p-dot" />
+          PadelPro
+        </Link>
+        <span className={styles.badge}>Admin</span>
+      </header>
+
+      <div className={styles.titleBlock}>
+        <span className={styles.eyebrow}>Gestión de acceso</span>
+        <h1>
+          Usuarios<br />
+          <em>del club.</em>
+        </h1>
+      </div>
+
+      <div className={styles.filterRow}>
+        <label className={styles.filterLabel} htmlFor="admin-status-filter">
+          Estado
+        </label>
+        <select
+          id="admin-status-filter"
+          className={styles.select}
+          value={statusFilter}
+          onChange={(e) => setStatusFilter(e.target.value)}
+        >
+          {STATUS_FILTERS.map((f) => (
+            <option key={f.value || 'all'} value={f.value}>
+              {f.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {errorMsg && (
+        <p className="p-error" role="alert">
+          {errorMsg}
+        </p>
+      )}
+
+      {/* Contraseña temporal — se muestra una sola vez (D4) */}
+      {tempReset && (
+        <div className={styles.tempReset} role="status">
+          <p className={styles.tempTitle}>Contraseña temporal generada</p>
+          <p className={styles.tempFor}>Para: {tempReset.email}</p>
+          <code className={styles.tempCode}>{tempReset.password}</code>
+          <p className={styles.tempWarning}>
+            Se muestra una sola vez. Comunícala al usuario de forma segura; deberá
+            cambiarla al iniciar sesión.
+          </p>
+          <button
+            type="button"
+            className="p-btn p-btn-outline"
+            onClick={() => setTempReset(null)}
+          >
+            Entendido, ocultar
+          </button>
+        </div>
+      )}
+
+      {loading ? (
+        <div className={styles.loadingWrapper}>
+          <div className={styles.spinner} role="status" aria-label="Cargando usuarios" />
+        </div>
+      ) : usuarios.length === 0 ? (
+        <p className={styles.empty}>No hay usuarios para el filtro seleccionado.</p>
+      ) : (
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th scope="col">Usuario</th>
+              <th scope="col">Estado</th>
+              <th scope="col">Acciones</th>
+            </tr>
+          </thead>
+          <tbody>
+            {usuarios.map((u) => (
+              <tr key={u.id}>
+                <td>
+                  <div className={styles.userName}>
+                    {u.firstName} {u.lastName}
+                  </div>
+                  <div className={styles.userEmail}>{u.email}</div>
+                </td>
+                <td>
+                  <span className={`${styles.statusPill} ${styles[`status_${u.status}`] ?? ''}`}>
+                    {u.status}
+                  </span>
+                </td>
+                <td>
+                  <div className={styles.actions}>
+                    {u.status === 'PENDING' && (
+                      <button
+                        type="button"
+                        className={styles.actionBtn}
+                        onClick={() => handleAprobar(u.id)}
+                        disabled={busyId === u.id}
+                      >
+                        Aprobar
+                      </button>
+                    )}
+                    {u.status === 'INACTIVE' && (
+                      <button
+                        type="button"
+                        className={styles.actionBtn}
+                        onClick={() => handleActivar(u.id)}
+                        disabled={busyId === u.id}
+                      >
+                        Activar
+                      </button>
+                    )}
+                    {u.status !== 'INACTIVE' && (
+                      <button
+                        type="button"
+                        className={`${styles.actionBtn} ${styles.actionDanger}`}
+                        onClick={() => handleDesactivar(u.id)}
+                        disabled={busyId === u.id}
+                      >
+                        Desactivar
+                      </button>
+                    )}
+                    <button
+                      type="button"
+                      className={styles.actionBtn}
+                      onClick={() => handleReset(u)}
+                      disabled={busyId === u.id}
+                    >
+                      Restablecer contraseña
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/ChangePasswordPage.module.css
+++ b/frontend/src/pages/ChangePasswordPage.module.css
@@ -1,0 +1,70 @@
+/* ChangePasswordPage — acceso-cuenta-prod (D9) */
+
+.page {
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  background: var(--cream);
+  max-width: 430px;
+  margin: 0 auto;
+  width: 100%;
+  padding: 28px 24px 40px;
+  gap: 8px;
+}
+
+.logo {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+}
+
+.hero {
+  padding: 24px 0 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.eyebrow {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.headline {
+  font-family: var(--font-display);
+  font-size: 42px;
+  line-height: 0.95;
+  letter-spacing: -0.03em;
+  margin: 0;
+  color: var(--ink);
+}
+
+.headline em {
+  font-style: italic;
+  color: var(--olive);
+}
+
+.notice {
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--ink);
+  background: rgba(224, 168, 0, 0.14);
+  border-left: 3px solid #e0a800;
+  padding: 10px 14px;
+  border-radius: 8px;
+  margin: 0;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  margin-top: 8px;
+}

--- a/frontend/src/pages/ChangePasswordPage.tsx
+++ b/frontend/src/pages/ChangePasswordPage.tsx
@@ -1,0 +1,153 @@
+// 7.4 — ChangePasswordPage (D9): cambio de contraseña forzado tras un reset.
+// Cuando el login devuelve must_change_password=true, el usuario aterriza aquí
+// y no puede usar la app hasta cambiarla. Usa POST /api/usuarios/me/password.
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import axios from 'axios';
+import { useAuth } from '../context/AuthContext';
+import { changeMyPasswordApi } from '../services/usuariosApi';
+import type { ApiError } from '../services/authApi';
+import { PasswordStrengthIndicator } from '../components/PasswordStrengthIndicator';
+import './pages.css';
+import styles from './ChangePasswordPage.module.css';
+
+const PASSWORD_ERROR_MESSAGES: Record<string, string> = {
+  MIN_LENGTH_8: 'La contraseña debe tener al menos 8 caracteres',
+  REQUIRES_UPPERCASE: 'La contraseña debe contener al menos una mayúscula',
+  REQUIRES_NUMBER: 'La contraseña debe contener al menos un número',
+};
+
+export function ChangePasswordPage() {
+  const { accessToken, mustChangePassword, clearMustChangePassword } = useAuth();
+  const navigate = useNavigate();
+
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setErrorMessage(null);
+
+    if (!currentPassword || !newPassword || !confirmPassword) {
+      setErrorMessage('Rellena todos los campos.');
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      setErrorMessage('Las contraseñas nuevas no coinciden.');
+      return;
+    }
+    if (!accessToken) return;
+
+    setSubmitting(true);
+    try {
+      await changeMyPasswordApi(accessToken, {
+        current_password: currentPassword,
+        new_password: newPassword,
+      });
+      clearMustChangePassword();
+      navigate('/home');
+    } catch (err) {
+      if (axios.isAxiosError(err)) {
+        const status = err.response?.status;
+        const body = err.response?.data as ApiError | undefined;
+        if (status === 401) {
+          setErrorMessage('La contraseña actual es incorrecta.');
+        } else if (status === 400 && body?.error === 'INVALID_PASSWORD') {
+          const detail = body.details?.[0];
+          setErrorMessage(
+            detail ? (PASSWORD_ERROR_MESSAGES[detail] ?? 'Contraseña no válida') : 'Contraseña no válida'
+          );
+        } else {
+          setErrorMessage('Error inesperado. Inténtalo de nuevo.');
+        }
+      } else {
+        setErrorMessage('Error inesperado. Inténtalo de nuevo.');
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className={styles.page}>
+      <div className={styles.logo}>
+        <span className="p-dot" />
+        PadelPro
+      </div>
+
+      <div className={styles.hero}>
+        <span className={styles.eyebrow}>Seguridad</span>
+        <h1 className={styles.headline}>
+          Cambia tu<br />
+          <em>contraseña.</em>
+        </h1>
+        {mustChangePassword && (
+          <p className={styles.notice}>
+            Estás usando una contraseña temporal. Por seguridad, debes establecer
+            una nueva antes de continuar.
+          </p>
+        )}
+      </div>
+
+      <form className={styles.form} onSubmit={handleSubmit} noValidate>
+        <div className="p-input-group">
+          <label className="p-input-label" htmlFor="cp-current">Contraseña actual</label>
+          <input
+            id="cp-current"
+            className="p-input"
+            type="password"
+            autoComplete="current-password"
+            value={currentPassword}
+            onChange={(e) => setCurrentPassword(e.target.value)}
+            required
+          />
+        </div>
+
+        <div className="p-input-group">
+          <label className="p-input-label" htmlFor="cp-new">Nueva contraseña</label>
+          <input
+            id="cp-new"
+            className="p-input"
+            type="password"
+            autoComplete="new-password"
+            value={newPassword}
+            onChange={(e) => setNewPassword(e.target.value)}
+            required
+          />
+          <PasswordStrengthIndicator password={newPassword} />
+        </div>
+
+        <div className="p-input-group">
+          <label className="p-input-label" htmlFor="cp-confirm">Confirmar nueva contraseña</label>
+          <input
+            id="cp-confirm"
+            className="p-input"
+            type="password"
+            autoComplete="new-password"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            required
+          />
+        </div>
+
+        {errorMessage && (
+          <p className="p-error" role="alert">
+            {errorMessage}
+          </p>
+        )}
+
+        <button
+          type="submit"
+          className="p-btn p-btn-primary"
+          disabled={submitting}
+        >
+          {submitting ? 'Guardando…' : 'Cambiar contraseña'}
+          <span className="p-arrow" aria-hidden="true">→</span>
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/pages/ForgotPasswordPage.module.css
+++ b/frontend/src/pages/ForgotPasswordPage.module.css
@@ -1,0 +1,69 @@
+/* ForgotPasswordPage — acceso-cuenta-prod (D3) */
+
+.page {
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  background: var(--cream);
+  max-width: 430px;
+  margin: 0 auto;
+  width: 100%;
+  padding: 28px 24px 40px;
+}
+
+.logo {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+}
+
+.content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 16px;
+}
+
+.eyebrow {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.headline {
+  font-family: var(--font-display);
+  font-size: 44px;
+  line-height: 0.95;
+  letter-spacing: -0.03em;
+  margin: 0;
+  color: var(--ink);
+}
+
+.headline em {
+  font-style: italic;
+  color: var(--olive);
+}
+
+.body {
+  font-size: 15px;
+  line-height: 1.5;
+  color: var(--ink);
+  opacity: 0.85;
+  max-width: 34ch;
+}
+
+.footer {
+  display: flex;
+  flex-direction: column;
+}
+
+.footer a {
+  text-decoration: none;
+}

--- a/frontend/src/pages/ForgotPasswordPage.tsx
+++ b/frontend/src/pages/ForgotPasswordPage.tsx
@@ -1,0 +1,37 @@
+// 7.1 — ForgotPasswordPage (D3): recuperación gobernada por el admin.
+// No hay reset self-service por email en esta fase; se indica al usuario que
+// contacte con el administrador del club.
+import { Link } from 'react-router-dom';
+import './pages.css';
+import styles from './ForgotPasswordPage.module.css';
+
+export function ForgotPasswordPage() {
+  return (
+    <div className={styles.page}>
+      <div className={styles.logo}>
+        <span className="p-dot" />
+        PadelPro
+      </div>
+
+      <div className={styles.content}>
+        <span className={styles.eyebrow}>Recuperar acceso</span>
+        <h1 className={styles.headline}>
+          ¿Olvidaste tu<br />
+          <em>contraseña?</em>
+        </h1>
+        <p className={styles.body}>
+          El acceso al club se gestiona de forma controlada. Para restablecer tu
+          contraseña, contacta con el <strong>administrador del club</strong>: él
+          generará una contraseña temporal que deberás cambiar en tu próximo inicio
+          de sesión.
+        </p>
+      </div>
+
+      <div className={styles.footer}>
+        <Link to="/login" className="p-btn p-btn-primary">
+          Volver al inicio de sesión <span className="p-arrow" aria-hidden="true">→</span>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -7,7 +7,7 @@ import './pages.css';
 import styles from './HomePage.module.css';
 
 export function HomePage() {
-  const { setAccessToken } = useAuth();
+  const { setAccessToken, role } = useAuth();
 
   function handleLogout() {
     setAccessToken(null);
@@ -63,6 +63,22 @@ export function HomePage() {
           <div className={styles.actionLabel}>Mi perfil</div>
           <div className={styles.actionSub}>Datos y configuración</div>
         </Link>
+
+        {/* Entrada de administración — solo visible para ADMIN (6.5, D6) */}
+        {role === 'ADMIN' && (
+          <Link to="/admin/usuarios" className={styles.action}>
+            <div className={styles.actionIco}>
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+                <circle cx="9" cy="7" r="4" />
+                <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
+                <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+              </svg>
+            </div>
+            <div className={styles.actionLabel}>Gestionar usuarios</div>
+            <div className={styles.actionSub}>Aprobar, activar y resetear</div>
+          </Link>
+        )}
       </div>
 
       {/* ── Logout ── */}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -12,7 +12,7 @@ export function LoginPage() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const { setAccessToken } = useAuth();
+  const { setSession } = useAuth();
   const navigate = useNavigate();
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
@@ -20,15 +20,32 @@ export function LoginPage() {
     setErrorMessage(null);
     try {
       const response = await loginApi({ email, password });
-      setAccessToken(response.access_token);
-      navigate('/home');
+      setSession({
+        accessToken: response.access_token,
+        role: response.role ?? null,
+        mustChangePassword: response.must_change_password ?? false,
+      });
+      // D9 — cambio forzado: si la cuenta debe cambiar la contraseña (tras un
+      // reset del admin), se redirige a la pantalla de cambio antes de entrar.
+      if (response.must_change_password) {
+        navigate('/cambiar-password');
+      } else {
+        navigate('/home');
+      }
     } catch (err) {
       if (axios.isAxiosError(err)) {
         const status = err.response?.status;
+        const body = err.response?.data as { error?: string } | undefined;
         if (status === 401) {
+          // Anti-enumeración: mensaje genérico de credenciales.
           setErrorMessage('Credenciales inválidas');
+        } else if (status === 403 && body?.error === 'ACCOUNT_NOT_ACTIVE') {
+          // D5 — cuenta pendiente de aprobación o desactivada (distinto de credenciales).
+          setErrorMessage(
+            'Tu cuenta aún no está activada. Contacta con el administrador del club.'
+          );
         } else if (status === 403) {
-          setErrorMessage('Tu cuenta aún no está activada. Contacta con el administrador.');
+          setErrorMessage('Tu cuenta aún no está activada. Contacta con el administrador del club.');
         } else if (status === 429) {
           setErrorMessage('Demasiados intentos. Inténtalo más tarde.');
         } else {
@@ -96,13 +113,9 @@ export function LoginPage() {
         </button>
 
         <div className={styles.footer}>
-          <button
-            type="button"
-            className="p-link"
-            onClick={() => {}}
-          >
+          <Link to="/forgot-password" className="p-link">
             ¿Olvidaste la contraseña?
-          </button>
+          </Link>
           <Link to="/register" className="p-link">
             Crear cuenta
           </Link>

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -69,7 +69,12 @@ export function RegisterPage() {
             ¡Cuenta creada!
           </h1>
           <p className={styles.step}>
-            Espera la aprobación del administrador para acceder.
+            Tu cuenta queda <strong>pendiente de aprobación</strong> por el
+            administrador del club.
+          </p>
+          <p className={styles.step}>
+            Mientras tanto, tienes <strong>acceso provisional durante 2 días</strong>{' '}
+            para empezar a usar la app.
           </p>
           <Link to="/login" className="p-link">
             Volver al inicio de sesión

--- a/frontend/src/services/adminUsuariosApi.ts
+++ b/frontend/src/services/adminUsuariosApi.ts
@@ -1,0 +1,92 @@
+// 6.2 — adminUsuariosApi — panel de administración de usuarios (D7).
+// Reutiliza los endpoints admin existentes del backend:
+//   GET    /api/admin/usuarios?status=&page=&size=   (listar/filtrar)
+//   PATCH  /api/admin/usuarios/{id}/aprobar          (PENDING → ACTIVE)
+//   PATCH  /api/admin/usuarios/{id}                  (cambiar estado)
+//   DELETE /api/admin/usuarios/{id}                  (desactivar)
+//   PATCH  /api/admin/usuarios/{id}/reset-password   (contraseña temporal, D3/D9)
+import axios from 'axios';
+
+const api = axios.create({ baseURL: '/api', withCredentials: true });
+
+function authHeader(token: string) {
+  return { headers: { Authorization: `Bearer ${token}` } };
+}
+
+export interface AdminUsuario {
+  id: number;
+  email: string;
+  firstName: string;
+  lastName: string;
+  status: string;
+  role: string;
+}
+
+export interface PagedUsuarios {
+  content: AdminUsuario[];
+  totalElements: number;
+  totalPages: number;
+  number: number;
+  size: number;
+}
+
+export interface ListUsuariosParams {
+  status?: string;
+  page?: number;
+  size?: number;
+}
+
+export interface ResetPasswordResponse {
+  user_id: number;
+  temporary_password: string;
+  must_change_password: boolean;
+}
+
+export async function listUsuariosApi(
+  token: string,
+  params: ListUsuariosParams = {}
+): Promise<PagedUsuarios> {
+  const { data } = await api.get<PagedUsuarios>('/admin/usuarios', {
+    ...authHeader(token),
+    params,
+  });
+  return data;
+}
+
+export async function aprobarUsuarioApi(token: string, id: number): Promise<AdminUsuario> {
+  const { data } = await api.patch<AdminUsuario>(
+    `/admin/usuarios/${id}/aprobar`,
+    {},
+    authHeader(token)
+  );
+  return data;
+}
+
+export async function updateUsuarioEstadoApi(
+  token: string,
+  id: number,
+  status: string
+): Promise<AdminUsuario> {
+  const { data } = await api.patch<AdminUsuario>(
+    `/admin/usuarios/${id}`,
+    { status },
+    authHeader(token)
+  );
+  return data;
+}
+
+export async function desactivarUsuarioApi(token: string, id: number): Promise<void> {
+  await api.delete(`/admin/usuarios/${id}`, authHeader(token));
+}
+
+export async function resetPasswordApi(
+  token: string,
+  id: number
+): Promise<ResetPasswordResponse> {
+  const { data } = await api.patch<ResetPasswordResponse>(
+    `/admin/usuarios/${id}/reset-password`,
+    {},
+    authHeader(token)
+  );
+  return data;
+}

--- a/frontend/src/services/authApi.ts
+++ b/frontend/src/services/authApi.ts
@@ -20,6 +20,9 @@ export interface LoginResponse {
   access_token: string;
   token_type: string;
   expires_in: number;
+  // acceso-cuenta-prod: el backend incluye el rol y el flag de cambio forzado (D9).
+  role?: string;
+  must_change_password?: boolean;
 }
 
 export interface RegisterResponse {

--- a/frontend/src/services/usuariosApi.ts
+++ b/frontend/src/services/usuariosApi.ts
@@ -35,3 +35,19 @@ export async function updateMeApi(token: string, req: UpdateMeRequest): Promise<
   });
   return data;
 }
+
+// acceso-cuenta-prod (D9) — cambio de contraseña propio.
+// POST /api/usuarios/me/password → 204; 401 (current mal); 400 INVALID_PASSWORD.
+export interface ChangePasswordRequest {
+  current_password: string;
+  new_password: string;
+}
+
+export async function changeMyPasswordApi(
+  token: string,
+  req: ChangePasswordRequest
+): Promise<void> {
+  await api.post('/usuarios/me/password', req, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+}

--- a/frontend/src/test/AdminRoute.test.tsx
+++ b/frontend/src/test/AdminRoute.test.tsx
@@ -1,0 +1,53 @@
+// 6.1 — AdminRoute guard (TDD RED)
+// D6: envuelve rutas que exigen role === 'ADMIN'. Un USER es redirigido; un
+// ADMIN pasa. Un no autenticado va a /login.
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { AuthContext } from '../context/AuthContext';
+import type { Session } from '../context/AuthContext';
+import { AdminRoute } from '../guards/AdminRoute';
+
+function renderWithRole(role: string | null, isAuthenticated: boolean) {
+  const value = {
+    accessToken: isAuthenticated ? 'tok' : null,
+    role,
+    mustChangePassword: false,
+    isAuthenticated,
+    setAccessToken: () => {},
+    setSession: (_: Session) => {},
+    clearMustChangePassword: () => {},
+  };
+  return render(
+    <AuthContext.Provider value={value}>
+      <MemoryRouter initialEntries={['/admin/usuarios']}>
+        <Routes>
+          <Route path="/login" element={<div>Login Page</div>} />
+          <Route path="/home" element={<div>Home Page</div>} />
+          <Route element={<AdminRoute />}>
+            <Route path="/admin/usuarios" element={<div>Admin Panel</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    </AuthContext.Provider>
+  );
+}
+
+describe('AdminRoute', () => {
+  it('lets an ADMIN through to the protected route', () => {
+    renderWithRole('ADMIN', true);
+    expect(screen.getByText('Admin Panel')).toBeDefined();
+  });
+
+  it('redirects a USER away from the admin route (to /home)', () => {
+    renderWithRole('USER', true);
+    expect(screen.queryByText('Admin Panel')).toBeNull();
+    expect(screen.getByText('Home Page')).toBeDefined();
+  });
+
+  it('redirects an unauthenticated visitor to /login', () => {
+    renderWithRole(null, false);
+    expect(screen.queryByText('Admin Panel')).toBeNull();
+    expect(screen.getByText('Login Page')).toBeDefined();
+  });
+});

--- a/frontend/src/test/AdminRoute.test.tsx
+++ b/frontend/src/test/AdminRoute.test.tsx
@@ -5,7 +5,6 @@ import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext';
-import type { Session } from '../context/AuthContext';
 import { AdminRoute } from '../guards/AdminRoute';
 
 function renderWithRole(role: string | null, isAuthenticated: boolean) {
@@ -15,7 +14,7 @@ function renderWithRole(role: string | null, isAuthenticated: boolean) {
     mustChangePassword: false,
     isAuthenticated,
     setAccessToken: () => {},
-    setSession: (_: Session) => {},
+    setSession: () => {},
     clearMustChangePassword: () => {},
   };
   return render(

--- a/frontend/src/test/AdminUsuariosPage.test.tsx
+++ b/frontend/src/test/AdminUsuariosPage.test.tsx
@@ -7,7 +7,6 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import { http, HttpResponse } from 'msw';
 import { AuthContext } from '../context/AuthContext';
-import type { Session } from '../context/AuthContext';
 import { AdminUsuariosPage } from '../pages/AdminUsuariosPage';
 import { server } from './mocks/server';
 
@@ -17,7 +16,7 @@ const adminValue = {
   mustChangePassword: false,
   isAuthenticated: true,
   setAccessToken: () => {},
-  setSession: (_: Session) => {},
+  setSession: () => {},
   clearMustChangePassword: () => {},
 };
 

--- a/frontend/src/test/AdminUsuariosPage.test.tsx
+++ b/frontend/src/test/AdminUsuariosPage.test.tsx
@@ -1,0 +1,107 @@
+// 6.3 + 6.4 — AdminUsuariosPage (TDD RED)
+// 6.3: lista, filtra por estado (PENDING) y dispara aprobar.
+// 6.4: la acción de reset muestra la temporal devuelta UNA sola vez con aviso.
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { http, HttpResponse } from 'msw';
+import { AuthContext } from '../context/AuthContext';
+import type { Session } from '../context/AuthContext';
+import { AdminUsuariosPage } from '../pages/AdminUsuariosPage';
+import { server } from './mocks/server';
+
+const adminValue = {
+  accessToken: 'admin.jwt.token',
+  role: 'ADMIN',
+  mustChangePassword: false,
+  isAuthenticated: true,
+  setAccessToken: () => {},
+  setSession: (_: Session) => {},
+  clearMustChangePassword: () => {},
+};
+
+function renderPage() {
+  return render(
+    <AuthContext.Provider value={adminValue}>
+      <MemoryRouter>
+        <AdminUsuariosPage />
+      </MemoryRouter>
+    </AuthContext.Provider>
+  );
+}
+
+const usuarios = [
+  { id: 1, email: 'ana@test.com', firstName: 'Ana', lastName: 'Ruiz', status: 'PENDING', role: 'USER' },
+  { id: 2, email: 'leo@test.com', firstName: 'Leo', lastName: 'Paz', status: 'ACTIVE', role: 'USER' },
+];
+
+function pagedResponse(list: typeof usuarios) {
+  return {
+    content: list,
+    totalElements: list.length,
+    totalPages: 1,
+    number: 0,
+    size: 20,
+  };
+}
+
+describe('AdminUsuariosPage', () => {
+  beforeEach(() => {
+    server.use(
+      http.get('/api/admin/usuarios', ({ request }) => {
+        const status = new URL(request.url).searchParams.get('status');
+        const filtered = status ? usuarios.filter((u) => u.status === status) : usuarios;
+        return HttpResponse.json(pagedResponse(filtered));
+      })
+    );
+  });
+
+  it('6.3 — lists users on load', async () => {
+    renderPage();
+    expect(await screen.findByText('ana@test.com')).toBeDefined();
+    expect(screen.getByText('leo@test.com')).toBeDefined();
+  });
+
+  it('6.3 — filters by status PENDING', async () => {
+    renderPage();
+    await screen.findByText('ana@test.com');
+
+    await userEvent.selectOptions(screen.getByLabelText(/estado/i), 'PENDING');
+
+    await waitFor(() => {
+      expect(screen.getByText('ana@test.com')).toBeDefined();
+      expect(screen.queryByText('leo@test.com')).toBeNull();
+    });
+  });
+
+  it('6.3 — approves a PENDING user', async () => {
+    let approved = false;
+    server.use(
+      http.patch('/api/admin/usuarios/1/aprobar', () => {
+        approved = true;
+        return HttpResponse.json({ ...usuarios[0], status: 'ACTIVE' });
+      })
+    );
+    renderPage();
+    const row = (await screen.findByText('ana@test.com')).closest('tr') as HTMLElement;
+    await userEvent.click(within(row).getByRole('button', { name: /aprobar/i }));
+    await waitFor(() => expect(approved).toBe(true));
+  });
+
+  it('6.4 — reset shows the temporary password exactly once with a warning', async () => {
+    server.use(
+      http.patch('/api/admin/usuarios/2/reset-password', () =>
+        HttpResponse.json({ user_id: 2, temporary_password: 'Temp1234abc', must_change_password: true })
+      )
+    );
+    renderPage();
+    const row = (await screen.findByText('leo@test.com')).closest('tr') as HTMLElement;
+    await userEvent.click(within(row).getByRole('button', { name: /restablecer|reset/i }));
+
+    // The temporary password appears
+    expect(await screen.findByText('Temp1234abc')).toBeDefined();
+    // With a warning to communicate it and that the user must change it
+    expect(screen.getByText(/una sola vez|comun|cambi/i)).toBeDefined();
+  });
+});

--- a/frontend/src/test/AuthContext.session.test.tsx
+++ b/frontend/src/test/AuthContext.session.test.tsx
@@ -1,0 +1,64 @@
+// acceso-cuenta-prod — AuthContext session extension (role + mustChangePassword)
+// TDD RED: fails until AuthContext exposes role, mustChangePassword and setSession.
+import { render, screen, act } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { AuthProvider, useAuth } from '../context/AuthContext';
+
+function SessionConsumer() {
+  const { role, mustChangePassword, setSession, clearMustChangePassword } = useAuth();
+  return (
+    <div>
+      <span data-testid="role">{role ?? 'null'}</span>
+      <span data-testid="must-change">{mustChangePassword ? 'yes' : 'no'}</span>
+      <button
+        onClick={() =>
+          setSession({ accessToken: 'tok', role: 'ADMIN', mustChangePassword: true })
+        }
+      >
+        Login Admin
+      </button>
+      <button onClick={() => clearMustChangePassword()}>Clear Must Change</button>
+    </div>
+  );
+}
+
+describe('AuthContext session (acceso-cuenta-prod)', () => {
+  it('starts with null role and mustChangePassword false', () => {
+    render(
+      <AuthProvider>
+        <SessionConsumer />
+      </AuthProvider>
+    );
+    expect(screen.getByTestId('role')).toHaveTextContent('null');
+    expect(screen.getByTestId('must-change')).toHaveTextContent('no');
+  });
+
+  it('setSession stores role and mustChangePassword flag together', async () => {
+    render(
+      <AuthProvider>
+        <SessionConsumer />
+      </AuthProvider>
+    );
+    await act(async () => {
+      screen.getByRole('button', { name: /Login Admin/i }).click();
+    });
+    expect(screen.getByTestId('role')).toHaveTextContent('ADMIN');
+    expect(screen.getByTestId('must-change')).toHaveTextContent('yes');
+  });
+
+  it('clearMustChangePassword resets only the flag, keeps role', async () => {
+    render(
+      <AuthProvider>
+        <SessionConsumer />
+      </AuthProvider>
+    );
+    await act(async () => {
+      screen.getByRole('button', { name: /Login Admin/i }).click();
+    });
+    await act(async () => {
+      screen.getByRole('button', { name: /Clear Must Change/i }).click();
+    });
+    expect(screen.getByTestId('must-change')).toHaveTextContent('no');
+    expect(screen.getByTestId('role')).toHaveTextContent('ADMIN');
+  });
+});

--- a/frontend/src/test/ChangePasswordPage.test.tsx
+++ b/frontend/src/test/ChangePasswordPage.test.tsx
@@ -1,0 +1,102 @@
+// 7.4 — ChangePasswordPage (TDD RED): cambio de contraseña forzado.
+// Usa POST /api/usuarios/me/password. Al éxito limpia el flag y navega a /home.
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { http, HttpResponse } from 'msw';
+import { AuthContext } from '../context/AuthContext';
+import { ChangePasswordPage } from '../pages/ChangePasswordPage';
+import { server } from './mocks/server';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const clearFlag = vi.fn();
+
+function renderPage(mustChange = true) {
+  const value = {
+    accessToken: 'tok',
+    role: 'USER',
+    mustChangePassword: mustChange,
+    isAuthenticated: true,
+    setAccessToken: () => {},
+    setSession: () => {},
+    clearMustChangePassword: clearFlag,
+  };
+  return render(
+    <AuthContext.Provider value={value}>
+      <MemoryRouter>
+        <ChangePasswordPage />
+      </MemoryRouter>
+    </AuthContext.Provider>
+  );
+}
+
+async function fill(current = 'Temp1234', next = 'NewPass123', confirm = 'NewPass123') {
+  await userEvent.type(screen.getByLabelText(/contraseña actual/i), current);
+  await userEvent.type(screen.getByLabelText(/^nueva contraseña/i), next);
+  await userEvent.type(screen.getByLabelText(/confirm/i), confirm);
+  await userEvent.click(screen.getByRole('button', { name: /cambiar|guardar/i }));
+}
+
+describe('ChangePasswordPage', () => {
+  beforeEach(() => {
+    mockNavigate.mockReset();
+    clearFlag.mockReset();
+  });
+
+  it('7.4 — on success clears the flag and navigates to /home', async () => {
+    server.use(
+      http.post('/api/usuarios/me/password', () => new HttpResponse(null, { status: 204 }))
+    );
+    renderPage();
+    await fill();
+    await waitFor(() => {
+      expect(clearFlag).toHaveBeenCalled();
+      expect(mockNavigate).toHaveBeenCalledWith('/home');
+    });
+  });
+
+  it('shows an error when current password is wrong (401)', async () => {
+    server.use(
+      http.post('/api/usuarios/me/password', () =>
+        HttpResponse.json({ error: 'AUTH_INVALID_CREDENTIALS' }, { status: 401 })
+      )
+    );
+    renderPage();
+    await fill('WrongCurrent', 'NewPass123', 'NewPass123');
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/actual.*incorrecta|incorrecta/i);
+    });
+    expect(mockNavigate).not.toHaveBeenCalledWith('/home');
+  });
+
+  it('shows a policy error on 400 INVALID_PASSWORD', async () => {
+    server.use(
+      http.post('/api/usuarios/me/password', () =>
+        HttpResponse.json(
+          { error: 'INVALID_PASSWORD', details: ['MIN_LENGTH_8'] },
+          { status: 400 }
+        )
+      )
+    );
+    renderPage();
+    await fill('Temp1234', 'short', 'short');
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/8 caracteres|no válida/i);
+    });
+  });
+
+  it('validates that the confirmation matches before calling the API', async () => {
+    renderPage();
+    await fill('Temp1234', 'NewPass123', 'Mismatch999');
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/no coinciden/i);
+    });
+    expect(mockNavigate).not.toHaveBeenCalledWith('/home');
+  });
+});

--- a/frontend/src/test/ForgotPasswordPage.test.tsx
+++ b/frontend/src/test/ForgotPasswordPage.test.tsx
@@ -1,0 +1,26 @@
+// 7.1 — ForgotPasswordPage (TDD RED): mensaje "contacta con el administrador".
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { ForgotPasswordPage } from '../pages/ForgotPasswordPage';
+
+describe('ForgotPasswordPage', () => {
+  it('tells the user to contact the club administrator', () => {
+    render(
+      <MemoryRouter>
+        <ForgotPasswordPage />
+      </MemoryRouter>
+    );
+    expect(screen.getByText(/administrador del club/i)).toBeDefined();
+  });
+
+  it('offers a link back to login', () => {
+    render(
+      <MemoryRouter>
+        <ForgotPasswordPage />
+      </MemoryRouter>
+    );
+    const link = screen.getByRole('link', { name: /inicio de sesión|iniciar sesión|volver/i });
+    expect(link.getAttribute('href')).toBe('/login');
+  });
+});

--- a/frontend/src/test/HomePage.adminNav.test.tsx
+++ b/frontend/src/test/HomePage.adminNav.test.tsx
@@ -1,0 +1,39 @@
+// 6.5 — La entrada de navegación al panel admin solo se muestra a ADMIN.
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { AuthContext } from '../context/AuthContext';
+import type { Session } from '../context/AuthContext';
+import { HomePage } from '../pages/HomePage';
+
+function renderHome(role: string | null) {
+  const value = {
+    accessToken: 'tok',
+    role,
+    mustChangePassword: false,
+    isAuthenticated: true,
+    setAccessToken: () => {},
+    setSession: (_: Session) => {},
+    clearMustChangePassword: () => {},
+  };
+  return render(
+    <AuthContext.Provider value={value}>
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>
+    </AuthContext.Provider>
+  );
+}
+
+describe('HomePage admin nav', () => {
+  it('shows the admin panel link for ADMIN', () => {
+    renderHome('ADMIN');
+    const link = screen.getByRole('link', { name: /gestionar usuarios|administr|panel/i });
+    expect(link.getAttribute('href')).toBe('/admin/usuarios');
+  });
+
+  it('does not show the admin panel link for USER', () => {
+    renderHome('USER');
+    expect(screen.queryByRole('link', { name: /gestionar usuarios|administr|panel/i })).toBeNull();
+  });
+});

--- a/frontend/src/test/HomePage.adminNav.test.tsx
+++ b/frontend/src/test/HomePage.adminNav.test.tsx
@@ -3,7 +3,6 @@ import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext';
-import type { Session } from '../context/AuthContext';
 import { HomePage } from '../pages/HomePage';
 
 function renderHome(role: string | null) {
@@ -13,7 +12,7 @@ function renderHome(role: string | null) {
     mustChangePassword: false,
     isAuthenticated: true,
     setAccessToken: () => {},
-    setSession: (_: Session) => {},
+    setSession: () => {},
     clearMustChangePassword: () => {},
   };
   return render(

--- a/frontend/src/test/LoginPage.acceso.test.tsx
+++ b/frontend/src/test/LoginPage.acceso.test.tsx
@@ -1,0 +1,115 @@
+// 7.1 / 7.2 / 7.4 — LoginPage UX de acceso (TDD RED)
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { http, HttpResponse } from 'msw';
+import { AuthProvider } from '../context/AuthContext';
+import { LoginPage } from '../pages/LoginPage';
+import { server } from './mocks/server';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+function renderLogin() {
+  return render(
+    <AuthProvider>
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>
+    </AuthProvider>
+  );
+}
+
+async function submit(email = 'user@test.com', password = 'Password1') {
+  await userEvent.type(screen.getByLabelText(/Email/i), email);
+  await userEvent.type(screen.getByLabelText(/Contraseña/i), password);
+  await userEvent.click(screen.getByRole('button', { name: /Entrar/i }));
+}
+
+describe('LoginPage — UX de acceso (acceso-cuenta-prod)', () => {
+  beforeEach(() => {
+    mockNavigate.mockReset();
+  });
+
+  it('7.1 — "¿Olvidaste la contraseña?" navigates to /forgot-password', () => {
+    renderLogin();
+    const link = screen.getByRole('link', { name: /olvidaste la contraseña/i });
+    expect(link.getAttribute('href')).toBe('/forgot-password');
+  });
+
+  it('7.2 — maps 403 ACCOUNT_NOT_ACTIVE to a pending/blocked message', async () => {
+    server.use(
+      http.post('/api/auth/login', () =>
+        HttpResponse.json({ error: 'ACCOUNT_NOT_ACTIVE' }, { status: 403 })
+      )
+    );
+    renderLogin();
+    await submit('pending@test.com', 'Password1');
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/no está activada|pendiente/i);
+    });
+    expect(mockNavigate).not.toHaveBeenCalledWith('/home');
+  });
+
+  it('7.2 — maps 401 to invalid credentials', async () => {
+    server.use(
+      http.post('/api/auth/login', () =>
+        HttpResponse.json({ error: 'AUTH_INVALID_CREDENTIALS' }, { status: 401 })
+      )
+    );
+    renderLogin();
+    await submit('x@test.com', 'bad');
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/credenciales inválidas/i);
+    });
+  });
+
+  it('7.4 — redirects to forced password change when must_change_password is true', async () => {
+    server.use(
+      http.post('/api/auth/login', () =>
+        HttpResponse.json(
+          {
+            access_token: 'test.jwt.token',
+            token_type: 'Bearer',
+            expires_in: 900,
+            role: 'USER',
+            must_change_password: true,
+          },
+          { status: 200 }
+        )
+      )
+    );
+    renderLogin();
+    await submit('reset@test.com', 'Temp1234');
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/cambiar-password');
+    });
+    expect(mockNavigate).not.toHaveBeenCalledWith('/home');
+  });
+
+  it('7.4 — navigates to /home when must_change_password is false', async () => {
+    server.use(
+      http.post('/api/auth/login', () =>
+        HttpResponse.json(
+          {
+            access_token: 'test.jwt.token',
+            token_type: 'Bearer',
+            expires_in: 900,
+            role: 'USER',
+            must_change_password: false,
+          },
+          { status: 200 }
+        )
+      )
+    );
+    renderLogin();
+    await submit('ok@test.com', 'Password1');
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/home');
+    });
+  });
+});

--- a/frontend/src/test/RegisterPage.confirmacion.test.tsx
+++ b/frontend/src/test/RegisterPage.confirmacion.test.tsx
@@ -1,0 +1,39 @@
+// 7.3 — RegisterPage: pantalla de confirmación tras registro con acceso provisional.
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { http, HttpResponse } from 'msw';
+import { RegisterPage } from '../pages/RegisterPage';
+import { server } from './mocks/server';
+
+function renderRegister() {
+  return render(
+    <MemoryRouter>
+      <RegisterPage />
+    </MemoryRouter>
+  );
+}
+
+describe('RegisterPage confirmation (7.3)', () => {
+  it('shows pending-approval and 2-day provisional access after a successful register', async () => {
+    server.use(
+      http.post('/api/auth/register', () =>
+        HttpResponse.json({ id: 1, email: 'new@test.com', role: 'USER' }, { status: 201 })
+      )
+    );
+    renderRegister();
+
+    await userEvent.type(screen.getByLabelText(/Nombre/i), 'Ana');
+    await userEvent.type(screen.getByLabelText(/Apellido/i), 'Ruiz');
+    await userEvent.type(screen.getByLabelText(/Email/i), 'new@test.com');
+    await userEvent.type(screen.getByLabelText(/Contraseña/i), 'Password1');
+    await userEvent.click(screen.getByRole('button', { name: /Crear cuenta/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/pendiente de aprobación/i)).toBeDefined();
+    });
+    // Mención del acceso provisional de 2 días
+    expect(screen.getByText(/provisional|2 días|48/i)).toBeDefined();
+  });
+});

--- a/frontend/src/test/adminUsuariosApi.test.ts
+++ b/frontend/src/test/adminUsuariosApi.test.ts
@@ -1,0 +1,97 @@
+// 6.2 — adminUsuariosApi (TDD RED) — validado contra MSW.
+// Cubre: listar con filtro de estado, aprobar, actualizar estado, desactivar,
+// reset-password (temporal devuelta una vez).
+import { describe, it, expect, afterEach } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from './mocks/server';
+import {
+  listUsuariosApi,
+  aprobarUsuarioApi,
+  updateUsuarioEstadoApi,
+  desactivarUsuarioApi,
+  resetPasswordApi,
+} from '../services/adminUsuariosApi';
+
+const TOKEN = 'admin.jwt.token';
+
+afterEach(() => server.resetHandlers());
+
+describe('adminUsuariosApi', () => {
+  it('listUsuariosApi sends status/page/size and Authorization header', async () => {
+    let capturedUrl = '';
+    let capturedAuth = '';
+    server.use(
+      http.get('/api/admin/usuarios', ({ request }) => {
+        capturedUrl = request.url;
+        capturedAuth = request.headers.get('Authorization') ?? '';
+        return HttpResponse.json({
+          content: [
+            { id: 1, email: 'a@test.com', firstName: 'Ana', lastName: 'Ruiz', status: 'PENDING', role: 'USER' },
+          ],
+          totalElements: 1,
+          totalPages: 1,
+          number: 0,
+          size: 20,
+        });
+      })
+    );
+
+    const result = await listUsuariosApi(TOKEN, { status: 'PENDING', page: 0, size: 20 });
+
+    expect(capturedAuth).toBe(`Bearer ${TOKEN}`);
+    expect(capturedUrl).toContain('status=PENDING');
+    expect(capturedUrl).toContain('page=0');
+    expect(capturedUrl).toContain('size=20');
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].status).toBe('PENDING');
+  });
+
+  it('aprobarUsuarioApi calls PATCH .../aprobar', async () => {
+    let hit = false;
+    server.use(
+      http.patch('/api/admin/usuarios/7/aprobar', () => {
+        hit = true;
+        return HttpResponse.json({ id: 7, email: 'x@test.com', firstName: 'X', lastName: 'Y', status: 'ACTIVE', role: 'USER' });
+      })
+    );
+    const updated = await aprobarUsuarioApi(TOKEN, 7);
+    expect(hit).toBe(true);
+    expect(updated.status).toBe('ACTIVE');
+  });
+
+  it('updateUsuarioEstadoApi PATCHes the status field', async () => {
+    let body: unknown = null;
+    server.use(
+      http.patch('/api/admin/usuarios/7', async ({ request }) => {
+        body = await request.json();
+        return HttpResponse.json({ id: 7, email: 'x@test.com', firstName: 'X', lastName: 'Y', status: 'INACTIVE', role: 'USER' });
+      })
+    );
+    const updated = await updateUsuarioEstadoApi(TOKEN, 7, 'INACTIVE');
+    expect(body).toMatchObject({ status: 'INACTIVE' });
+    expect(updated.status).toBe('INACTIVE');
+  });
+
+  it('desactivarUsuarioApi calls DELETE', async () => {
+    let hit = false;
+    server.use(
+      http.delete('/api/admin/usuarios/7', () => {
+        hit = true;
+        return new HttpResponse(null, { status: 204 });
+      })
+    );
+    await desactivarUsuarioApi(TOKEN, 7);
+    expect(hit).toBe(true);
+  });
+
+  it('resetPasswordApi returns the temporary password once', async () => {
+    server.use(
+      http.patch('/api/admin/usuarios/7/reset-password', () =>
+        HttpResponse.json({ user_id: 7, temporary_password: 'Temp1234abc', must_change_password: true })
+      )
+    );
+    const result = await resetPasswordApi(TOKEN, 7);
+    expect(result.temporary_password).toBe('Temp1234abc');
+    expect(result.must_change_password).toBe(true);
+  });
+});

--- a/openspec/changes/acceso-cuenta-prod/.openspec.yaml
+++ b/openspec/changes/acceso-cuenta-prod/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-30

--- a/openspec/changes/acceso-cuenta-prod/design.md
+++ b/openspec/changes/acceso-cuenta-prod/design.md
@@ -52,7 +52,7 @@ La página `/admin/usuarios` consume `GET /api/admin/usuarios` (listar/filtrar),
 ### D8 — Periodo de gracia de 2 días para cuentas PENDING
 Un usuario recién registrado (`PENDING`) SHALL poder iniciar sesión y usar la app durante **48 horas desde su registro**. Pasado ese plazo, si sigue `PENDING` (no aprobado), el login SHALL devolver `403 ACCOUNT_NOT_ACTIVE`. La aprobación del admin lo deja `ACTIVE` de forma permanente.
 - **Alternativa:** bloquear `PENDING` desde el primer momento → la demo no sería "abierta" (nadie probaría sin que un admin apruebe primero).
-- **Razón:** concilia "demo abierta" (acceso inmediato provisional) con "simula control" (el admin debe aprobar para acceso continuado). La ventana se calcula sobre `users.created_at`. La transición a `INACTIVE` (desactivado por admin) no tiene gracia: bloquea siempre.
+- **Razón:** concilia "demo abierta" (acceso inmediato provisional) con "simula control" (el admin debe aprobar para acceso continuado). La ventana se calcula sobre `users.registered_at` (timestamp de registro; no existe columna `created_at`). La transición a `INACTIVE` (desactivado por admin) no tiene gracia: bloquea siempre.
 
 ### D9 — Cambio de contraseña forzado tras un reset
 Una contraseña temporal (generada por el admin en un reset) SHALL marcar la cuenta con `must_change_password = true`. En el siguiente login, el sistema SHALL exigir el cambio de contraseña antes de permitir el uso normal de la app; tras cambiarla, el flag se limpia.

--- a/openspec/changes/acceso-cuenta-prod/design.md
+++ b/openspec/changes/acceso-cuenta-prod/design.md
@@ -1,0 +1,91 @@
+## Context
+
+PadelPro está en producción pero el acceso es inutilizable y el relato de "sistema controlado" no se puede demostrar por la UI. La activación de cuentas ya existe en `usuarios` (backend): `GET /api/admin/usuarios` (listar con filtro de estado), `PATCH /api/admin/usuarios/{id}/aprobar` (PENDING→ACTIVE), `PATCH /api/admin/usuarios/{id}` (rol/estado), `DELETE` (desactivar). Lo que falta es: (a) un primer admin que arranque la cadena, (b) **interfaz** para que el admin gobierne el acceso, y (c) una vía de recuperación de contraseña coherente con el control.
+
+Frontend: React + Vite. `role` ya viaja en la respuesta de login y se muestra en el perfil; `PrivateRoute` solo comprueba autenticación (no rol). No hay servicio ni páginas admin. `UpdateUserAdminCommand` no admite contraseña. No hay SMTP ni `otp_codes`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Que exista siempre un admin `ACTIVE` tras un despliegue nuevo.
+- Que el admin gobierne el acceso **desde la UI**: ver pendientes, aprobar, activar/desactivar, y resetear contraseñas.
+- Que el usuario entienda por qué no puede entrar (pendiente vs credenciales) y dónde acudir si olvida la contraseña.
+
+**Non-Goals:**
+- Reset self-service por email (SMTP/`otp_codes`) — diferido a `notificaciones`.
+- Auto-activación del registro — se mantiene el flujo controlado.
+- OTP Telegram / bot / notificaciones.
+
+## Decisions
+
+### D1 — Bootstrap del primer admin vía runner idempotente con credenciales de entorno
+Un `ApplicationRunner` crea un admin `ACTIVE` solo si no existe ningún ADMIN, leyendo `ADMIN_EMAIL`/`ADMIN_PASSWORD` del entorno y cifrando con BCrypt. Idempotente; si faltan las variables no crea nada y no rompe el arranque.
+- **Alternativa:** seed por migración Flyway → no puede aplicar BCrypt ni leer entorno sin hash hardcodeado (inseguro).
+- **Razón (RN-AUTH-07):** hash en runtime desde un secreto del entorno, idempotente y sin credenciales en el repo.
+
+### D2 — Se mantiene `PENDING` + aprobación admin (no auto-activación)
+El registro deja `PENDING`; el admin aprueba. Es el comportamiento que la demo debe **simular** (control de acceso real).
+- **Razón:** auto-activar rompería la narrativa de sistema controlado; además el backend de aprobación ya existe.
+
+### D3 — Recuperación de contraseña gobernada por el admin (no email self-service)
+"¿Olvidaste la contraseña?" lleva a una pantalla "contacta con el administrador del club". El admin, desde el panel, dispara un reset que **genera una contraseña temporal**; el sistema la devuelve en claro **una sola vez** en la respuesta para que el admin la comunique, y la persiste cifrada (BCrypt).
+- **Alternativa A:** reset self-service por email + token (`otp_codes`, SMTP) → introduce infraestructura de email y no encaja con el modelo controlado de esta fase.
+- **Alternativa B:** el admin teclea la contraseña → el admin conocería/elegiría contraseñas (peor higiene).
+- **Razón:** la generación por el sistema evita que el admin elija contraseñas, no expone hashes, reutiliza el panel admin que ya se construye, y refuerza el relato de control sin SMTP.
+
+### D4 — La contraseña temporal se muestra una sola vez y nunca se loguea
+La respuesta del endpoint de reset incluye la contraseña temporal en claro exactamente una vez; no se persiste en claro ni aparece en logs (RN-RGPD-04).
+- **Razón:** minimizar la exposición del secreto temporal.
+
+### D5 — Distinción de error en login en el frontend (D6 de la versión previa)
+El backend ya devuelve `403 ACCOUNT_NOT_ACTIVE` vs `401`; el frontend mapea cada uno a un mensaje distinto.
+- **Razón (UX):** el usuario sabe si debe esperar aprobación o revisar credenciales.
+
+### D6 — Guard de rol en el frontend y nav condicionada
+Nuevo `AdminRoute` (envuelve rutas que exigen `role === ADMIN`); la entrada de navegación al panel solo se muestra a ADMIN. La autorización real la sigue imponiendo el backend (`/api/admin/**` requiere ROLE_ADMIN); el guard de frontend es UX/defensa en profundidad.
+- **Razón:** evitar que un USER vea u opere el panel; el backend es la barrera autoritativa.
+
+### D7 — El panel admin reutiliza los endpoints existentes (alcance v1 completo)
+La página `/admin/usuarios` consume `GET /api/admin/usuarios` (listar/filtrar), `PATCH .../aprobar`, `PATCH .../{id}` (estado), `DELETE .../{id}` (desactivar) y el nuevo reset. **Alcance v1: aprobar pendientes + activar/desactivar + resetear contraseña.** La edición de rol (USER↔ADMIN) queda fuera de v1.
+- **Razón:** el backend de gestión ya está; el trabajo es de frontend. Excluir la edición de rol reduce el riesgo de escalada de privilegios y respeta la protección de identidad del ADMIN (usuarios Requirement 3).
+
+### D8 — Periodo de gracia de 2 días para cuentas PENDING
+Un usuario recién registrado (`PENDING`) SHALL poder iniciar sesión y usar la app durante **48 horas desde su registro**. Pasado ese plazo, si sigue `PENDING` (no aprobado), el login SHALL devolver `403 ACCOUNT_NOT_ACTIVE`. La aprobación del admin lo deja `ACTIVE` de forma permanente.
+- **Alternativa:** bloquear `PENDING` desde el primer momento → la demo no sería "abierta" (nadie probaría sin que un admin apruebe primero).
+- **Razón:** concilia "demo abierta" (acceso inmediato provisional) con "simula control" (el admin debe aprobar para acceso continuado). La ventana se calcula sobre `users.created_at`. La transición a `INACTIVE` (desactivado por admin) no tiene gracia: bloquea siempre.
+
+### D9 — Cambio de contraseña forzado tras un reset
+Una contraseña temporal (generada por el admin en un reset) SHALL marcar la cuenta con `must_change_password = true`. En el siguiente login, el sistema SHALL exigir el cambio de contraseña antes de permitir el uso normal de la app; tras cambiarla, el flag se limpia.
+- **Alternativa:** solo recomendar el cambio → el usuario podría seguir con una contraseña que el admin conoció.
+- **Razón:** la contraseña temporal la conoce (transitoriamente) el admin al comunicarla; forzar el cambio cierra esa ventana. Aplica también, opcionalmente, al admin sembrado (D1) si se quiere endurecer.
+
+## Decisiones cerradas (antes Open Questions)
+
+- **Forzar cambio de la contraseña temporal:** SÍ (D9).
+- **Alcance del panel v1:** aprobar + activar/desactivar + reset; sin edición de rol (D7).
+- **Pantalla post-registro:** SÍ — tras registrarse, el usuario ve "cuenta creada, pendiente de aprobación; tienes acceso provisional durante 2 días" (alineado con D8).
+
+## Open Questions
+
+- ¿El periodo de gracia se comunica con una cuenta atrás visible (días restantes) en la UI, o solo como aviso?
+- ¿El cambio forzado (D9) aplica también al admin sembrado en su primer login, o solo a usuarios reseteados?
+
+## Risks / Trade-offs
+
+- **`ADMIN_PASSWORD` débil/filtrada (D1)** → admin comprometido. **Mitigación:** longitud mínima; `.env` fuera del repo; rotación documentada.
+- **Contraseña temporal interceptada al comunicarla (D3/D4)** → acceso indebido. **Mitigación:** mostrar una sola vez; TTL conceptual corto comunicado al usuario; (futuro) forzar cambio en el primer login.
+- **Guard de frontend confundido con seguridad (D6)** → si alguien cree que el guard protege, podría relajar el backend. **Mitigación:** documentar que el backend (`/api/admin/**` = ROLE_ADMIN) es la barrera real; el guard es solo UX.
+- **El admin se desactiva/elimina a sí mismo desde el panel** → lockout. **Mitigación:** el backend ya protege la identidad del ADMIN (usuarios Requirement 3, RN-AUTH-05); el panel debe respetar esos errores.
+- **Sin forzar cambio de la contraseña temporal** → el usuario podría no cambiarla. **Mitigación:** comunicarlo en UX; dejar el forzado como mejora futura (Open Questions).
+
+## Migration Plan
+
+1. Desplegar el backend con `ADMIN_EMAIL`/`ADMIN_PASSWORD` en el `.env` del EC2 → el runner crea el admin en el primer arranque.
+2. El frontend (panel + reset + pantallas) se despliega con el mismo pipeline.
+3. **Rollback:** additivo; el endpoint de reset y el panel se pueden retirar sin afectar datos; el admin sembrado se desactiva con el endpoint existente.
+
+## Open Questions
+
+- ¿Forzar el cambio de la contraseña temporal en el primer login? (recomendado; requiere un flag `must_change_password` y un flujo de cambio — evaluar coste).
+- ¿Alcance exacto del panel v1: solo aprobar pendientes, o también activar/desactivar, cambiar rol y resetear desde el inicio?
+- ¿Conviene una pantalla "mi cuenta está pendiente" tras el registro (además del mensaje en el login)?

--- a/openspec/changes/acceso-cuenta-prod/proposal.md
+++ b/openspec/changes/acceso-cuenta-prod/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+La app está desplegada pero **nadie puede iniciar sesión** y el flujo de acceso controlado no se puede demostrar por la interfaz. Es una **demo abierta que debe simular un sistema controlado**: cualquiera puede registrarse, pero el acceso lo gobierna un administrador (registro → `PENDING` → el admin aprueba → `ACTIVE`). Hoy faltan tres piezas para que eso funcione end-to-end:
+
+1. **No existe ningún administrador** (BD prod: 1 usuario, 0 admins, 0 activos) → nadie puede aprobar a nadie.
+2. **No hay panel admin en el frontend** → el admin solo podría aprobar por `curl`; la "simulación de control" es invisible. (El backend ya tiene los endpoints: listar, aprobar, activar/desactivar.)
+3. **"¿Olvidaste la contraseña?" es un placeholder muerto** (`onClick` vacío) y el login muestra "Credenciales inválidas" también cuando la cuenta está pendiente.
+
+En un sistema controlado, la recuperación de contraseña la gobierna el **admin** (no un reset self-service por email), lo que además evita introducir infraestructura de email en esta fase.
+
+Fase del producto: **fase-1**.
+
+## What Changes
+
+- **Administrador inicial** (desbloquea la cadena): un runner idempotente crea un admin `ACTIVE` desde variables de entorno si no existe ninguno (D1).
+- **Panel admin en el frontend** (la pieza que hace visible el control): guard por rol, página de gestión de usuarios (listar con filtro por estado, aprobar pendientes, activar/desactivar) y entrada de navegación visible solo para ADMIN. Reutiliza los endpoints ya existentes en la capability `usuarios`.
+- **Reset de contraseña gobernado por el admin** (en vez de email self-service): un nuevo endpoint admin genera una contraseña temporal, la muestra al admin **una sola vez** para que la comunique al usuario, y no expone hashes. El botón "¿Olvidaste la contraseña?" deja de estar muerto: lleva a una pantalla "contacta con el administrador del club".
+- **UX de errores de login**: el frontend distingue `ACCOUNT_NOT_ACTIVE` (403, cuenta pendiente) de credenciales inválidas (401), con mensajes claros.
+- **Acceso provisional de 2 días para cuentas nuevas** (D8): un usuario recién registrado (`PENDING`) puede usar la app durante 48 h desde el registro; pasado ese plazo sin aprobación del admin, queda bloqueado. Tras registrarse ve una pantalla de confirmación ("pendiente de aprobación; acceso provisional 2 días").
+- **Cambio de contraseña forzado tras un reset** (D9): la contraseña temporal marca la cuenta con `must_change_password`; en el siguiente login se exige cambiarla antes de usar la app.
+
+## Capabilities
+
+### New Capabilities
+_(ninguna — todo encaja en capabilities existentes)_
+
+### Modified Capabilities
+- `auth-local`: bootstrap del primer administrador en un despliegue nuevo; distinción explícita de cuenta-no-activa vs credenciales inválidas en el login; pantalla "olvidé la contraseña → contacta con el administrador".
+- `usuarios`: panel admin en el frontend para gestionar usuarios (listar/aprobar/activar/desactivar, ya soportado en backend) y nuevo reset de contraseña gobernado por el admin (genera contraseña temporal de un solo uso a mostrar).
+
+## Impact
+
+- **Backend** (`com.padelpro.usuarios`): nuevo endpoint admin de reset de contraseña que genera una contraseña temporal (BCrypt al persistir) y la devuelve en claro **una vez** en la respuesta; el resto de gestión de usuarios ya existe.
+- **Frontend**: nuevo `AdminRoute` (guard `role === ADMIN`); página `/admin/usuarios` (+ servicio `adminUsuariosApi`); entrada de nav condicionada a ADMIN; páginas/rutas `/forgot-password` (pantalla "contacta admin") y el mapeo del error `ACCOUNT_NOT_ACTIVE`; enlazado del botón de `LoginPage`.
+- **Config / Secrets**: `ADMIN_EMAIL`/`ADMIN_PASSWORD` en el `.env` del EC2 para el seed (D1).
+- **docs/DEPLOYMENT-RUNBOOK.md**: cómo se crea el primer admin en un despliegue nuevo.
+- **Sin** infraestructura de email (SMTP), **sin** tabla `otp_codes`, **sin** `spring-boot-starter-mail` en esta fase.
+
+## Fuera de alcance
+
+- **Reset self-service por email/token** (SMTP, plantillas, `otp_codes`): se difiere a cuando exista la capability `notificaciones`. En esta fase el reset lo gobierna el admin.
+- OTP por Telegram y bot (`auth-otp-telegram`) y `notificaciones`.
+- Auto-activación del registro (se mantiene deliberadamente el flujo `PENDING` → aprobación admin para simular control).
+- Verificación de email en el registro.
+- Gestión avanzada de roles/permisos y edición de rol desde el panel (USER↔ADMIN) — fuera de la v1.

--- a/openspec/changes/acceso-cuenta-prod/specs/auth-local/spec.md
+++ b/openspec/changes/acceso-cuenta-prod/specs/auth-local/spec.md
@@ -22,7 +22,7 @@ El sistema SHALL garantizar que exista al menos un administrador `ACTIVE` tras u
 
 ### Requirement: Acceso provisional de 2 días para cuentas pendientes
 
-El sistema SHALL permitir iniciar sesión a un usuario `PENDING` durante las 48 horas siguientes a su registro (calculadas sobre `created_at`). Pasado ese plazo sin aprobación, el login SHALL devolver `403 ACCOUNT_NOT_ACTIVE`. La aprobación del administrador deja la cuenta `ACTIVE` de forma permanente; una cuenta `INACTIVE` (desactivada por el admin) no tiene periodo de gracia y SHALL bloquearse siempre.
+El sistema SHALL permitir iniciar sesión a un usuario `PENDING` durante las 48 horas siguientes a su registro (calculadas sobre `registered_at`). Pasado ese plazo sin aprobación, el login SHALL devolver `403 ACCOUNT_NOT_ACTIVE`. La aprobación del administrador deja la cuenta `ACTIVE` de forma permanente; una cuenta `INACTIVE` (desactivada por el admin) no tiene periodo de gracia y SHALL bloquearse siempre.
 
 #### Scenario: PENDING dentro de la ventana de gracia
 - **GIVEN** un usuario `PENDING` registrado hace menos de 48 horas

--- a/openspec/changes/acceso-cuenta-prod/specs/auth-local/spec.md
+++ b/openspec/changes/acceso-cuenta-prod/specs/auth-local/spec.md
@@ -1,0 +1,86 @@
+## ADDED Requirements
+
+### Requirement: Administrador inicial en un despliegue nuevo
+
+El sistema SHALL garantizar que exista al menos un administrador `ACTIVE` tras un despliegue nuevo, creándolo de forma idempotente a partir de credenciales del entorno cuando no exista ningún administrador, con la contraseña cifrada en BCrypt (RN-AUTH-07).
+
+#### Scenario: Primer arranque sin ningún administrador
+- **GIVEN** una base de datos sin ningún usuario con rol ADMIN
+- **AND** las variables `ADMIN_EMAIL` y `ADMIN_PASSWORD` están definidas en el entorno
+- **WHEN** el backend arranca
+- **THEN** se crea un usuario ADMIN con estado `ACTIVE` y la contraseña cifrada con BCrypt
+
+#### Scenario: Arranque cuando ya existe un administrador
+- **GIVEN** ya existe al menos un usuario con rol ADMIN
+- **WHEN** el backend arranca de nuevo
+- **THEN** no se crea ningún administrador adicional (operación idempotente)
+
+#### Scenario: Arranque sin credenciales de admin configuradas
+- **GIVEN** no existe ningún ADMIN y `ADMIN_EMAIL`/`ADMIN_PASSWORD` no están definidas
+- **WHEN** el backend arranca
+- **THEN** el arranque no falla y no se crea ningún administrador
+
+### Requirement: Acceso provisional de 2 días para cuentas pendientes
+
+El sistema SHALL permitir iniciar sesión a un usuario `PENDING` durante las 48 horas siguientes a su registro (calculadas sobre `created_at`). Pasado ese plazo sin aprobación, el login SHALL devolver `403 ACCOUNT_NOT_ACTIVE`. La aprobación del administrador deja la cuenta `ACTIVE` de forma permanente; una cuenta `INACTIVE` (desactivada por el admin) no tiene periodo de gracia y SHALL bloquearse siempre.
+
+#### Scenario: PENDING dentro de la ventana de gracia
+- **GIVEN** un usuario `PENDING` registrado hace menos de 48 horas
+- **WHEN** inicia sesión con credenciales correctas
+- **THEN** el sistema responde 200 y permite el uso provisional de la app
+
+#### Scenario: PENDING fuera de la ventana de gracia
+- **GIVEN** un usuario `PENDING` registrado hace más de 48 horas
+- **WHEN** intenta iniciar sesión con credenciales correctas
+- **THEN** el sistema responde 403 con `code: "ACCOUNT_NOT_ACTIVE"`
+
+#### Scenario: Cuenta desactivada no tiene gracia
+- **GIVEN** un usuario `INACTIVE`
+- **WHEN** intenta iniciar sesión
+- **THEN** el sistema responde 403 con `code: "ACCOUNT_NOT_ACTIVE"` independientemente de su antigüedad
+
+### Requirement: Distinción entre cuenta no activa y credenciales inválidas en el login
+
+El sistema SHALL diferenciar una cuenta no activa (403 `ACCOUNT_NOT_ACTIVE`) de credenciales inválidas (401), y la interfaz web SHALL mostrar mensajes distintos para cada caso.
+
+#### Scenario: Login con credenciales incorrectas
+- **WHEN** un usuario intenta iniciar sesión con un email inexistente o una contraseña incorrecta
+- **THEN** el sistema responde 401
+- **AND** la interfaz web muestra un mensaje de credenciales inválidas
+
+#### Scenario: La UI distingue cuenta pendiente/bloqueada de credenciales
+- **WHEN** el login devuelve `403 ACCOUNT_NOT_ACTIVE`
+- **THEN** la interfaz web muestra un mensaje de cuenta pendiente/no activa, distinto del de credenciales inválidas
+
+### Requirement: Confirmación tras el registro
+
+La interfaz web SHALL mostrar, tras un registro correcto, una pantalla de confirmación que informe de que la cuenta queda pendiente de aprobación del administrador y de que dispone de acceso provisional durante 2 días.
+
+#### Scenario: Pantalla posterior al registro
+- **WHEN** un usuario completa el registro con éxito
+- **THEN** ve una confirmación indicando que su cuenta está pendiente de aprobación y que tiene acceso provisional de 2 días
+
+### Requirement: Cambio de contraseña forzado tras un restablecimiento
+
+Cuando una cuenta tiene `must_change_password = true` (tras un reset del administrador), el sistema SHALL exigir el cambio de contraseña en el siguiente acceso antes de permitir el uso normal de la app, y SHALL limpiar el flag al cambiarla.
+
+#### Scenario: Login con cambio de contraseña pendiente
+- **GIVEN** una cuenta con `must_change_password = true`
+- **WHEN** el usuario inicia sesión con la contraseña temporal
+- **THEN** la interfaz web le exige establecer una nueva contraseña antes de continuar
+
+#### Scenario: Tras cambiar la contraseña se limpia el flag
+- **WHEN** el usuario establece una nueva contraseña válida
+- **THEN** `must_change_password` pasa a `false` y puede usar la app con normalidad
+
+### Requirement: Recuperación de contraseña gobernada por el administrador
+
+La interfaz web SHALL ofrecer, desde el login, una vía para los usuarios que olvidan su contraseña que los dirija a contactar con el administrador del club; el restablecimiento efectivo lo realiza el administrador (ver capability `usuarios`). El sistema SHALL NOT exponer un reset self-service por email en esta fase.
+
+#### Scenario: Usuario pulsa "¿Olvidaste la contraseña?"
+- **WHEN** el usuario pulsa "¿Olvidaste la contraseña?" en la pantalla de login
+- **THEN** la app navega a una pantalla que le indica contactar con el administrador del club para restablecer su acceso
+
+#### Scenario: No existe endpoint público de reset por email
+- **WHEN** se inspecciona la API pública de autenticación
+- **THEN** no existe ningún endpoint de reset self-service por email/token en esta fase

--- a/openspec/changes/acceso-cuenta-prod/specs/usuarios/spec.md
+++ b/openspec/changes/acceso-cuenta-prod/specs/usuarios/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: Panel de administración de usuarios en la interfaz web
+
+La interfaz web SHALL ofrecer a los administradores un panel para gobernar el acceso de los usuarios: listar usuarios con filtro por estado, aprobar cuentas pendientes y activar/desactivar cuentas. El panel SHALL ser accesible solo para usuarios con rol ADMIN; la autorización efectiva la impone el backend (`/api/admin/**` requiere ROLE_ADMIN) y el frontend añade un guard por rol como defensa en profundidad.
+
+#### Scenario: ADMIN accede al panel de usuarios
+- **GIVEN** un usuario autenticado con rol ADMIN
+- **WHEN** navega al panel de administración de usuarios
+- **THEN** ve la lista de usuarios y puede filtrar por estado (p. ej. `PENDING`)
+
+#### Scenario: USER no puede acceder al panel
+- **GIVEN** un usuario autenticado con rol USER
+- **WHEN** intenta acceder a la ruta del panel admin
+- **THEN** el frontend impide el acceso (redirección) y el backend rechazaría cualquier operación admin con 403
+
+#### Scenario: ADMIN aprueba una cuenta pendiente desde el panel
+- **GIVEN** existe un usuario en estado `PENDING`
+- **WHEN** el ADMIN pulsa aprobar en el panel
+- **THEN** el usuario pasa a `ACTIVE` (vía `PATCH /api/admin/usuarios/{id}/aprobar`)
+- **AND** ese usuario puede iniciar sesión a continuación
+
+#### Scenario: ADMIN activa o desactiva una cuenta
+- **WHEN** el ADMIN cambia el estado de una cuenta desde el panel
+- **THEN** el cambio se refleja vía los endpoints admin existentes y el listado se actualiza
+
+### Requirement: Restablecimiento de contraseña por el administrador
+
+El sistema SHALL permitir a un administrador restablecer la contraseña de un usuario generando una contraseña temporal; la contraseña temporal SHALL devolverse en claro exactamente una vez en la respuesta para que el administrador la comunique, SHALL persistirse cifrada con BCrypt, SHALL marcar la cuenta con `must_change_password = true` y SHALL NOT aparecer en ningún log (RN-RGPD-04, RN-AUTH-07).
+
+#### Scenario: ADMIN restablece la contraseña de un usuario
+- **GIVEN** un usuario existente
+- **WHEN** el ADMIN dispara el restablecimiento de contraseña desde el panel
+- **THEN** el sistema genera una contraseña temporal, la persiste cifrada con BCrypt
+- **AND** marca la cuenta con `must_change_password = true`
+- **AND** la devuelve en claro una sola vez en la respuesta al ADMIN
+- **AND** el usuario puede iniciar sesión con la contraseña temporal y se le exige cambiarla
+
+#### Scenario: La contraseña temporal no se expone fuera de la respuesta única
+- **WHEN** se genera una contraseña temporal
+- **THEN** no aparece en logs ni se persiste en claro
+- **AND** una consulta posterior del usuario no devuelve la contraseña
+
+#### Scenario: USER no puede resetear contraseñas de otros
+- **WHEN** un usuario con rol USER intenta el endpoint de restablecimiento
+- **THEN** el sistema responde 403

--- a/openspec/changes/acceso-cuenta-prod/tasks.md
+++ b/openspec/changes/acceso-cuenta-prod/tasks.md
@@ -32,11 +32,11 @@
 
 ## 4. Cambio de contraseña forzado (auth-local) — TDD
 
-- [ ] 4.1 🔴 Test: el login de una cuenta con `must_change_password=true` señala el cambio requerido en la respuesta
-- [ ] 4.2 🟢 Exponer el flag en la respuesta de login (mínimo) → verde
-- [ ] 4.3 🔴 Test: endpoint de cambio de contraseña propio valida política, guarda BCrypt y pone `must_change_password=false`
-- [ ] 4.4 🟢 Implementar/extender el endpoint (`/usuarios/me` o dedicado) → verde
-- [ ] 4.5 🔴 Test de seguridad: contraseña que no cumple política → 400; no se loguea → 🟢 / ♻️
+- [x] 4.1 🔴 Test: el login de una cuenta con `must_change_password=true` señala el cambio requerido en la respuesta
+- [x] 4.2 🟢 Exponer el flag en la respuesta de login (mínimo) → verde
+- [x] 4.3 🔴 Test: endpoint de cambio de contraseña propio valida política, guarda BCrypt y pone `must_change_password=false`
+- [x] 4.4 🟢 Implementar/extender el endpoint (`/usuarios/me` o dedicado) → verde
+- [x] 4.5 🔴 Test de seguridad: contraseña que no cumple política → 400; no se loguea → 🟢 / ♻️
 
 ## 5. Reset de contraseña por el admin (usuarios) — TDD
 

--- a/openspec/changes/acceso-cuenta-prod/tasks.md
+++ b/openspec/changes/acceso-cuenta-prod/tasks.md
@@ -1,0 +1,78 @@
+# Tasks — acceso-cuenta-prod (TDD)
+
+> Ciclo por unidad: **🔴 Red** (test que falla) → **🟢 Green** (implementación mínima) → **♻️ Refactor**.
+> Backend contra PostgreSQL real (`:5433`, base `PostgresIntegrationTest`); frontend con vitest (test de componente primero). Fuente autoritativa: `docs/TESTING-STRATEGY.md`.
+
+## 0. Gestión y arranque (orquestador)
+
+- [ ] 0.1 Crear/identificar Issue en GitHub y obtener su número
+- [ ] 0.2 Crear rama `feat/<id>-acceso-cuenta-prod` desde `develop` y push
+- [ ] 0.3 Mover el item del Project v2 a "In Progress"
+- [ ] 0.4 Releer `docs/TESTING-STRATEGY.md` y fijar convenciones (naming, fixtures, perfiles)
+
+## 1. Esquema base (habilitador de los ciclos)
+
+- [ ] 1.1 Migración: `users.must_change_password BOOLEAN NOT NULL DEFAULT false` (con test de migración que verifica la columna y el default)
+
+## 2. Seed del primer admin (auth-local) — TDD
+
+- [ ] 2.1 🔴 Test: con BD sin ADMIN y `ADMIN_EMAIL`/`ADMIN_PASSWORD` definidos, al arrancar se crea un ADMIN `ACTIVE` con hash BCrypt
+- [ ] 2.2 🟢 Implementar el `ApplicationRunner` mínimo que hace pasar 2.1
+- [ ] 2.3 🔴 Test: si ya existe un ADMIN, el arranque no crea otro (idempotente) → 🟢 ajustar
+- [ ] 2.4 🔴 Test: sin variables de entorno, el arranque no falla y no crea admin → 🟢 ajustar
+- [ ] 2.5 ♻️ Refactor (extraer servicio/política) manteniendo verde; documentar `ADMIN_EMAIL`/`ADMIN_PASSWORD` en `.env.example` y runbook
+
+## 3. Acceso provisional de 2 días + bloqueo (auth-local) — TDD
+
+- [ ] 3.1 🔴 Test: usuario `PENDING` con `created_at` < 48 h → login 200
+- [ ] 3.2 🟢 Modificar la regla de login para permitir PENDING dentro de la ventana (mínimo) → verde
+- [ ] 3.3 🔴 Test: `PENDING` con `created_at` > 48 h → 403 `ACCOUNT_NOT_ACTIVE` → 🟢 ajustar
+- [ ] 3.4 🔴 Test: `INACTIVE` → 403 siempre (sin gracia) y `ACTIVE` → 200 → 🟢 ajustar
+- [ ] 3.5 ♻️ Refactor de la política de acceso (objeto de dominio testeado en aislamiento)
+
+## 4. Cambio de contraseña forzado (auth-local) — TDD
+
+- [ ] 4.1 🔴 Test: el login de una cuenta con `must_change_password=true` señala el cambio requerido en la respuesta
+- [ ] 4.2 🟢 Exponer el flag en la respuesta de login (mínimo) → verde
+- [ ] 4.3 🔴 Test: endpoint de cambio de contraseña propio valida política, guarda BCrypt y pone `must_change_password=false`
+- [ ] 4.4 🟢 Implementar/extender el endpoint (`/usuarios/me` o dedicado) → verde
+- [ ] 4.5 🔴 Test de seguridad: contraseña que no cumple política → 400; no se loguea → 🟢 / ♻️
+
+## 5. Reset de contraseña por el admin (usuarios) — TDD
+
+- [ ] 5.1 🔴 Test: ADMIN resetea → 200, devuelve temporal en claro una vez, persiste BCrypt y marca `must_change_password=true`
+- [ ] 5.2 🟢 Implementar `PATCH /api/admin/usuarios/{id}/reset-password` mínimo → verde
+- [ ] 5.3 🔴 Test: login posterior con la temporal funciona y exige cambio → 🟢 ajustar
+- [ ] 5.4 🔴 Test: USER → 403; la temporal no aparece en logs; respeta protección de identidad ADMIN (RN-AUTH-05) → 🟢
+- [ ] 5.5 ♻️ Refactor (generador de contraseña temporal aislado y testeado)
+
+## 6. Panel admin de usuarios (frontend, usuarios) — test-first de componente
+
+- [ ] 6.1 🔴 Test: `AdminRoute` redirige a un USER y deja pasar a un ADMIN → 🟢 implementar guard
+- [ ] 6.2 🔴 Test: `adminUsuariosApi` (mock) — listar con filtro, aprobar, activar/desactivar, reset → 🟢 implementar servicio
+- [ ] 6.3 🔴 Test de componente: la página `/admin/usuarios` lista, filtra por estado y dispara aprobar → 🟢 implementar
+- [ ] 6.4 🔴 Test: la acción de reset muestra la temporal devuelta una sola vez (con aviso) → 🟢 implementar
+- [ ] 6.5 ♻️ Refactor + entrada de nav condicionada a ADMIN
+
+## 7. UX de acceso (frontend, auth-local) — test-first de componente
+
+- [ ] 7.1 🔴 Test: el botón "¿Olvidaste la contraseña?" navega a `/forgot-password` → 🟢 enlazar + pantalla "contacta con el administrador"
+- [ ] 7.2 🔴 Test: el login mapea `403 ACCOUNT_NOT_ACTIVE` → mensaje de cuenta pendiente/bloqueada y `401` → credenciales inválidas → 🟢 implementar
+- [ ] 7.3 🔴 Test: tras registro correcto se muestra la confirmación "pendiente de aprobación; acceso provisional 2 días" → 🟢 implementar
+- [ ] 7.4 🔴 Test: si el login indica `must_change_password`, se fuerza la pantalla de cambio antes de entrar → 🟢 implementar
+- [ ] 7.5 ♻️ Refactor de los componentes/estados de error
+
+## 8. API spec
+
+- [ ] 8.1 Actualizar `docs/openapi.yaml`: endpoint de reset admin (temporal de un solo uso), flag de cambio requerido en login, códigos
+
+## 9. QA (verificación adversarial, sobre código ya cubierto por TDD)
+
+- [ ] 9.1 `test-runner`: suite completa backend + frontend en verde (Postgres real :5433) y cobertura dentro del umbral JaCoCo
+- [ ] 9.2 `verification-specialist`: probes (reset solo ADMIN, temporal fuera de logs, gracia 48h en bordes, guard de rol, cambio forzado)
+- [ ] 9.3 `reality-checker`: journey end-to-end — seed admin → login admin → registro usuario (PENDING) → acceso provisional → admin aprueba en panel → reset admin → login con temporal → cambio forzado → uso normal
+
+## 10. Cierre
+
+- [ ] 10.1 PR con `Closes #<id>` y CI en verde
+- [ ] 10.2 Merge → deploy automático; en el `.env` del EC2 añadir `ADMIN_EMAIL`/`ADMIN_PASSWORD`; verificar login admin y panel en vivo

--- a/openspec/changes/acceso-cuenta-prod/tasks.md
+++ b/openspec/changes/acceso-cuenta-prod/tasks.md
@@ -24,11 +24,11 @@
 
 ## 3. Acceso provisional de 2 días + bloqueo (auth-local) — TDD
 
-- [ ] 3.1 🔴 Test: usuario `PENDING` con `created_at` < 48 h → login 200
-- [ ] 3.2 🟢 Modificar la regla de login para permitir PENDING dentro de la ventana (mínimo) → verde
-- [ ] 3.3 🔴 Test: `PENDING` con `created_at` > 48 h → 403 `ACCOUNT_NOT_ACTIVE` → 🟢 ajustar
-- [ ] 3.4 🔴 Test: `INACTIVE` → 403 siempre (sin gracia) y `ACTIVE` → 200 → 🟢 ajustar
-- [ ] 3.5 ♻️ Refactor de la política de acceso (objeto de dominio testeado en aislamiento)
+- [x] 3.1 🔴 Test: usuario `PENDING` con `created_at` < 48 h → login 200
+- [x] 3.2 🟢 Modificar la regla de login para permitir PENDING dentro de la ventana (mínimo) → verde
+- [x] 3.3 🔴 Test: `PENDING` con `created_at` > 48 h → 403 `ACCOUNT_NOT_ACTIVE` → 🟢 ajustar
+- [x] 3.4 🔴 Test: `INACTIVE` → 403 siempre (sin gracia) y `ACTIVE` → 200 → 🟢 ajustar
+- [x] 3.5 ♻️ Refactor de la política de acceso (objeto de dominio testeado en aislamiento)
 
 ## 4. Cambio de contraseña forzado (auth-local) — TDD
 

--- a/openspec/changes/acceso-cuenta-prod/tasks.md
+++ b/openspec/changes/acceso-cuenta-prod/tasks.md
@@ -48,19 +48,19 @@
 
 ## 6. Panel admin de usuarios (frontend, usuarios) — test-first de componente
 
-- [ ] 6.1 🔴 Test: `AdminRoute` redirige a un USER y deja pasar a un ADMIN → 🟢 implementar guard
-- [ ] 6.2 🔴 Test: `adminUsuariosApi` (mock) — listar con filtro, aprobar, activar/desactivar, reset → 🟢 implementar servicio
-- [ ] 6.3 🔴 Test de componente: la página `/admin/usuarios` lista, filtra por estado y dispara aprobar → 🟢 implementar
-- [ ] 6.4 🔴 Test: la acción de reset muestra la temporal devuelta una sola vez (con aviso) → 🟢 implementar
-- [ ] 6.5 ♻️ Refactor + entrada de nav condicionada a ADMIN
+- [x] 6.1 🔴 Test: `AdminRoute` redirige a un USER y deja pasar a un ADMIN → 🟢 implementar guard
+- [x] 6.2 🔴 Test: `adminUsuariosApi` (mock) — listar con filtro, aprobar, activar/desactivar, reset → 🟢 implementar servicio
+- [x] 6.3 🔴 Test de componente: la página `/admin/usuarios` lista, filtra por estado y dispara aprobar → 🟢 implementar
+- [x] 6.4 🔴 Test: la acción de reset muestra la temporal devuelta una sola vez (con aviso) → 🟢 implementar
+- [x] 6.5 ♻️ Refactor + entrada de nav condicionada a ADMIN
 
 ## 7. UX de acceso (frontend, auth-local) — test-first de componente
 
-- [ ] 7.1 🔴 Test: el botón "¿Olvidaste la contraseña?" navega a `/forgot-password` → 🟢 enlazar + pantalla "contacta con el administrador"
-- [ ] 7.2 🔴 Test: el login mapea `403 ACCOUNT_NOT_ACTIVE` → mensaje de cuenta pendiente/bloqueada y `401` → credenciales inválidas → 🟢 implementar
-- [ ] 7.3 🔴 Test: tras registro correcto se muestra la confirmación "pendiente de aprobación; acceso provisional 2 días" → 🟢 implementar
-- [ ] 7.4 🔴 Test: si el login indica `must_change_password`, se fuerza la pantalla de cambio antes de entrar → 🟢 implementar
-- [ ] 7.5 ♻️ Refactor de los componentes/estados de error
+- [x] 7.1 🔴 Test: el botón "¿Olvidaste la contraseña?" navega a `/forgot-password` → 🟢 enlazar + pantalla "contacta con el administrador"
+- [x] 7.2 🔴 Test: el login mapea `403 ACCOUNT_NOT_ACTIVE` → mensaje de cuenta pendiente/bloqueada y `401` → credenciales inválidas → 🟢 implementar
+- [x] 7.3 🔴 Test: tras registro correcto se muestra la confirmación "pendiente de aprobación; acceso provisional 2 días" → 🟢 implementar
+- [x] 7.4 🔴 Test: si el login indica `must_change_password`, se fuerza la pantalla de cambio antes de entrar → 🟢 implementar
+- [x] 7.5 ♻️ Refactor de los componentes/estados de error
 
 ## 8. API spec
 

--- a/openspec/changes/acceso-cuenta-prod/tasks.md
+++ b/openspec/changes/acceso-cuenta-prod/tasks.md
@@ -64,7 +64,7 @@
 
 ## 8. API spec
 
-- [ ] 8.1 Actualizar `docs/openapi.yaml`: endpoint de reset admin (temporal de un solo uso), flag de cambio requerido en login, códigos
+- [x] 8.1 Actualizar `docs/openapi.yaml`: endpoint de reset admin (temporal de un solo uso), flag de cambio requerido en login, códigos
 
 ## 9. QA (verificación adversarial, sobre código ya cubierto por TDD)
 

--- a/openspec/changes/acceso-cuenta-prod/tasks.md
+++ b/openspec/changes/acceso-cuenta-prod/tasks.md
@@ -12,7 +12,7 @@
 
 ## 1. Esquema base (habilitador de los ciclos)
 
-- [ ] 1.1 Migración: `users.must_change_password BOOLEAN NOT NULL DEFAULT false` (con test de migración que verifica la columna y el default)
+- [x] 1.1 Migración: `users.must_change_password BOOLEAN NOT NULL DEFAULT false` (con test de migración que verifica la columna y el default)
 
 ## 2. Seed del primer admin (auth-local) — TDD
 

--- a/openspec/changes/acceso-cuenta-prod/tasks.md
+++ b/openspec/changes/acceso-cuenta-prod/tasks.md
@@ -16,11 +16,11 @@
 
 ## 2. Seed del primer admin (auth-local) — TDD
 
-- [ ] 2.1 🔴 Test: con BD sin ADMIN y `ADMIN_EMAIL`/`ADMIN_PASSWORD` definidos, al arrancar se crea un ADMIN `ACTIVE` con hash BCrypt
-- [ ] 2.2 🟢 Implementar el `ApplicationRunner` mínimo que hace pasar 2.1
-- [ ] 2.3 🔴 Test: si ya existe un ADMIN, el arranque no crea otro (idempotente) → 🟢 ajustar
-- [ ] 2.4 🔴 Test: sin variables de entorno, el arranque no falla y no crea admin → 🟢 ajustar
-- [ ] 2.5 ♻️ Refactor (extraer servicio/política) manteniendo verde; documentar `ADMIN_EMAIL`/`ADMIN_PASSWORD` en `.env.example` y runbook
+- [x] 2.1 🔴 Test: con BD sin ADMIN y `ADMIN_EMAIL`/`ADMIN_PASSWORD` definidos, al arrancar se crea un ADMIN `ACTIVE` con hash BCrypt
+- [x] 2.2 🟢 Implementar el `ApplicationRunner` mínimo que hace pasar 2.1
+- [x] 2.3 🔴 Test: si ya existe un ADMIN, el arranque no crea otro (idempotente) → 🟢 ajustar
+- [x] 2.4 🔴 Test: sin variables de entorno, el arranque no falla y no crea admin → 🟢 ajustar
+- [x] 2.5 ♻️ Refactor (extraer servicio/política) manteniendo verde; documentar `ADMIN_EMAIL`/`ADMIN_PASSWORD` en `.env.example` y runbook
 
 ## 3. Acceso provisional de 2 días + bloqueo (auth-local) — TDD
 

--- a/openspec/changes/acceso-cuenta-prod/tasks.md
+++ b/openspec/changes/acceso-cuenta-prod/tasks.md
@@ -40,11 +40,11 @@
 
 ## 5. Reset de contraseña por el admin (usuarios) — TDD
 
-- [ ] 5.1 🔴 Test: ADMIN resetea → 200, devuelve temporal en claro una vez, persiste BCrypt y marca `must_change_password=true`
-- [ ] 5.2 🟢 Implementar `PATCH /api/admin/usuarios/{id}/reset-password` mínimo → verde
-- [ ] 5.3 🔴 Test: login posterior con la temporal funciona y exige cambio → 🟢 ajustar
-- [ ] 5.4 🔴 Test: USER → 403; la temporal no aparece en logs; respeta protección de identidad ADMIN (RN-AUTH-05) → 🟢
-- [ ] 5.5 ♻️ Refactor (generador de contraseña temporal aislado y testeado)
+- [x] 5.1 🔴 Test: ADMIN resetea → 200, devuelve temporal en claro una vez, persiste BCrypt y marca `must_change_password=true`
+- [x] 5.2 🟢 Implementar `PATCH /api/admin/usuarios/{id}/reset-password` mínimo → verde
+- [x] 5.3 🔴 Test: login posterior con la temporal funciona y exige cambio → 🟢 ajustar
+- [x] 5.4 🔴 Test: USER → 403; la temporal no aparece en logs; respeta protección de identidad ADMIN (RN-AUTH-05) → 🟢
+- [x] 5.5 ♻️ Refactor (generador de contraseña temporal aislado y testeado)
 
 ## 6. Panel admin de usuarios (frontend, usuarios) — test-first de componente
 

--- a/openspec/changes/acceso-cuenta-prod/tasks.md
+++ b/openspec/changes/acceso-cuenta-prod/tasks.md
@@ -68,11 +68,11 @@
 
 ## 9. QA (verificación adversarial, sobre código ya cubierto por TDD)
 
-- [ ] 9.1 `test-runner`: suite completa backend + frontend en verde (Postgres real :5433) y cobertura dentro del umbral JaCoCo
-- [ ] 9.2 `verification-specialist`: probes (reset solo ADMIN, temporal fuera de logs, gracia 48h en bordes, guard de rol, cambio forzado)
-- [ ] 9.3 `reality-checker`: journey end-to-end — seed admin → login admin → registro usuario (PENDING) → acceso provisional → admin aprueba en panel → reset admin → login con temporal → cambio forzado → uso normal
+- [x] 9.1 `test-runner`: suite completa backend + frontend en verde (Postgres real :5433) y cobertura dentro del umbral JaCoCo
+- [x] 9.2 `verification-specialist`: probes (reset solo ADMIN, temporal fuera de logs, gracia 48h en bordes, guard de rol, cambio forzado)
+- [x] 9.3 `reality-checker`: journey end-to-end — seed admin → login admin → registro usuario (PENDING) → acceso provisional → admin aprueba en panel → reset admin → login con temporal → cambio forzado → uso normal
 
 ## 10. Cierre
 
-- [ ] 10.1 PR con `Closes #<id>` y CI en verde
+- [x] 10.1 PR con `Closes #<id>` y CI en verde
 - [ ] 10.2 Merge → deploy automático; en el `.env` del EC2 añadir `ADMIN_EMAIL`/`ADMIN_PASSWORD`; verificar login admin y panel en vivo


### PR DESCRIPTION
## Resumen

Hace usable el acceso en producción para una **demo abierta que simula un sistema controlado**:

- **Admin inicial** (D1): runner idempotente crea un ADMIN `ACTIVE` desde `ADMIN_EMAIL`/`ADMIN_PASSWORD` si no existe ninguno (BCrypt).
- **Acceso provisional de 2 días** (D8): un `PENDING` puede usar la app 48h desde su registro (login y peticiones autenticadas); pasado el plazo o si `INACTIVE` → 403 `ACCOUNT_NOT_ACTIVE`. Aprobar en el panel lo deja `ACTIVE`.
- **Panel admin en frontend** (D6/D7): guard de rol `AdminRoute`, página `/admin/usuarios` (listar/filtrar, aprobar, activar/desactivar, reset), nav condicionada a ADMIN.
- **Reset de contraseña por el admin** (D3/D4): `PATCH /api/admin/usuarios/{id}/reset-password` genera una temporal, la muestra **una sola vez**, marca `must_change_password`.
- **Cambio de contraseña forzado** (D9): el login expone `must_change_password`; `POST /api/usuarios/me/password` cambia y limpia el flag; el frontend fuerza la pantalla de cambio.
- **UX de acceso**: "¿Olvidaste la contraseña?" → "contacta con el administrador"; confirmación post-registro; distinción 403 cuenta-no-activa vs 401 credenciales.

## Issues vinculados
Closes #173

## Spec / Docs
Change OpenSpec: `openspec/changes/acceso-cuenta-prod/` · API: `docs/openapi.yaml`

## Testing (TDD, Red→Green→Refactor)
- [x] Backend: `mvn verify` contra PostgreSQL real → **222 tests, 0 fallos**, cobertura JaCoCo OK
- [x] Frontend: **69 tests** (29 nuevos), lint y build limpios
- [x] `verification-specialist`: **PASS** (probes adversariales: gracia 48h en bordes, reset solo ADMIN, temporal fuera de logs, cambio forzado, guard de rol, 404 no 500)
- [x] `reality-checker`: **READY (A-)** — journey end-to-end por HTTP+DB real

## Migraciones
`V11__add_must_change_password_to_users.sql` (additiva).

## Notas de despliegue
Tras el merge, añadir al `.env` del EC2: `ADMIN_EMAIL` y `ADMIN_PASSWORD` (≥12 chars) para que el runner cree el primer admin. Sin ellas el arranque no falla, pero no habrá admin.

## Deuda conocida (fuera de alcance)
- `docs/openapi.yaml` usa camelCase mientras la impl devuelve snake_case (deriva preexistente `error` vs `code`, `access_token`, etc.) — ticket de reconciliación aparte.
- Reset self-service por email → cuando exista `notificaciones`.

🤖 Generado con Claude Code (orchestrator agent)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added admin account seeding on first launch using environment-provided credentials.
  - Introduced a forced password-change flow after admin resets and a self-service password change screen.
  - Added an admin users page to list, filter, approve, activate/deactivate, and reset user passwords.
  - Login now respects provisional access for newly registered accounts and shows account state more clearly.

- **Bug Fixes**
  - Login and access checks now handle pending, active, and inactive accounts consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->