### PR TITLE
fix(auth): incluir role en la respuesta de login (#176)

### DIFF
--- a/backend/src/main/java/com/padelpro/auth/application/dto/TokenPair.java
+++ b/backend/src/main/java/com/padelpro/auth/application/dto/TokenPair.java
@@ -2,6 +2,7 @@ package com.padelpro.auth.application.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.padelpro.auth.domain.model.UserRole;
 
 /**
  * Response payload returned after a successful login.
@@ -14,6 +15,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * @param tokenType           always {@code "Bearer"}
  * @param expiresIn           access token lifetime in seconds
  * @param mustChangePassword  whether the user must set a new password before normal use (D9)
+ * @param role                the authenticated user's role (e.g. USER, ADMIN) — used by the client to gate admin UI
  * @param rawRefreshToken     raw refresh token for cookie — NOT included in JSON response
  */
 public record TokenPair(
@@ -21,14 +23,15 @@ public record TokenPair(
         @JsonProperty("token_type")            String tokenType,
         @JsonProperty("expires_in")            int expiresIn,
         @JsonProperty("must_change_password")  boolean mustChangePassword,
+        @JsonProperty("role")                  UserRole role,
         @JsonIgnore                             String rawRefreshToken
 ) {
 
     /**
      * Convenience constructor for tests and callers that don't need the refresh token
-     * (defaults {@code mustChangePassword} to {@code false}).
+     * (defaults {@code mustChangePassword} to {@code false} and {@code role} to {@code null}).
      */
     public TokenPair(String accessToken, String tokenType, int expiresIn) {
-        this(accessToken, tokenType, expiresIn, false, null);
+        this(accessToken, tokenType, expiresIn, false, null, null);
     }
 }

--- a/backend/src/main/java/com/padelpro/auth/application/service/AuthService.java
+++ b/backend/src/main/java/com/padelpro/auth/application/service/AuthService.java
@@ -156,7 +156,7 @@ public class AuthService implements LoginUseCase {
         saveAuditLog("LOGIN_SUCCESS", user, null);
 
         return new TokenPair(accessToken, "Bearer", jwtService.getExpirySeconds(),
-                user.isMustChangePassword(), rawRefreshToken);
+                user.isMustChangePassword(), user.getRole(), rawRefreshToken);
     }
 
     // -------------------------------------------------------------------------

--- a/backend/src/test/java/com/padelpro/auth/infrastructure/web/AuthControllerIntegrationTest.java
+++ b/backend/src/test/java/com/padelpro/auth/infrastructure/web/AuthControllerIntegrationTest.java
@@ -184,6 +184,7 @@ class AuthControllerIntegrationTest extends PostgresIntegrationTest {
                 .andExpect(jsonPath("$.token_type").value("Bearer"))
                 .andExpect(jsonPath("$.expires_in").value(900))
                 .andExpect(jsonPath("$.must_change_password").value(false))
+                .andExpect(jsonPath("$.role").value("USER"))
                 .andExpect(cookie().httpOnly("refresh_token", true))
                 .andExpect(cookie().exists("refresh_token"));
     }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1452,6 +1452,10 @@ components:
             (p. ej. tras un reset del administrador). El cliente debe redirigir al
             cambio obligatorio de contraseña.
           example: false
+        role:
+          type: string
+          description: Rol del usuario autenticado (p. ej. `USER`, `ADMIN`). El cliente lo usa para mostrar u ocultar la UI de administración.
+          example: "USER"
 
     RefreshRequest:
       type: object


### PR DESCRIPTION
El panel admin no era accesible: el login solo llevaba el rol en el JWT, no en el cuerpo, y el frontend lee `response.role` → null → oculta el panel. Añadido `role` al TokenPair (test-first). NO mergear — pendiente de tu revisión. Closes #176

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authentication responses now include the user’s role, making it available immediately after login.
* **Bug Fixes**
  * Login response details now return a more complete user profile alongside the existing password-change status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->