### PR TITLE
feat(#178): alta/edición de usuarios en el panel + email de bienvenida al activar

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,19 @@ POSTGRES_PASSWORD=padelpro_dev
 ADMIN_EMAIL=admin@yourclub.local
 ADMIN_PASSWORD=change-this-strong-admin-password
 
+# SMTP / Email (notificaciones — welcome/activation emails)
+# Provider inicial: Ethereal (https://ethereal.email) — SMTP de PRUEBAS que captura los
+# emails sin entregarlos. Crea una cuenta desechable y pega aquí sus credenciales.
+# NUNCA commitear credenciales reales: solo placeholders aquí; los valores van en el .env del EC2.
+MAIL_HOST=smtp.ethereal.email
+MAIL_PORT=587
+MAIL_USERNAME=your-ethereal-user@ethereal.email
+MAIL_PASSWORD=your-ethereal-password
+MAIL_FROM=no-reply@padelpro.local
+# TLS: Ethereal usa STARTTLS en el 587 con auth
+MAIL_SMTP_AUTH=true
+MAIL_SMTP_STARTTLS=true
+
 # Spring Boot Profile
 SPRING_PROFILES_ACTIVE=prod
 

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -52,6 +52,12 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
 
+        <!-- Mail (SMTP) — notificaciones capability: welcome/activation emails (D1) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
+
         <!-- Caching (Caffeine, in-JVM) — available-slots 30s TTL (data-model §7.3) -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/backend/src/main/java/com/padelpro/auth/infrastructure/web/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/padelpro/auth/infrastructure/web/GlobalExceptionHandler.java
@@ -16,8 +16,11 @@ import com.padelpro.usuarios.domain.exception.AdminSelfDeactivationException;
 import com.padelpro.usuarios.domain.exception.EmailConflictException;
 import com.padelpro.usuarios.domain.exception.UserNotFoundException;
 import com.padelpro.usuarios.domain.exception.UserNotPendingException;
+import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -46,6 +49,27 @@ public class GlobalExceptionHandler {
                         "INVALID_PASSWORD",
                         "Password does not meet policy requirements",
                         ex.getViolations()));
+    }
+
+    /**
+     * Bean-validation failures on {@code @Valid @RequestBody} DTOs (e.g. a malformed
+     * {@code email} on admin user create/edit). Returns 400 with the offending field
+     * names in {@code details}, mirroring the {@code INVALID_PASSWORD} convention of
+     * carrying machine-readable violation identifiers.
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
+        List<String> details = ex.getBindingResult().getFieldErrors().stream()
+                .map(FieldError::getField)
+                .distinct()
+                .sorted()
+                .toList();
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(
+                        "VALIDATION_ERROR",
+                        "One or more fields have an invalid value",
+                        details));
     }
 
     @ExceptionHandler(IllegalArgumentException.class)

--- a/backend/src/main/java/com/padelpro/notificaciones/domain/model/WelcomeEmail.java
+++ b/backend/src/main/java/com/padelpro/notificaciones/domain/model/WelcomeEmail.java
@@ -1,0 +1,44 @@
+package com.padelpro.notificaciones.domain.model;
+
+/**
+ * Value object describing a welcome email to be sent when a user account becomes ACTIVE
+ * (change {@code usuarios-alta-edicion-email}, D3).
+ *
+ * <p>The content differs by activation flow:
+ * <ul>
+ *   <li><b>Direct creation (admin alta):</b> the system generates a temporary password and it is
+ *       included in the email so the user can log in. {@link #temporaryPassword()} is non-null.</li>
+ *   <li><b>Approval of a self-registered PENDING account:</b> the user keeps the password they chose
+ *       at registration; no password is included. {@link #temporaryPassword()} is {@code null}.</li>
+ * </ul>
+ *
+ * <p>The temporary password, when present, is sensitive: it MUST NOT be written to logs
+ * (RN-RGPD-04). Use {@link #hasPassword()} to branch on the flow without exposing the value.
+ *
+ * @param recipientEmail    destination address (the user's email)
+ * @param recipientName     display name for the greeting (typically the first name)
+ * @param temporaryPassword the temporary password to communicate, or {@code null} when the user
+ *                          already has their own password (approval flow)
+ */
+public record WelcomeEmail(
+        String recipientEmail,
+        String recipientName,
+        String temporaryPassword
+) {
+
+    /** Welcome email for the direct-creation flow, carrying the system-generated password. */
+    public static WelcomeEmail withPassword(String recipientEmail, String recipientName,
+                                            String temporaryPassword) {
+        return new WelcomeEmail(recipientEmail, recipientName, temporaryPassword);
+    }
+
+    /** Welcome email for the approval flow: "your account is approved", no password. */
+    public static WelcomeEmail accountApproved(String recipientEmail, String recipientName) {
+        return new WelcomeEmail(recipientEmail, recipientName, null);
+    }
+
+    /** @return {@code true} if this email carries a temporary password (direct-creation flow). */
+    public boolean hasPassword() {
+        return temporaryPassword != null && !temporaryPassword.isBlank();
+    }
+}

--- a/backend/src/main/java/com/padelpro/notificaciones/domain/port/out/NotificationPort.java
+++ b/backend/src/main/java/com/padelpro/notificaciones/domain/port/out/NotificationPort.java
@@ -1,0 +1,27 @@
+package com.padelpro.notificaciones.domain.port.out;
+
+import com.padelpro.notificaciones.domain.model.WelcomeEmail;
+
+/**
+ * Outbound domain port for sending transactional notifications (change
+ * {@code usuarios-alta-edicion-email}, D1).
+ *
+ * <p>Business code (e.g. {@code UserAdminService}) depends on this interface, never on JavaMail or a
+ * concrete SMTP client — the adapter lives in {@code notificaciones.infrastructure} (hexagonal /
+ * ports &amp; adapters).
+ *
+ * <p><b>Fault tolerance (D4):</b> implementations MUST NOT propagate a delivery failure to the
+ * caller — account activation/creation must complete even when SMTP is unavailable. A failure is
+ * logged (without ever exposing a password, RN-RGPD-04) and swallowed. Delivery is asynchronous.
+ */
+public interface NotificationPort {
+
+    /**
+     * Send the welcome email triggered when an account becomes ACTIVE.
+     *
+     * <p>Never throws on delivery failure: the send is best-effort and asynchronous.
+     *
+     * @param email the welcome email content (with or without a temporary password, per the flow)
+     */
+    void sendWelcomeEmail(WelcomeEmail email);
+}

--- a/backend/src/main/java/com/padelpro/notificaciones/infrastructure/config/AsyncConfig.java
+++ b/backend/src/main/java/com/padelpro/notificaciones/infrastructure/config/AsyncConfig.java
@@ -1,0 +1,32 @@
+package com.padelpro.notificaciones.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+/**
+ * Enables asynchronous method execution for the {@code notificaciones} capability (D4).
+ *
+ * <p>The welcome email is sent on this executor ({@code @Async} on
+ * {@link com.padelpro.notificaciones.infrastructure.email.SmtpNotificationAdapter}) so a slow or
+ * failing SMTP server never blocks account activation/creation.
+ */
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    /** Small bounded pool — email volume is low and best-effort. */
+    @Bean(name = "notificationsTaskExecutor")
+    public Executor notificationsTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(4);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("notif-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/backend/src/main/java/com/padelpro/notificaciones/infrastructure/email/SmtpNotificationAdapter.java
+++ b/backend/src/main/java/com/padelpro/notificaciones/infrastructure/email/SmtpNotificationAdapter.java
@@ -1,0 +1,61 @@
+package com.padelpro.notificaciones.infrastructure.email;
+
+import com.padelpro.notificaciones.domain.model.WelcomeEmail;
+import com.padelpro.notificaciones.domain.port.out.NotificationPort;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+/**
+ * SMTP adapter for the {@link NotificationPort} (change {@code usuarios-alta-edicion-email}, D1/D4/D5).
+ *
+ * <p>Sends transactional emails through a {@link JavaMailSender} configured by environment
+ * ({@code spring.mail.*} ← {@code MAIL_HOST/PORT/USERNAME/PASSWORD}). The sender address comes from
+ * {@code MAIL_FROM}.
+ *
+ * <p><b>Asynchronous &amp; fault-tolerant (D4):</b> the send runs on a separate thread ({@code @Async})
+ * and any delivery failure is caught and logged — it never propagates to the caller, so account
+ * activation/creation always completes. The temporary password is never written to the logs
+ * (RN-RGPD-04): only the recipient and the flow (with/without password) are logged.
+ */
+@Component
+public class SmtpNotificationAdapter implements NotificationPort {
+
+    private static final Logger log = LoggerFactory.getLogger(SmtpNotificationAdapter.class);
+
+    private final JavaMailSender mailSender;
+    private final String from;
+
+    public SmtpNotificationAdapter(JavaMailSender mailSender,
+                                   @Value("${app.mail.from:${spring.mail.username:no-reply@padelpro.local}}") String from) {
+        this.mailSender = mailSender;
+        this.from = from;
+    }
+
+    @Async
+    @Override
+    public void sendWelcomeEmail(WelcomeEmail email) {
+        try {
+            SimpleMailMessage message = new SimpleMailMessage();
+            message.setFrom(from);
+            message.setTo(email.recipientEmail());
+            message.setSubject(WelcomeEmailTemplate.subject());
+            message.setText(WelcomeEmailTemplate.body(email));
+
+            mailSender.send(message);
+
+            // RN-RGPD-04: log the recipient and the flow, never the password itself.
+            log.info("Welcome email sent to {} (withPassword={})",
+                    email.recipientEmail(), email.hasPassword());
+        } catch (Exception ex) {
+            // D4: a delivery failure must not break activation/creation. Swallow and log.
+            // Never include the message body / password in the log — only a safe summary.
+            log.warn("Failed to send welcome email to {} (withPassword={}): {}",
+                    email.recipientEmail(), email.hasPassword(), ex.getClass().getSimpleName());
+        }
+    }
+}

--- a/backend/src/main/java/com/padelpro/notificaciones/infrastructure/email/WelcomeEmailTemplate.java
+++ b/backend/src/main/java/com/padelpro/notificaciones/infrastructure/email/WelcomeEmailTemplate.java
@@ -1,0 +1,49 @@
+package com.padelpro.notificaciones.infrastructure.email;
+
+import com.padelpro.notificaciones.domain.model.WelcomeEmail;
+
+/**
+ * Builds the subject and body of the welcome email (change {@code usuarios-alta-edicion-email},
+ * task 1.5). Two variants per D3:
+ * <ul>
+ *   <li><b>with password</b> (direct creation): includes the temporary password and asks the user
+ *       to change it on first login;</li>
+ *   <li><b>account approved</b> (approval): welcome message, no password.</li>
+ * </ul>
+ *
+ * <p>Plain-text bodies keep the adapter simple and provider-agnostic (Ethereal, SES, ...).
+ */
+final class WelcomeEmailTemplate {
+
+    private static final String SUBJECT = "Bienvenido/a a PadelPro";
+
+    private WelcomeEmailTemplate() {
+    }
+
+    static String subject() {
+        return SUBJECT;
+    }
+
+    static String body(WelcomeEmail email) {
+        String name = (email.recipientName() != null && !email.recipientName().isBlank())
+                ? email.recipientName()
+                : "";
+        String greeting = name.isBlank() ? "Hola," : "Hola " + name + ",";
+
+        if (email.hasPassword()) {
+            return greeting + "\n\n"
+                    + "Se ha creado tu cuenta en PadelPro y ya está activa.\n\n"
+                    + "Puedes entrar con tu email (" + email.recipientEmail() + ") y esta "
+                    + "contraseña temporal:\n\n"
+                    + "    " + email.temporaryPassword() + "\n\n"
+                    + "Por seguridad, se te pedirá cambiarla la primera vez que inicies sesión.\n\n"
+                    + "Un saludo,\nEl equipo de PadelPro";
+        }
+
+        return greeting + "\n\n"
+                + "Tu cuenta en PadelPro ha sido aprobada y ya está activa.\n\n"
+                + "Puedes iniciar sesión con tu email (" + email.recipientEmail() + ") y la "
+                + "contraseña que elegiste al registrarte.\n\n"
+                + "Un saludo,\nEl equipo de PadelPro";
+    }
+}

--- a/backend/src/main/java/com/padelpro/usuarios/application/dto/CreateUserAdminCommand.java
+++ b/backend/src/main/java/com/padelpro/usuarios/application/dto/CreateUserAdminCommand.java
@@ -5,8 +5,14 @@ package com.padelpro.usuarios.application.dto;
  *
  * <p>Admin-created users are set to {@code status=ACTIVE} immediately — no
  * approval step required (spec Requirement 2, scenario 1).
- * Password policy RN-AUTH-08 is enforced in the service layer.
  *
+ * <p><b>Password (change usuarios-alta-edicion-email, D2/D3):</b> the {@code password} field is
+ * <b>ignored</b> by the service. The system generates a temporary password with
+ * {@link com.padelpro.usuarios.application.service.TemporaryPasswordGenerator}, sets
+ * {@code must_change_password = true}, and communicates it to the user via the welcome email. The
+ * field is retained only for backward compatibility of the request shape.
+ *
+ * @param password ignored — the system generates the temporary password (D3)
  * @param role optional — defaults to USER if null
  */
 public record CreateUserAdminCommand(

--- a/backend/src/main/java/com/padelpro/usuarios/application/dto/CreateUserAdminCommand.java
+++ b/backend/src/main/java/com/padelpro/usuarios/application/dto/CreateUserAdminCommand.java
@@ -1,5 +1,8 @@
 package com.padelpro.usuarios.application.dto;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
 /**
  * Command for admin-created user accounts (POST /api/admin/usuarios).
  *
@@ -19,7 +22,7 @@ public record CreateUserAdminCommand(
         String login,
         String firstName,
         String lastName,
-        String email,
+        @NotBlank(message = "email") @Email(message = "email") String email,
         String password,
         String phone,
         String role

--- a/backend/src/main/java/com/padelpro/usuarios/application/dto/UpdateUserAdminCommand.java
+++ b/backend/src/main/java/com/padelpro/usuarios/application/dto/UpdateUserAdminCommand.java
@@ -1,15 +1,21 @@
 package com.padelpro.usuarios.application.dto;
 
+import jakarta.validation.constraints.Email;
+
 /**
  * Command for admin updates to any user account (PATCH /api/admin/usuarios/{id}).
  *
  * <p>All fields are nullable — only non-null values are applied.
  * {@code login} is intentionally absent: login is immutable post-creation.
+ *
+ * <p>{@code email} is optional (partial update), but when present it MUST be a
+ * well-formed address — {@code @Email} treats {@code null} as valid, so
+ * phone-only or name-only patches are unaffected.
  */
 public record UpdateUserAdminCommand(
         String firstName,
         String lastName,
-        String email,
+        @Email(message = "email") String email,
         String phone,
         String role,
         String status

--- a/backend/src/main/java/com/padelpro/usuarios/application/service/UserAdminService.java
+++ b/backend/src/main/java/com/padelpro/usuarios/application/service/UserAdminService.java
@@ -6,6 +6,8 @@ import com.padelpro.auth.domain.model.UserRole;
 import com.padelpro.auth.domain.model.UserStatus;
 import com.padelpro.auth.domain.port.out.AuditLogRepositoryPort;
 import com.padelpro.auth.domain.port.out.UserRepositoryPort;
+import com.padelpro.notificaciones.domain.model.WelcomeEmail;
+import com.padelpro.notificaciones.domain.port.out.NotificationPort;
 import com.padelpro.usuarios.application.dto.CreateUserAdminCommand;
 import com.padelpro.usuarios.application.dto.PagedUsersResponse;
 import com.padelpro.usuarios.application.dto.ResetPasswordResult;
@@ -16,6 +18,8 @@ import com.padelpro.usuarios.domain.exception.AdminSelfDeactivationException;
 import com.padelpro.usuarios.domain.exception.EmailConflictException;
 import com.padelpro.usuarios.domain.exception.UserNotFoundException;
 import com.padelpro.usuarios.domain.exception.UserNotPendingException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -35,19 +39,24 @@ import java.util.List;
 @Service
 public class UserAdminService {
 
+    private static final Logger log = LoggerFactory.getLogger(UserAdminService.class);
+
     private final UserRepositoryPort userRepositoryPort;
     private final AuditLogRepositoryPort auditLogRepositoryPort;
     private final BCryptPasswordEncoder passwordEncoder;
     private final TemporaryPasswordGenerator temporaryPasswordGenerator;
+    private final NotificationPort notificationPort;
 
     public UserAdminService(UserRepositoryPort userRepositoryPort,
                             AuditLogRepositoryPort auditLogRepositoryPort,
                             BCryptPasswordEncoder passwordEncoder,
-                            TemporaryPasswordGenerator temporaryPasswordGenerator) {
+                            TemporaryPasswordGenerator temporaryPasswordGenerator,
+                            NotificationPort notificationPort) {
         this.userRepositoryPort   = userRepositoryPort;
         this.auditLogRepositoryPort = auditLogRepositoryPort;
         this.passwordEncoder      = passwordEncoder;
         this.temporaryPasswordGenerator = temporaryPasswordGenerator;
+        this.notificationPort     = notificationPort;
     }
 
     /**
@@ -69,10 +78,14 @@ public class UserAdminService {
                 ? UserRole.valueOf(cmd.role().toUpperCase())
                 : UserRole.USER;
 
+        // D2/D3: the system generates the temporary password (the admin does not type it, and any
+        // password in the request is ignored). It is communicated to the user via the welcome email.
+        String temporaryPassword = temporaryPasswordGenerator.generate();
+
         OffsetDateTime now = OffsetDateTime.now();
         User user = new User(
                 cmd.login(),
-                passwordEncoder.encode(cmd.password()),
+                passwordEncoder.encode(temporaryPassword),
                 cmd.firstName(),
                 cmd.lastName(),
                 cmd.email(),
@@ -82,12 +95,19 @@ public class UserAdminService {
                 now
         );
         user.setPhone(cmd.phone());
+        user.setMustChangePassword(true);
 
         User saved = userRepositoryPort.save(user);
 
         auditLogRepositoryPort.save(new AuditLog(
                 AuditActions.USER_CREATED_BY_ADMIN, saved, null,
                 "login=" + cmd.login(), OffsetDateTime.now()));
+
+        // D3 (direct-creation flow): welcome email WITH the temporary password. Best-effort/async;
+        // a failure never breaks the creation (D4). RN-RGPD-04: the password is not logged here.
+        sendWelcomeEmailSafely(
+                WelcomeEmail.withPassword(saved.getEmail(), saved.getFirstName(), temporaryPassword),
+                saved.getEmail());
 
         return toAdminResponse(saved);
     }
@@ -104,12 +124,19 @@ public class UserAdminService {
         if (user.getStatus() != UserStatus.PENDING) {
             throw new UserNotPendingException(targetId);
         }
+        // D3: approval does NOT reset the password — the user keeps the one chosen at registration.
         user.setStatus(UserStatus.ACTIVE);
         User saved = userRepositoryPort.save(user);
 
         auditLogRepositoryPort.save(new AuditLog(
                 AuditActions.USER_APPROVED, saved, null,
                 "userId=" + targetId, OffsetDateTime.now()));
+
+        // D3 (approval flow): welcome email WITHOUT password ("account approved, you can log in").
+        // Best-effort/async; a failure never breaks the approval (D4).
+        sendWelcomeEmailSafely(
+                WelcomeEmail.accountApproved(saved.getEmail(), saved.getFirstName()),
+                saved.getEmail());
 
         return toAdminResponse(saved);
     }
@@ -259,6 +286,22 @@ public class UserAdminService {
     private User requireUser(Long id) {
         return userRepositoryPort.findById(id)
                 .orElseThrow(() -> new UserNotFoundException(id));
+    }
+
+    /**
+     * Fire the welcome email without letting any failure break the activation/creation (D4).
+     *
+     * <p>The SMTP adapter is {@code @Async} and already swallows delivery errors, but this guard
+     * makes the calling flow robust even if the port implementation changes or is invoked
+     * synchronously (e.g. in tests). RN-RGPD-04: only the recipient is logged, never a password.
+     */
+    private void sendWelcomeEmailSafely(WelcomeEmail email, String recipientEmail) {
+        try {
+            notificationPort.sendWelcomeEmail(email);
+        } catch (Exception ex) {
+            log.warn("Welcome email dispatch failed for {} — activation not affected: {}",
+                    recipientEmail, ex.getClass().getSimpleName());
+        }
     }
 
     static UserAdminResponse toAdminResponse(User user) {

--- a/backend/src/main/java/com/padelpro/usuarios/infrastructure/web/AdminUsuariosController.java
+++ b/backend/src/main/java/com/padelpro/usuarios/infrastructure/web/AdminUsuariosController.java
@@ -7,6 +7,7 @@ import com.padelpro.usuarios.application.dto.ResetPasswordResult;
 import com.padelpro.usuarios.application.dto.UpdateUserAdminCommand;
 import com.padelpro.usuarios.application.dto.UserAdminResponse;
 import com.padelpro.usuarios.application.service.UserAdminService;
+import jakarta.validation.Valid;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -65,7 +66,7 @@ public class AdminUsuariosController {
      */
     @PostMapping
     public ResponseEntity<UserAdminResponse> createUser(
-            @RequestBody CreateUserAdminCommand command) {
+            @Valid @RequestBody CreateUserAdminCommand command) {
         UserAdminResponse created = userAdminService.createUser(command);
         return ResponseEntity.status(HttpStatus.CREATED).body(created);
     }
@@ -86,7 +87,7 @@ public class AdminUsuariosController {
     @PatchMapping("/{id}")
     public ResponseEntity<UserAdminResponse> updateUser(
             @PathVariable Long id,
-            @RequestBody UpdateUserAdminCommand command) {
+            @Valid @RequestBody UpdateUserAdminCommand command) {
         return ResponseEntity.ok(userAdminService.updateUser(id, command));
     }
 

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -32,6 +32,19 @@ spring:
     locations: classpath:db/migration
     baseline-on-migrate: false
 
+  # SMTP (notificaciones) — credentials come from the environment (D5); never committed.
+  mail:
+    host: ${MAIL_HOST:}
+    port: ${MAIL_PORT:587}
+    username: ${MAIL_USERNAME:}
+    password: ${MAIL_PASSWORD:}
+    properties:
+      mail:
+        smtp:
+          auth: ${MAIL_SMTP_AUTH:true}
+          starttls:
+            enable: ${MAIL_SMTP_STARTTLS:true}
+
 server:
   port: 8080
   servlet:
@@ -49,6 +62,11 @@ jwt:
 # Encryption
 encryption:
   key: ${ENCRYPTION_KEY}
+
+# Application-level mail settings (sender address for notificaciones)
+app:
+  mail:
+    from: ${MAIL_FROM:no-reply@padelpro.local}
 
 # Logging
 logging:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -10,8 +10,21 @@ spring:
   flyway:
     enabled: true
     locations: classpath:db/migration
+  mail:
+    host: ${MAIL_HOST:localhost}
+    port: ${MAIL_PORT:1025}
+    username: ${MAIL_USERNAME:}
+    password: ${MAIL_PASSWORD:}
+    properties:
+      mail:
+        smtp:
+          auth: ${MAIL_SMTP_AUTH:false}
+          starttls:
+            enable: ${MAIL_SMTP_STARTTLS:false}
 
 app:
+  mail:
+    from: ${MAIL_FROM:no-reply@padelpro.local}
   jwt:
     secret: ${JWT_SECRET}
     access-token-expiry-minutes: 15

--- a/backend/src/test/java/com/padelpro/notificaciones/infrastructure/email/SmtpNotificationAdapterTest.java
+++ b/backend/src/test/java/com/padelpro/notificaciones/infrastructure/email/SmtpNotificationAdapterTest.java
@@ -1,0 +1,132 @@
+package com.padelpro.notificaciones.infrastructure.email;
+
+import com.padelpro.notificaciones.domain.model.WelcomeEmail;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+import org.springframework.mail.MailSendException;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+/**
+ * TDD unit tests for the SMTP adapter of the {@code notificaciones} capability (D1, D4).
+ *
+ * <p>No real SMTP server is used — {@link JavaMailSender} is mocked. These tests pin the
+ * fault-tolerance contract (a send failure never propagates) and RN-RGPD-04 (the temporary
+ * password never reaches the logs).
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SmtpNotificationAdapter — welcome email delivery (fault-tolerant, no secrets in logs)")
+class SmtpNotificationAdapterTest {
+
+    private static final String FROM = "no-reply@padelpro.test";
+
+    @Mock
+    private JavaMailSender mailSender;
+
+    private SmtpNotificationAdapter adapter;
+
+    private ListAppender<ILoggingEvent> logAppender;
+    private Logger adapterLogger;
+
+    @BeforeEach
+    void setUp() {
+        adapter = new SmtpNotificationAdapter(mailSender, FROM);
+
+        adapterLogger = (Logger) LoggerFactory.getLogger(SmtpNotificationAdapter.class);
+        logAppender = new ListAppender<>();
+        logAppender.start();
+        adapterLogger.addAppender(logAppender);
+        adapterLogger.setLevel(Level.DEBUG);
+    }
+
+    @AfterEach
+    void tearDown() {
+        adapterLogger.detachAppender(logAppender);
+    }
+
+    @Test
+    @DisplayName("sends the welcome email with password via SMTP using the configured sender")
+    void sends_welcome_email_with_password() {
+        WelcomeEmail email = WelcomeEmail.withPassword("user@example.com", "Ana", "Temp0rary9X");
+
+        adapter.sendWelcomeEmail(email);
+
+        ArgumentCaptor<SimpleMailMessage> captor = ArgumentCaptor.forClass(SimpleMailMessage.class);
+        verify(mailSender).send(captor.capture());
+        SimpleMailMessage sent = captor.getValue();
+        assertThat(sent.getFrom()).isEqualTo(FROM);
+        assertThat(sent.getTo()).containsExactly("user@example.com");
+        assertThat(sent.getText()).contains("Temp0rary9X");
+    }
+
+    @Test
+    @DisplayName("sends the approval welcome email without any password")
+    void sends_approval_email_without_password() {
+        WelcomeEmail email = WelcomeEmail.accountApproved("user@example.com", "Ana");
+
+        adapter.sendWelcomeEmail(email);
+
+        ArgumentCaptor<SimpleMailMessage> captor = ArgumentCaptor.forClass(SimpleMailMessage.class);
+        verify(mailSender).send(captor.capture());
+        assertThat(captor.getValue().getTo()).containsExactly("user@example.com");
+    }
+
+    @Test
+    @DisplayName("a SMTP send failure is swallowed — never propagates to the caller (D4)")
+    void smtp_failure_does_not_propagate() {
+        doThrow(new MailSendException("SMTP down")).when(mailSender).send(any(SimpleMailMessage.class));
+        WelcomeEmail email = WelcomeEmail.withPassword("user@example.com", "Ana", "Temp0rary9X");
+
+        assertThatCode(() -> adapter.sendWelcomeEmail(email)).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("the temporary password never appears in the logs — on success (RN-RGPD-04)")
+    void password_not_in_logs_on_success() {
+        WelcomeEmail email = WelcomeEmail.withPassword("user@example.com", "Ana", "Temp0rary9X");
+
+        adapter.sendWelcomeEmail(email);
+
+        assertThat(logContent()).doesNotContain("Temp0rary9X");
+    }
+
+    @Test
+    @DisplayName("the temporary password never appears in the logs — on failure (RN-RGPD-04)")
+    void password_not_in_logs_on_failure() {
+        doThrow(new MailSendException("SMTP down")).when(mailSender).send(any(SimpleMailMessage.class));
+        WelcomeEmail email = WelcomeEmail.withPassword("user@example.com", "Ana", "Temp0rary9X");
+
+        adapter.sendWelcomeEmail(email);
+
+        assertThat(logContent()).doesNotContain("Temp0rary9X");
+    }
+
+    private String logContent() {
+        StringBuilder sb = new StringBuilder();
+        for (ILoggingEvent e : logAppender.list) {
+            sb.append(e.getFormattedMessage()).append('\n');
+            if (e.getThrowableProxy() != null) {
+                sb.append(e.getThrowableProxy().getMessage()).append('\n');
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/backend/src/test/java/com/padelpro/usuarios/application/service/UserAdminServiceTest.java
+++ b/backend/src/test/java/com/padelpro/usuarios/application/service/UserAdminServiceTest.java
@@ -6,6 +6,8 @@ import com.padelpro.auth.domain.model.UserRole;
 import com.padelpro.auth.domain.model.UserStatus;
 import com.padelpro.auth.domain.port.out.AuditLogRepositoryPort;
 import com.padelpro.auth.domain.port.out.UserRepositoryPort;
+import com.padelpro.notificaciones.domain.model.WelcomeEmail;
+import com.padelpro.notificaciones.domain.port.out.NotificationPort;
 import com.padelpro.usuarios.application.dto.CreateUserAdminCommand;
 import com.padelpro.usuarios.application.dto.PagedUsersResponse;
 import com.padelpro.usuarios.application.dto.UserAdminResponse;
@@ -53,6 +55,9 @@ class UserAdminServiceTest {
     @Mock
     private TemporaryPasswordGenerator temporaryPasswordGenerator;
 
+    @Mock
+    private NotificationPort notificationPort;
+
     @InjectMocks
     private UserAdminService userAdminService;
 
@@ -72,11 +77,13 @@ class UserAdminServiceTest {
     // -------------------------------------------------------------------------
 
     @Test
-    @DisplayName("should_create_user_with_active_status_and_bcrypt_hash")
+    @DisplayName("should_create_user_active_with_system_generated_password_and_must_change_flag (D2/D3)")
     void should_create_user_with_active_status_and_bcrypt_hash() {
         when(userRepositoryPort.existsByEmail("new@example.com")).thenReturn(false);
         when(userRepositoryPort.existsByLogin("newlogin")).thenReturn(false);
-        when(passwordEncoder.encode("P@ssword1")).thenReturn("$2a$12$hashed");
+        // D3: the system GENERATES the temporary password; the request password is ignored.
+        when(temporaryPasswordGenerator.generate()).thenReturn("Gener4tedX9");
+        when(passwordEncoder.encode("Gener4tedX9")).thenReturn("$2a$12$hashed");
         when(userRepositoryPort.save(any(User.class))).thenAnswer(inv -> {
             User u = inv.getArgument(0);
             setId(u, 10L);
@@ -85,14 +92,49 @@ class UserAdminServiceTest {
         when(auditLogRepositoryPort.save(any(AuditLog.class))).thenAnswer(inv -> inv.getArgument(0));
 
         CreateUserAdminCommand cmd = new CreateUserAdminCommand(
-                "newlogin", "New", "User", "new@example.com", "P@ssword1", null, null);
+                "newlogin", "New", "User", "new@example.com", "IgnoredReqPw1", null, null);
 
         UserAdminResponse response = userAdminService.createUser(cmd);
 
         assertThat(response.status()).isEqualTo("ACTIVE");
         assertThat(response.role()).isEqualTo("USER");
-        verify(passwordEncoder).encode("P@ssword1");
+        // system-generated password is hashed; request password is NOT used
+        verify(temporaryPasswordGenerator).generate();
+        verify(passwordEncoder).encode("Gener4tedX9");
+        verify(passwordEncoder, never()).encode("IgnoredReqPw1");
         verify(auditLogRepositoryPort).save(any(AuditLog.class));
+    }
+
+    @Test
+    @DisplayName("should_persist_must_change_password_true_and_send_welcome_with_generated_password (D3)")
+    void should_send_welcome_email_with_generated_password_on_create() {
+        when(userRepositoryPort.existsByEmail("new@example.com")).thenReturn(false);
+        when(userRepositoryPort.existsByLogin("newlogin")).thenReturn(false);
+        when(temporaryPasswordGenerator.generate()).thenReturn("Gener4tedX9");
+        when(passwordEncoder.encode("Gener4tedX9")).thenReturn("$2a$12$hashed");
+        ArgumentCaptor<User> savedUser = ArgumentCaptor.forClass(User.class);
+        when(userRepositoryPort.save(savedUser.capture())).thenAnswer(inv -> {
+            User u = inv.getArgument(0);
+            setId(u, 10L);
+            return u;
+        });
+        when(auditLogRepositoryPort.save(any(AuditLog.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        CreateUserAdminCommand cmd = new CreateUserAdminCommand(
+                "newlogin", "New", "User", "new@example.com", null, null, null);
+
+        userAdminService.createUser(cmd);
+
+        // must_change_password = true on the persisted user
+        assertThat(savedUser.getValue().isMustChangePassword()).isTrue();
+
+        // welcome email carries the generated temporary password (D3 direct-creation flow)
+        ArgumentCaptor<WelcomeEmail> emailCaptor = ArgumentCaptor.forClass(WelcomeEmail.class);
+        verify(notificationPort).sendWelcomeEmail(emailCaptor.capture());
+        WelcomeEmail email = emailCaptor.getValue();
+        assertThat(email.recipientEmail()).isEqualTo("new@example.com");
+        assertThat(email.hasPassword()).isTrue();
+        assertThat(email.temporaryPassword()).isEqualTo("Gener4tedX9");
     }
 
     @Test
@@ -122,6 +164,46 @@ class UserAdminServiceTest {
 
         assertThat(response.status()).isEqualTo("ACTIVE");
         verify(auditLogRepositoryPort).save(any(AuditLog.class));
+    }
+
+    @Test
+    @DisplayName("should_send_welcome_email_without_password_and_not_reset_on_approve (D3)")
+    void should_send_welcome_email_without_password_on_approve() {
+        String originalHash = pendingUser.getPasswordHash();
+        when(userRepositoryPort.findById(1L)).thenReturn(Optional.of(pendingUser));
+        when(userRepositoryPort.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(auditLogRepositoryPort.save(any(AuditLog.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        userAdminService.approveUser(1L);
+
+        // approval MUST NOT reset the password: the user keeps the one chosen at registration
+        assertThat(pendingUser.getPasswordHash()).isEqualTo(originalHash);
+        assertThat(pendingUser.isMustChangePassword()).isFalse();
+        verify(temporaryPasswordGenerator, never()).generate();
+
+        // welcome email WITHOUT password (approval flow)
+        ArgumentCaptor<WelcomeEmail> emailCaptor = ArgumentCaptor.forClass(WelcomeEmail.class);
+        verify(notificationPort).sendWelcomeEmail(emailCaptor.capture());
+        WelcomeEmail email = emailCaptor.getValue();
+        assertThat(email.recipientEmail()).isEqualTo(pendingUser.getEmail());
+        assertThat(email.hasPassword()).isFalse();
+        assertThat(email.temporaryPassword()).isNull();
+    }
+
+    @Test
+    @DisplayName("should_complete_approve_even_when_email_send_fails (D4)")
+    void should_complete_approve_even_when_email_fails() {
+        when(userRepositoryPort.findById(1L)).thenReturn(Optional.of(pendingUser));
+        when(userRepositoryPort.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(auditLogRepositoryPort.save(any(AuditLog.class))).thenAnswer(inv -> inv.getArgument(0));
+        doThrow(new RuntimeException("SMTP down"))
+                .when(notificationPort).sendWelcomeEmail(any(WelcomeEmail.class));
+
+        UserAdminResponse response = userAdminService.approveUser(1L);
+
+        // activation completes despite the email failure (the port is best-effort/async)
+        assertThat(response.status()).isEqualTo("ACTIVE");
+        assertThat(pendingUser.getStatus()).isEqualTo(UserStatus.ACTIVE);
     }
 
     @Test

--- a/backend/src/test/java/com/padelpro/usuarios/infrastructure/web/AdminUsuariosControllerIntegrationTest.java
+++ b/backend/src/test/java/com/padelpro/usuarios/infrastructure/web/AdminUsuariosControllerIntegrationTest.java
@@ -111,6 +111,83 @@ class AdminUsuariosControllerIntegrationTest extends PostgresIntegrationTest {
                 .andExpect(jsonPath("$.error", is("USUARIOS_EMAIL_CONFLICT")));
     }
 
+    @Test
+    @DisplayName("POST /api/admin/usuarios malformed email → 400 VALIDATION_ERROR")
+    void create_user_malformed_email_returns_400() throws Exception {
+        Map<String, String> body = Map.of(
+                "login", "bad.email.user",
+                "firstName", "Bad",
+                "lastName", "Email",
+                "email", "no-es-email",
+                "password", "Password1"
+        );
+        mockMvc.perform(post("/api/admin/usuarios")
+                        .header("Authorization", "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error", is("VALIDATION_ERROR")))
+                .andExpect(jsonPath("$.details[0]", is("email")));
+
+        // must NOT have been persisted
+        assert userRepository.findByLogin("bad.email.user").isEmpty();
+    }
+
+    // -------------------------------------------------------------------------
+    // PATCH /api/admin/usuarios/{id}
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("PATCH /api/admin/usuarios/{id} valid contact data → 200 persists")
+    void update_user_valid_contact_returns_200() throws Exception {
+        Map<String, String> body = Map.of(
+                "firstName", "Reggie",
+                "email", "regular.updated@example.com",
+                "phone", "600999888"
+        );
+        mockMvc.perform(patch("/api/admin/usuarios/{id}", regularUser.getId())
+                        .header("Authorization", "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.firstName", is("Reggie")))
+                .andExpect(jsonPath("$.email", is("regular.updated@example.com")));
+    }
+
+    @Test
+    @DisplayName("PATCH /api/admin/usuarios/{id} malformed email → 400 VALIDATION_ERROR, no change")
+    void update_user_malformed_email_returns_400_no_change() throws Exception {
+        Map<String, String> body = Map.of(
+                "firstName", "Regular",
+                "lastName", "User",
+                "email", "no-es-email",
+                "phone", ""
+        );
+        mockMvc.perform(patch("/api/admin/usuarios/{id}", regularUser.getId())
+                        .header("Authorization", "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error", is("VALIDATION_ERROR")))
+                .andExpect(jsonPath("$.details[0]", is("email")));
+
+        // email must remain unchanged in DB
+        User reloaded = userRepository.findByLogin(regularUser.getLogin()).orElseThrow();
+        assert reloaded.getEmail().equals("regular@example.com");
+    }
+
+    @Test
+    @DisplayName("PATCH /api/admin/usuarios/{id} partial update (only phone) → 200, email untouched")
+    void update_user_partial_only_phone_returns_200() throws Exception {
+        Map<String, String> body = Map.of("phone", "611222333");
+        mockMvc.perform(patch("/api/admin/usuarios/{id}", regularUser.getId())
+                        .header("Authorization", "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.email", is("regular@example.com")));
+    }
+
     // -------------------------------------------------------------------------
     // PATCH /api/admin/usuarios/{id}/aprobar
     // -------------------------------------------------------------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,16 @@ services:
       ADMIN_EMAIL: ${ADMIN_EMAIL:-}
       ADMIN_PASSWORD: ${ADMIN_PASSWORD:-}
 
+      # SMTP / Email (notificaciones). Credenciales SOLO en el .env del EC2 (nunca en el repo).
+      # Si MAIL_HOST está vacío, el envío falla de forma tolerante (D4) y no rompe la gestión.
+      MAIL_HOST: ${MAIL_HOST:-}
+      MAIL_PORT: ${MAIL_PORT:-587}
+      MAIL_USERNAME: ${MAIL_USERNAME:-}
+      MAIL_PASSWORD: ${MAIL_PASSWORD:-}
+      MAIL_FROM: ${MAIL_FROM:-no-reply@padelpro.local}
+      MAIL_SMTP_AUTH: ${MAIL_SMTP_AUTH:-true}
+      MAIL_SMTP_STARTTLS: ${MAIL_SMTP_STARTTLS:-true}
+
       # Spring Boot
       SPRING_PROFILES_ACTIVE: prod
       SERVER_PORT: 8080

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -400,6 +400,10 @@ paths:
       description: |
         Crea un nuevo usuario directamente sin proceso de aprobación.
         El usuario se crea con estado ACTIVE. Requiere ROLE_ADMIN.
+
+        La contraseña la **genera el sistema** (el campo `password` del cuerpo se ignora):
+        se crea una contraseña temporal, se marca `mustChangePassword=true` y se comunica
+        al usuario mediante un **email de bienvenida**. El fallo del email no impide el alta.
       requestBody:
         required: true
         content:
@@ -1666,7 +1670,6 @@ components:
         - phone
         - firstName
         - lastName
-        - password
         - role
       properties:
         login:
@@ -1696,8 +1699,9 @@ components:
         password:
           type: string
           format: password
-          minLength: 8
-          example: "SecureP4ss!"
+          deprecated: true
+          description: Ignorado — la contraseña la genera el sistema y se envía por email de bienvenida.
+          example: ""
         role:
           $ref: '#/components/schemas/UserRole'
 

--- a/frontend/src/components/UsuarioFormModal.module.css
+++ b/frontend/src/components/UsuarioFormModal.module.css
@@ -1,0 +1,103 @@
+/* UsuarioFormModal — modal de alta/edición de usuarios.
+   Coherente con los tokens de PadelPro (cream/ink/lime, Bricolage display). */
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(13, 13, 13, 0.45);
+  backdrop-filter: blur(3px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 100;
+  animation: overlayIn 0.18s ease;
+}
+
+@keyframes overlayIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.modal {
+  background: var(--cream);
+  border: 1.5px solid var(--ink);
+  border-radius: 18px;
+  width: 100%;
+  max-width: 440px;
+  max-height: calc(100vh - 48px);
+  overflow-y: auto;
+  box-shadow: 10px 10px 0 rgba(13, 13, 13, 0.9);
+  animation: modalIn 0.22s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@keyframes modalIn {
+  from {
+    opacity: 0;
+    transform: translateY(12px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.modalHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 22px 24px 6px;
+}
+
+.modalTitle {
+  font-family: var(--font-display);
+  font-size: 26px;
+  font-weight: 700;
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+  margin: 0;
+  color: var(--ink);
+}
+
+.closeBtn {
+  background: transparent;
+  border: none;
+  font-size: 28px;
+  line-height: 1;
+  color: var(--muted);
+  cursor: pointer;
+  padding: 0 4px;
+  transition: color 0.15s ease, transform 0.15s ease;
+}
+
+.closeBtn:hover {
+  color: var(--ink);
+  transform: rotate(90deg);
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 12px 24px 26px;
+}
+
+.hint {
+  font-size: 12.5px;
+  color: var(--muted);
+  margin: -4px 0 0;
+  padding-left: 10px;
+  border-left: 2px solid var(--lime);
+  line-height: 1.4;
+}
+
+.actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+  margin-top: 6px;
+}

--- a/frontend/src/components/UsuarioFormModal.tsx
+++ b/frontend/src/components/UsuarioFormModal.tsx
@@ -1,0 +1,200 @@
+// UsuarioFormModal — formulario modal reutilizable para alta y edición de
+// usuarios desde el panel admin (change usuarios-alta-edicion-email, D6/D7).
+//
+// - Alta (mode="create"): pide nombre, apellidos, email, teléfono y ROL.
+//   NO hay campo de contraseña — la genera el backend (D2/D3).
+// - Edición (mode="edit"): precarga los datos de contacto; NO ofrece cambiar
+//   el rol ni el estado (D7, evita escalada de privilegios).
+//
+// La accesibilidad se cubre con role="dialog", aria-modal y cierre por Escape.
+import { FormEvent, useEffect, useRef, useState } from 'react';
+import type { AdminUsuario } from '../services/adminUsuariosApi';
+import styles from './UsuarioFormModal.module.css';
+
+export interface UsuarioFormValues {
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone: string;
+  role: string;
+}
+
+interface Props {
+  mode: 'create' | 'edit';
+  initial?: AdminUsuario | null;
+  submitting?: boolean;
+  errorMsg?: string | null;
+  onSubmit: (values: UsuarioFormValues) => void;
+  onClose: () => void;
+}
+
+const ROLES = [
+  { value: 'USER', label: 'Usuario' },
+  { value: 'ADMIN', label: 'Administrador' },
+];
+
+export function UsuarioFormModal({
+  mode,
+  initial,
+  submitting = false,
+  errorMsg,
+  onSubmit,
+  onClose,
+}: Props) {
+  const [firstName, setFirstName] = useState(initial?.firstName ?? '');
+  const [lastName, setLastName] = useState(initial?.lastName ?? '');
+  const [email, setEmail] = useState(initial?.email ?? '');
+  const [phone, setPhone] = useState(initial?.phone ?? '');
+  const [role, setRole] = useState(initial?.role ?? 'USER');
+
+  const firstFieldRef = useRef<HTMLInputElement>(null);
+
+  const title = mode === 'create' ? 'Dar de alta usuario' : 'Editar usuario';
+
+  useEffect(() => {
+    firstFieldRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose();
+    }
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    onSubmit({ firstName, lastName, email, phone, role });
+  }
+
+  return (
+    <div className={styles.overlay} onMouseDown={onClose}>
+      <div
+        className={styles.modal}
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        <div className={styles.modalHeader}>
+          <h2 className={styles.modalTitle}>{title}</h2>
+          <button
+            type="button"
+            className={styles.closeBtn}
+            onClick={onClose}
+            aria-label="Cerrar"
+          >
+            ×
+          </button>
+        </div>
+
+        <form className={styles.form} onSubmit={handleSubmit} noValidate>
+          <div className="p-input-group">
+            <label className="p-input-label" htmlFor="usuario-nombre">
+              Nombre
+            </label>
+            <input
+              id="usuario-nombre"
+              ref={firstFieldRef}
+              className="p-input"
+              value={firstName}
+              onChange={(e) => setFirstName(e.target.value)}
+              required
+            />
+          </div>
+
+          <div className="p-input-group">
+            <label className="p-input-label" htmlFor="usuario-apellidos">
+              Apellidos
+            </label>
+            <input
+              id="usuario-apellidos"
+              className="p-input"
+              value={lastName}
+              onChange={(e) => setLastName(e.target.value)}
+              required
+            />
+          </div>
+
+          <div className="p-input-group">
+            <label className="p-input-label" htmlFor="usuario-email">
+              Email
+            </label>
+            <input
+              id="usuario-email"
+              className="p-input"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+          </div>
+
+          <div className="p-input-group">
+            <label className="p-input-label" htmlFor="usuario-phone">
+              Teléfono
+            </label>
+            <input
+              id="usuario-phone"
+              className="p-input"
+              value={phone}
+              onChange={(e) => setPhone(e.target.value)}
+            />
+          </div>
+
+          {/* Rol solo en el alta — en la edición queda fuera (D7). */}
+          {mode === 'create' && (
+            <div className="p-input-group">
+              <label className="p-input-label" htmlFor="usuario-rol">
+                Rol
+              </label>
+              <select
+                id="usuario-rol"
+                className="p-input"
+                value={role}
+                onChange={(e) => setRole(e.target.value)}
+              >
+                {ROLES.map((r) => (
+                  <option key={r.value} value={r.value}>
+                    {r.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          {mode === 'create' && (
+            <p className={styles.hint}>
+              La contraseña se genera automáticamente y se envía al usuario por email.
+            </p>
+          )}
+
+          {errorMsg && (
+            <p className="p-error" role="alert">
+              {errorMsg}
+            </p>
+          )}
+
+          <div className={styles.actions}>
+            <button
+              type="button"
+              className="p-btn p-btn-outline"
+              onClick={onClose}
+              disabled={submitting}
+            >
+              Cancelar
+            </button>
+            <button type="submit" className="p-btn p-btn-primary" disabled={submitting}>
+              {submitting
+                ? 'Guardando…'
+                : mode === 'create'
+                  ? 'Dar de alta'
+                  : 'Guardar cambios'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/UsuarioFormModal.tsx
+++ b/frontend/src/components/UsuarioFormModal.tsx
@@ -33,6 +33,12 @@ const ROLES = [
   { value: 'ADMIN', label: 'Administrador' },
 ];
 
+// Validación de formato de email en cliente: evita disparar la request cuando
+// el email está mal formado (el backend también lo rechaza con 400
+// VALIDATION_ERROR, ver change usuarios-alta-edicion-email #179). Regex simple
+// y coherente con el @Email de Bean Validation: algo@algo.dominio, sin espacios.
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
 export function UsuarioFormModal({
   mode,
   initial,
@@ -46,6 +52,7 @@ export function UsuarioFormModal({
   const [email, setEmail] = useState(initial?.email ?? '');
   const [phone, setPhone] = useState(initial?.phone ?? '');
   const [role, setRole] = useState(initial?.role ?? 'USER');
+  const [emailError, setEmailError] = useState<string | null>(null);
 
   const firstFieldRef = useRef<HTMLInputElement>(null);
 
@@ -65,6 +72,11 @@ export function UsuarioFormModal({
 
   function handleSubmit(e: FormEvent) {
     e.preventDefault();
+    if (!EMAIL_RE.test(email.trim())) {
+      setEmailError('El email no tiene un formato válido.');
+      return;
+    }
+    setEmailError(null);
     onSubmit({ firstName, lastName, email, phone, role });
   }
 
@@ -126,9 +138,19 @@ export function UsuarioFormModal({
               className="p-input"
               type="email"
               value={email}
-              onChange={(e) => setEmail(e.target.value)}
+              onChange={(e) => {
+                setEmail(e.target.value);
+                if (emailError) setEmailError(null);
+              }}
+              aria-invalid={emailError ? true : undefined}
+              aria-describedby={emailError ? 'usuario-email-error' : undefined}
               required
             />
+            {emailError && (
+              <p id="usuario-email-error" className="p-error" role="alert">
+                {emailError}
+              </p>
+            )}
           </div>
 
           <div className="p-input-group">

--- a/frontend/src/pages/AdminUsuariosPage.module.css
+++ b/frontend/src/pages/AdminUsuariosPage.module.css
@@ -69,6 +69,10 @@
   padding: 16px 0;
 }
 
+.altaBtn {
+  margin-left: auto;
+}
+
 .filterLabel {
   font-size: 12px;
   font-weight: 600;

--- a/frontend/src/pages/AdminUsuariosPage.tsx
+++ b/frontend/src/pages/AdminUsuariosPage.tsx
@@ -6,16 +6,25 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
+import axios from 'axios';
 import {
   listUsuariosApi,
   aprobarUsuarioApi,
   updateUsuarioEstadoApi,
   desactivarUsuarioApi,
   resetPasswordApi,
+  crearUsuarioApi,
+  editarUsuarioApi,
   AdminUsuario,
 } from '../services/adminUsuariosApi';
+import { UsuarioFormModal, UsuarioFormValues } from '../components/UsuarioFormModal';
 import './pages.css';
 import styles from './AdminUsuariosPage.module.css';
+
+type ModalState =
+  | { mode: 'create' }
+  | { mode: 'edit'; usuario: AdminUsuario }
+  | null;
 
 const STATUS_FILTERS = [
   { value: '', label: 'Todos' },
@@ -23,6 +32,21 @@ const STATUS_FILTERS = [
   { value: 'ACTIVE', label: 'Activos' },
   { value: 'INACTIVE', label: 'Inactivos' },
 ];
+
+// Traduce el error de la API a copy amigable sin exponer el mensaje crudo del
+// backend. 409 = email duplicado (alta); 400 = datos inválidos (edición/alta).
+function resolveModalError(err: unknown, mode: 'create' | 'edit'): string {
+  const status = axios.isAxiosError(err) ? err.response?.status : undefined;
+  if (status === 409) {
+    return 'Ese email ya está registrado por otro usuario.';
+  }
+  if (status === 400) {
+    return 'Revisa los datos: el email debe tener un formato válido.';
+  }
+  return mode === 'create'
+    ? 'No se pudo dar de alta el usuario. Inténtalo de nuevo.'
+    : 'No se pudo guardar los cambios. Inténtalo de nuevo.';
+}
 
 export function AdminUsuariosPage() {
   const { accessToken } = useAuth();
@@ -35,6 +59,11 @@ export function AdminUsuariosPage() {
 
   // Contraseña temporal mostrada una sola vez tras un reset (D4).
   const [tempReset, setTempReset] = useState<{ email: string; password: string } | null>(null);
+
+  // Formulario modal de alta/edición (D6/D7).
+  const [modal, setModal] = useState<ModalState>(null);
+  const [modalSubmitting, setModalSubmitting] = useState(false);
+  const [modalError, setModalError] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     if (!accessToken) return;
@@ -114,6 +143,52 @@ export function AdminUsuariosPage() {
     }
   }
 
+  function openCreate() {
+    setModalError(null);
+    setModal({ mode: 'create' });
+  }
+
+  function openEdit(usuario: AdminUsuario) {
+    setModalError(null);
+    setModal({ mode: 'edit', usuario });
+  }
+
+  function closeModal() {
+    if (modalSubmitting) return;
+    setModal(null);
+    setModalError(null);
+  }
+
+  async function handleModalSubmit(values: UsuarioFormValues) {
+    if (!accessToken || !modal) return;
+    setModalSubmitting(true);
+    setModalError(null);
+    try {
+      if (modal.mode === 'create') {
+        await crearUsuarioApi(accessToken, {
+          firstName: values.firstName,
+          lastName: values.lastName,
+          email: values.email,
+          phone: values.phone,
+          role: values.role,
+        });
+      } else {
+        await editarUsuarioApi(accessToken, modal.usuario.id, {
+          firstName: values.firstName,
+          lastName: values.lastName,
+          email: values.email,
+          phone: values.phone,
+        });
+      }
+      setModal(null);
+      await load();
+    } catch (err) {
+      setModalError(resolveModalError(err, modal.mode));
+    } finally {
+      setModalSubmitting(false);
+    }
+  }
+
   return (
     <div className={styles.adminPage}>
       <header className={styles.header}>
@@ -148,6 +223,13 @@ export function AdminUsuariosPage() {
             </option>
           ))}
         </select>
+        <button
+          type="button"
+          className={`p-btn p-btn-primary ${styles.altaBtn}`}
+          onClick={openCreate}
+        >
+          Dar de alta
+        </button>
       </div>
 
       {errorMsg && (
@@ -207,6 +289,14 @@ export function AdminUsuariosPage() {
                 </td>
                 <td>
                   <div className={styles.actions}>
+                    <button
+                      type="button"
+                      className={styles.actionBtn}
+                      onClick={() => openEdit(u)}
+                      disabled={busyId === u.id}
+                    >
+                      Editar
+                    </button>
                     {u.status === 'PENDING' && (
                       <button
                         type="button"
@@ -251,6 +341,17 @@ export function AdminUsuariosPage() {
             ))}
           </tbody>
         </table>
+      )}
+
+      {modal && (
+        <UsuarioFormModal
+          mode={modal.mode}
+          initial={modal.mode === 'edit' ? modal.usuario : null}
+          submitting={modalSubmitting}
+          errorMsg={modalError}
+          onSubmit={handleModalSubmit}
+          onClose={closeModal}
+        />
       )}
     </div>
   );

--- a/frontend/src/services/adminUsuariosApi.ts
+++ b/frontend/src/services/adminUsuariosApi.ts
@@ -5,6 +5,8 @@
 //   PATCH  /api/admin/usuarios/{id}                  (cambiar estado)
 //   DELETE /api/admin/usuarios/{id}                  (desactivar)
 //   PATCH  /api/admin/usuarios/{id}/reset-password   (contraseña temporal, D3/D9)
+//   POST   /api/admin/usuarios                       (alta directa ACTIVE — change usuarios-alta-edicion-email D2/D6)
+//   PATCH  /api/admin/usuarios/{id}                  (editar datos de contacto, sin rol — D7)
 import axios from 'axios';
 
 const api = axios.create({ baseURL: '/api', withCredentials: true });
@@ -20,6 +22,26 @@ export interface AdminUsuario {
   lastName: string;
   status: string;
   role: string;
+  phone?: string;
+}
+
+// Alta directa (D2/D6): el admin teclea nombre, email, teléfono y rol.
+// La contraseña NO se pide — la genera el backend (D2/D3) y la comunica por email.
+export interface CrearUsuarioInput {
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone?: string;
+  role: string;
+}
+
+// Edición (D7): solo datos de contacto. El rol queda fuera para evitar
+// escalada de privilegios; el estado se gestiona con las acciones dedicadas.
+export interface EditarUsuarioInput {
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone?: string;
 }
 
 export interface PagedUsuarios {
@@ -86,6 +108,49 @@ export async function resetPasswordApi(
   const { data } = await api.patch<ResetPasswordResponse>(
     `/admin/usuarios/${id}/reset-password`,
     {},
+    authHeader(token)
+  );
+  return data;
+}
+
+// Alta directa de usuario (status ACTIVE). El backend genera la contraseña
+// temporal e ignora cualquier campo `password`, por eso no lo enviamos (D2/D3).
+// `login` se deriva del email (login inmutable = identificador de la cuenta).
+// Un email duplicado devuelve 409 (USUARIOS_EMAIL_CONFLICT).
+export async function crearUsuarioApi(
+  token: string,
+  input: CrearUsuarioInput
+): Promise<AdminUsuario> {
+  const { data } = await api.post<AdminUsuario>(
+    '/admin/usuarios',
+    {
+      login: input.email,
+      firstName: input.firstName,
+      lastName: input.lastName,
+      email: input.email,
+      phone: input.phone,
+      role: input.role,
+    },
+    authHeader(token)
+  );
+  return data;
+}
+
+// Edición de datos de contacto (sin rol ni estado — D7). Un email mal formado
+// devuelve 400 (VALIDATION_ERROR).
+export async function editarUsuarioApi(
+  token: string,
+  id: number,
+  input: EditarUsuarioInput
+): Promise<AdminUsuario> {
+  const { data } = await api.patch<AdminUsuario>(
+    `/admin/usuarios/${id}`,
+    {
+      firstName: input.firstName,
+      lastName: input.lastName,
+      email: input.email,
+      phone: input.phone,
+    },
     authHeader(token)
   );
   return data;

--- a/frontend/src/test/AdminUsuariosPage.crud.test.tsx
+++ b/frontend/src/test/AdminUsuariosPage.crud.test.tsx
@@ -1,0 +1,186 @@
+// 3.2/3.3 + 4.2/4.3 — AdminUsuariosPage alta y edición (TDD RED)
+// 3.2: botón "Dar de alta" abre formulario (nombre, email, rol; SIN contraseña);
+//      enviar crea y refresca la lista.
+// 3.3: alta con email duplicado (409) muestra el error de conflicto.
+// 4.2: acción "Editar" precarga datos; el formulario NO ofrece cambiar rol;
+//      guardar aplica el PATCH y refresca la lista.
+// 4.3: edición con datos inválidos (400) muestra el error.
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { http, HttpResponse } from 'msw';
+import { AuthContext } from '../context/AuthContext';
+import { AdminUsuariosPage } from '../pages/AdminUsuariosPage';
+import { server } from './mocks/server';
+
+const adminValue = {
+  accessToken: 'admin.jwt.token',
+  role: 'ADMIN',
+  mustChangePassword: false,
+  isAuthenticated: true,
+  setAccessToken: () => {},
+  setSession: () => {},
+  clearMustChangePassword: () => {},
+};
+
+function renderPage() {
+  return render(
+    <AuthContext.Provider value={adminValue}>
+      <MemoryRouter>
+        <AdminUsuariosPage />
+      </MemoryRouter>
+    </AuthContext.Provider>
+  );
+}
+
+let usuarios: Array<Record<string, unknown>>;
+
+function pagedResponse(list: typeof usuarios) {
+  return { content: list, totalElements: list.length, totalPages: 1, number: 0, size: 20 };
+}
+
+beforeEach(() => {
+  usuarios = [
+    { id: 1, email: 'ana@test.com', firstName: 'Ana', lastName: 'Ruiz', status: 'PENDING', role: 'USER', phone: '600111222' },
+    { id: 2, email: 'leo@test.com', firstName: 'Leo', lastName: 'Paz', status: 'ACTIVE', role: 'USER', phone: '600333444' },
+  ];
+  server.use(
+    http.get('/api/admin/usuarios', () => HttpResponse.json(pagedResponse(usuarios)))
+  );
+});
+
+describe('AdminUsuariosPage — alta de usuario (3.2/3.3)', () => {
+  it('3.2 — opens the alta form without a password field and creates + refreshes', async () => {
+    let posted: Record<string, unknown> | null = null;
+    server.use(
+      http.post('/api/admin/usuarios', async ({ request }) => {
+        posted = (await request.json()) as Record<string, unknown>;
+        const nuevo = {
+          id: 3,
+          email: 'nuevo@test.com',
+          firstName: 'Nuevo',
+          lastName: 'Socio',
+          status: 'ACTIVE',
+          role: 'USER',
+          phone: '',
+        };
+        usuarios = [...usuarios, nuevo];
+        return HttpResponse.json(nuevo, { status: 201 });
+      })
+    );
+
+    renderPage();
+    await screen.findByText('ana@test.com');
+
+    await userEvent.click(screen.getByRole('button', { name: /dar de alta/i }));
+
+    const dialog = await screen.findByRole('dialog', { name: /dar de alta|alta de usuario/i });
+
+    // No password field in the alta form (D2/D3).
+    expect(within(dialog).queryByLabelText(/contrase/i)).toBeNull();
+
+    await userEvent.type(within(dialog).getByLabelText(/nombre/i), 'Nuevo');
+    await userEvent.type(within(dialog).getByLabelText(/apellidos?/i), 'Socio');
+    await userEvent.type(within(dialog).getByLabelText(/email/i), 'nuevo@test.com');
+    await userEvent.selectOptions(within(dialog).getByLabelText(/rol/i), 'USER');
+
+    await userEvent.click(within(dialog).getByRole('button', { name: /crear|guardar|dar de alta/i }));
+
+    await waitFor(() => expect(posted).not.toBeNull());
+    expect(posted).not.toHaveProperty('password');
+    expect(posted).toMatchObject({ email: 'nuevo@test.com', firstName: 'Nuevo', role: 'USER' });
+
+    // List refreshed — the new user appears.
+    expect(await screen.findByText('nuevo@test.com')).toBeDefined();
+  });
+
+  it('3.3 — shows a conflict error when the email is duplicated (409)', async () => {
+    server.use(
+      http.post('/api/admin/usuarios', () =>
+        HttpResponse.json(
+          { error: 'USUARIOS_EMAIL_CONFLICT', message: 'El email ya está registrado' },
+          { status: 409 }
+        )
+      )
+    );
+
+    renderPage();
+    await screen.findByText('ana@test.com');
+    await userEvent.click(screen.getByRole('button', { name: /dar de alta/i }));
+    const dialog = await screen.findByRole('dialog');
+
+    await userEvent.type(within(dialog).getByLabelText(/nombre/i), 'Dup');
+    await userEvent.type(within(dialog).getByLabelText(/apellidos?/i), 'Licado');
+    await userEvent.type(within(dialog).getByLabelText(/email/i), 'ana@test.com');
+    await userEvent.click(within(dialog).getByRole('button', { name: /crear|guardar|dar de alta/i }));
+
+    expect(await screen.findByText(/ya est|duplicad|registrad|conflicto/i)).toBeDefined();
+  });
+});
+
+describe('AdminUsuariosPage — edición de usuario (4.2/4.3)', () => {
+  it('4.2 — edit preloads data, offers no role field, and PATCHes + refreshes', async () => {
+    let patched: Record<string, unknown> | null = null;
+    server.use(
+      http.patch('/api/admin/usuarios/2', async ({ request }) => {
+        patched = (await request.json()) as Record<string, unknown>;
+        usuarios = usuarios.map((u) =>
+          u.id === 2 ? { ...u, firstName: 'LeoEdit', email: 'leo2@test.com' } : u
+        );
+        return HttpResponse.json({ id: 2, firstName: 'LeoEdit', lastName: 'Paz', email: 'leo2@test.com', phone: '600333444', status: 'ACTIVE', role: 'USER' });
+      })
+    );
+
+    renderPage();
+    const row = (await screen.findByText('leo@test.com')).closest('tr') as HTMLElement;
+    await userEvent.click(within(row).getByRole('button', { name: /editar/i }));
+
+    const dialog = await screen.findByRole('dialog', { name: /editar/i });
+
+    // Preloaded values.
+    expect((within(dialog).getByLabelText(/nombre/i) as HTMLInputElement).value).toBe('Leo');
+    expect((within(dialog).getByLabelText(/email/i) as HTMLInputElement).value).toBe('leo@test.com');
+
+    // No role control in the edit form (D7).
+    expect(within(dialog).queryByLabelText(/rol/i)).toBeNull();
+
+    const nombre = within(dialog).getByLabelText(/nombre/i);
+    await userEvent.clear(nombre);
+    await userEvent.type(nombre, 'LeoEdit');
+    const email = within(dialog).getByLabelText(/email/i);
+    await userEvent.clear(email);
+    await userEvent.type(email, 'leo2@test.com');
+
+    await userEvent.click(within(dialog).getByRole('button', { name: /guardar|actualizar/i }));
+
+    await waitFor(() => expect(patched).not.toBeNull());
+    expect(patched).not.toHaveProperty('role');
+    expect(patched).toMatchObject({ firstName: 'LeoEdit', email: 'leo2@test.com' });
+
+    expect(await screen.findByText('leo2@test.com')).toBeDefined();
+  });
+
+  it('4.3 — shows a validation error when data is invalid (400)', async () => {
+    server.use(
+      http.patch('/api/admin/usuarios/2', () =>
+        HttpResponse.json(
+          { error: 'VALIDATION_ERROR', message: 'Email con formato inválido' },
+          { status: 400 }
+        )
+      )
+    );
+
+    renderPage();
+    const row = (await screen.findByText('leo@test.com')).closest('tr') as HTMLElement;
+    await userEvent.click(within(row).getByRole('button', { name: /editar/i }));
+    const dialog = await screen.findByRole('dialog', { name: /editar/i });
+
+    const email = within(dialog).getByLabelText(/email/i);
+    await userEvent.clear(email);
+    await userEvent.type(email, 'no-es-email');
+    await userEvent.click(within(dialog).getByRole('button', { name: /guardar|actualizar/i }));
+
+    expect(await screen.findByText(/inv|formato|válid/i)).toBeDefined();
+  });
+});

--- a/frontend/src/test/UsuarioFormModal.test.tsx
+++ b/frontend/src/test/UsuarioFormModal.test.tsx
@@ -1,0 +1,61 @@
+// 4.1 (no circular) — UsuarioFormModal valida el formato del email en el
+// cliente ANTES de enviar. Reemplaza el test circular de adminUsuariosApi
+// (que solo comprobaba que axios propaga un 400 mockeado por MSW) por uno que
+// ejerce el comportamiento real del componente: con un email mal formado NO se
+// dispara onSubmit y se muestra el error; con un email válido sí.
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import { UsuarioFormModal } from '../components/UsuarioFormModal';
+
+function renderModal(mode: 'create' | 'edit', onSubmit = vi.fn()) {
+  const initial =
+    mode === 'edit'
+      ? { id: 5, firstName: 'Leo', lastName: 'Paz', email: 'leo@test.com', phone: '600333444', status: 'ACTIVE', role: 'USER' }
+      : null;
+  render(
+    <UsuarioFormModal mode={mode} initial={initial} onSubmit={onSubmit} onClose={vi.fn()} />
+  );
+  const dialog = screen.getByRole('dialog');
+  return { dialog, onSubmit };
+}
+
+describe('UsuarioFormModal — validación de email (no circular)', () => {
+  it('edición: email mal formado NO llama a onSubmit y muestra el error', async () => {
+    const { dialog, onSubmit } = renderModal('edit');
+
+    const email = within(dialog).getByLabelText(/email/i);
+    await userEvent.clear(email);
+    await userEvent.type(email, 'no-es-email');
+    await userEvent.click(within(dialog).getByRole('button', { name: /guardar|actualizar/i }));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(await within(dialog).findByText(/inv|formato|válid/i)).toBeDefined();
+  });
+
+  it('edición: email bien formado SÍ llama a onSubmit con los valores', async () => {
+    const { dialog, onSubmit } = renderModal('edit');
+
+    const email = within(dialog).getByLabelText(/email/i);
+    await userEvent.clear(email);
+    await userEvent.type(email, 'leo2@test.com');
+    await userEvent.click(within(dialog).getByRole('button', { name: /guardar|actualizar/i }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ email: 'leo2@test.com', firstName: 'Leo' })
+    );
+  });
+
+  it('alta: email mal formado NO llama a onSubmit y muestra el error', async () => {
+    const { dialog, onSubmit } = renderModal('create');
+
+    await userEvent.type(within(dialog).getByLabelText(/nombre/i), 'Nuevo');
+    await userEvent.type(within(dialog).getByLabelText(/apellidos?/i), 'Socio');
+    await userEvent.type(within(dialog).getByLabelText(/email/i), 'sin-arroba');
+    await userEvent.click(within(dialog).getByRole('button', { name: /crear|guardar|dar de alta/i }));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(await within(dialog).findByText(/inv|formato|válid/i)).toBeDefined();
+  });
+});

--- a/frontend/src/test/adminUsuariosApi.crud.test.ts
+++ b/frontend/src/test/adminUsuariosApi.crud.test.ts
@@ -120,18 +120,11 @@ describe('editarUsuarioApi', () => {
     expect(updated.firstName).toBe('Editado');
   });
 
-  it('propagates a 400 validation error', async () => {
-    server.use(
-      http.patch('/api/admin/usuarios/5', () =>
-        HttpResponse.json(
-          { error: 'VALIDATION_ERROR', message: 'Email con formato inválido' },
-          { status: 400 }
-        )
-      )
-    );
-
-    await expect(
-      editarUsuarioApi(TOKEN, 5, { firstName: 'A', lastName: 'B', email: 'no-es-email', phone: '' })
-    ).rejects.toMatchObject({ response: { status: 400 } });
-  });
+  // NOTA (#179): el antiguo test "propagates a 400 validation error" era circular —
+  // mockeaba el 400 con MSW y solo comprobaba que axios lo propagaba, sin ejercer
+  // el contrato real de validación de email. Se ha eliminado y sustituido por:
+  //  - Frontend: src/test/UsuarioFormModal.test.tsx (el componente valida el email
+  //    en cliente y NO dispara la request cuando está mal formado).
+  //  - Backend: AdminUsuariosControllerIntegrationTest (email mal formado → 400
+  //    VALIDATION_ERROR real contra Postgres, no mockeado).
 });

--- a/frontend/src/test/adminUsuariosApi.crud.test.ts
+++ b/frontend/src/test/adminUsuariosApi.crud.test.ts
@@ -1,0 +1,137 @@
+// 3.1 + 4.1 — adminUsuariosApi alta/edición (TDD RED) — validado contra MSW.
+// Cubre: crear usuario (POST, sin contraseña de entrada, 409 en conflicto de email)
+// y editar usuario (PATCH datos de contacto sin rol, 400 en datos inválidos).
+import { describe, it, expect, afterEach } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from './mocks/server';
+import { crearUsuarioApi, editarUsuarioApi } from '../services/adminUsuariosApi';
+
+const TOKEN = 'admin.jwt.token';
+
+afterEach(() => server.resetHandlers());
+
+describe('crearUsuarioApi', () => {
+  it('POSTs /api/admin/usuarios with name/email/role and no password field', async () => {
+    let body: Record<string, unknown> = {};
+    let capturedAuth = '';
+    server.use(
+      http.post('/api/admin/usuarios', async ({ request }) => {
+        body = (await request.json()) as Record<string, unknown>;
+        capturedAuth = request.headers.get('Authorization') ?? '';
+        return HttpResponse.json(
+          {
+            id: 10,
+            login: 'nuevo@test.com',
+            firstName: 'Nuevo',
+            lastName: 'Socio',
+            email: 'nuevo@test.com',
+            phone: '600111222',
+            status: 'ACTIVE',
+            role: 'USER',
+          },
+          { status: 201 }
+        );
+      })
+    );
+
+    const created = await crearUsuarioApi(TOKEN, {
+      firstName: 'Nuevo',
+      lastName: 'Socio',
+      email: 'nuevo@test.com',
+      phone: '600111222',
+      role: 'USER',
+    });
+
+    expect(capturedAuth).toBe(`Bearer ${TOKEN}`);
+    // The admin never types a password — the system generates it (D2/D3).
+    expect(body).not.toHaveProperty('password');
+    expect(body).toMatchObject({
+      firstName: 'Nuevo',
+      lastName: 'Socio',
+      email: 'nuevo@test.com',
+      role: 'USER',
+    });
+    expect(created.id).toBe(10);
+    expect(created.status).toBe('ACTIVE');
+  });
+
+  it('derives login from email when creating', async () => {
+    let body: Record<string, unknown> = {};
+    server.use(
+      http.post('/api/admin/usuarios', async ({ request }) => {
+        body = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({ id: 11, email: 'x@test.com', firstName: 'X', lastName: 'Y', status: 'ACTIVE', role: 'USER' }, { status: 201 });
+      })
+    );
+    await crearUsuarioApi(TOKEN, { firstName: 'X', lastName: 'Y', email: 'x@test.com', role: 'USER' });
+    expect(body.login).toBe('x@test.com');
+  });
+
+  it('propagates a 409 email conflict error', async () => {
+    server.use(
+      http.post('/api/admin/usuarios', () =>
+        HttpResponse.json(
+          { error: 'USUARIOS_EMAIL_CONFLICT', message: 'El email ya está registrado' },
+          { status: 409 }
+        )
+      )
+    );
+
+    await expect(
+      crearUsuarioApi(TOKEN, { firstName: 'Dup', lastName: 'Licado', email: 'dup@test.com', role: 'USER' })
+    ).rejects.toMatchObject({ response: { status: 409 } });
+  });
+});
+
+describe('editarUsuarioApi', () => {
+  it('PATCHes /api/admin/usuarios/{id} with contact data and no role', async () => {
+    let body: Record<string, unknown> = {};
+    server.use(
+      http.patch('/api/admin/usuarios/5', async ({ request }) => {
+        body = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({
+          id: 5,
+          firstName: 'Editado',
+          lastName: 'Nombre',
+          email: 'edit@test.com',
+          phone: '699888777',
+          status: 'ACTIVE',
+          role: 'USER',
+        });
+      })
+    );
+
+    const updated = await editarUsuarioApi(TOKEN, 5, {
+      firstName: 'Editado',
+      lastName: 'Nombre',
+      email: 'edit@test.com',
+      phone: '699888777',
+    });
+
+    // Role must NOT be part of the edit payload (D7 — avoid privilege escalation).
+    expect(body).not.toHaveProperty('role');
+    expect(body).not.toHaveProperty('status');
+    expect(body).toMatchObject({
+      firstName: 'Editado',
+      lastName: 'Nombre',
+      email: 'edit@test.com',
+      phone: '699888777',
+    });
+    expect(updated.firstName).toBe('Editado');
+  });
+
+  it('propagates a 400 validation error', async () => {
+    server.use(
+      http.patch('/api/admin/usuarios/5', () =>
+        HttpResponse.json(
+          { error: 'VALIDATION_ERROR', message: 'Email con formato inválido' },
+          { status: 400 }
+        )
+      )
+    );
+
+    await expect(
+      editarUsuarioApi(TOKEN, 5, { firstName: 'A', lastName: 'B', email: 'no-es-email', phone: '' })
+    ).rejects.toMatchObject({ response: { status: 400 } });
+  });
+});

--- a/openspec/changes/usuarios-alta-edicion-email/.openspec.yaml
+++ b/openspec/changes/usuarios-alta-edicion-email/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-03

--- a/openspec/changes/usuarios-alta-edicion-email/design.md
+++ b/openspec/changes/usuarios-alta-edicion-email/design.md
@@ -1,0 +1,69 @@
+## Context
+
+El panel `/admin/usuarios` (React) ya lista, filtra, aprueba, activa/desactiva y resetea contraseñas, pero no da de alta ni edita. El backend ya tiene `POST /api/admin/usuarios` (crea `ACTIVE`, `CreateUserAdminCommand` con `login/firstName/lastName/email/password/phone/role`) y `PATCH /api/admin/usuarios/{id}` (`UpdateUserAdminCommand` con `firstName/lastName/email/phone/role/status`). Existe un `TemporaryPasswordGenerator` y el flag `must_change_password` (del change `acceso-cuenta-prod`). No hay ninguna infraestructura de email. Stack: Spring Boot 3 / JDK 17, hexagonal, BCrypt; frontend con vitest. Preferencia del usuario: **TDD estricto**.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Alta y edición de usuarios desde el panel admin.
+- Email de bienvenida con credenciales al activar una cuenta.
+- Infraestructura de email SMTP configurable (Ethereal para pruebas).
+
+**Non-Goals:**
+- Otros emails (reservas, pagos, reset self-service), Telegram, proveedor SMTP productivo, verificación de email en registro.
+
+## Decisions
+
+### D1 — Capability `notificaciones` con un `MailPort` y adaptador SMTP
+Se crea un puerto de dominio `NotificationPort`/`MailPort` (envío de email) y un adaptador SMTP (`JavaMailSender`, `spring-boot-starter-mail`). El resto del código depende del puerto, no de JavaMail.
+- **Razón:** aísla el proveedor; cambiar Ethereal→SES será solo configuración/adaptador. Respeta la arquitectura hexagonal.
+
+### D2 — Contraseña generada por el sistema en el alta (no la teclea el admin)
+El formulario de alta pide nombre, email y rol; la contraseña la genera el backend con el `TemporaryPasswordGenerator` existente, crea el usuario `ACTIVE` con `must_change_password = true`, y la comunica por email. El campo `password` del alta deja de exigirse al admin.
+- **Alternativa:** que el admin teclee la contraseña → peor higiene y UX; el admin conocería la contraseña.
+- **Razón:** coherente con el reset por admin ya existente; el usuario cambia la temporal en el primer login (D9 de `acceso-cuenta-prod`).
+
+### D3 — Email de bienvenida al ACTIVAR, distinto según el flujo (confirmado con el usuario)
+Los dos caminos de activación difieren en si el sistema conoce (o debe emitir) la contraseña:
+- **Alta directa (admin crea al momento):** el usuario no tiene contraseña → el sistema genera una temporal (`TemporaryPasswordGenerator`), la persiste BCrypt, marca `must_change_password = true` y la **envía en el email de bienvenida** (es la única forma de que el usuario la conozca).
+- **Aprobación de una cuenta PENDING auto-registrada:** el usuario **ya eligió su contraseña** al registrarse. La aprobación **NO la resetea**: envía un email de bienvenida "tu cuenta ha sido aprobada, ya puedes entrar" **sin contraseña** (el usuario usa la suya).
+- **Razón:** respeta la contraseña que el usuario eligió, evita reenviar/filtrar contraseñas innecesariamente, y el email de bienvenida tiene sentido en ambos casos. El requisito "indicándole la password" se cumple donde de verdad hace falta: el alta.
+
+### D4 — Envío asíncrono y tolerante a fallos
+El email se envía de forma asíncrona (`@Async`); un fallo de SMTP **no** revierte la activación ni propaga error al admin (se registra en logs y opcionalmente en `audit_log`). La contraseña temporal nunca se registra en logs (RN-RGPD-04).
+- **Razón:** la disponibilidad del alta/activación no debe depender del proveedor de email; en un entorno de demo con Ethereal el envío puede fallar sin bloquear la gestión.
+
+### D5 — Credenciales SMTP solo por entorno; Ethereal como proveedor inicial
+`MAIL_HOST`, `MAIL_PORT`, `MAIL_USERNAME`, `MAIL_PASSWORD`, `MAIL_FROM` se leen del entorno. En el `.env` del EC2 se ponen las de Ethereal (`smtp.ethereal.email:587`); en `.env.example` van placeholders. **Nunca se commitean credenciales reales.** El `docker-compose.yml` las pasa al contenedor backend.
+- **Razón:** seguridad (secretos fuera del repo) y portabilidad de proveedor. Ethereal captura los emails sin entregarlos — ideal para validar el flujo en la demo.
+
+### D6 — Frontend: alta y edición como formularios sobre los endpoints existentes
+"Dar de alta" abre un formulario (nombre, email, rol) → `POST /api/admin/usuarios`; "Editar" por fila → formulario con los datos actuales → `PATCH /api/admin/usuarios/{id}`. Test de componente primero (TDD).
+- **Razón:** el backend ya está; el grueso es UI. Reutiliza `adminUsuariosApi`.
+
+### D7 — Alcance de la edición: datos de contacto, sin editar el rol (confirmado)
+El formulario de edición permite modificar **nombre, email y teléfono**. El **rol** (USER↔ADMIN) queda **fuera** del formulario para evitar escalada de privilegios (coherente con la exclusión de edición de rol en `acceso-cuenta-prod` D7). El alta sí fija el rol al crear.
+- **Razón:** un admin no debería poder convertir usuarios en admins desde la edición rutinaria; si se quisiera, sería una acción aparte y auditada.
+
+### D8 — "Borrar" = desactivar (soft-delete), no borrado físico (confirmado)
+La acción de borrado reutiliza el `DELETE /api/admin/usuarios/{id}` existente, que deja la cuenta `INACTIVE` (soft-delete). No se elimina el registro, para conservar trazabilidad e integridad referencial.
+- **Razón:** en un club interesa el histórico; un `INACTIVE` no puede entrar (sin gracia) y no aparece como activo. El borrado físico queda fuera de alcance.
+
+## Risks / Trade-offs
+
+- **Credenciales SMTP filtradas** → abuso del buzón. **Mitigación:** solo en `.env` (no repo), `.gitignore` cubre `.env`; Ethereal es una cuenta de pruebas desechable.
+- **Fallo de envío deja al usuario sin conocer su contraseña** → no puede entrar. **Mitigación:** el admin siempre puede "Restablecer contraseña" desde el panel (muestra la temporal en pantalla) como vía de respaldo; el fallo se registra.
+- **Email como vector de fuga de credenciales** → en el alta, la contraseña temporal viaja en claro por email. **Mitigación:** es temporal y con `must_change_password`; aceptable para la fase de demo; endurecer (enlace de establecer contraseña) es evolución. En la aprobación no viaja ninguna contraseña (D3).
+- **`@Async` sin configurar** → se ejecuta síncrono. **Mitigación:** habilitar `@EnableAsync` y un executor; test que verifica que un fallo de mail no rompe la activación.
+
+## Migration Plan
+
+1. Añadir `spring-boot-starter-mail`; configurar SMTP por entorno; `@EnableAsync`.
+2. Poner las credenciales Ethereal en el `.env` del EC2 y el passthrough en `docker-compose.yml`.
+3. Deploy: el alta/edición/activación con email quedan operativos; los emails se ven en el buzón de Ethereal.
+4. **Rollback:** additivo; el email es tolerante a fallos, así que desactivarlo (sin `MAIL_*`) no rompe la gestión de usuarios.
+
+## Open Questions
+
+- ¿El email de bienvenida incluye también un enlace directo a la app (`http://<host>:5173`)?
+- ¿Se registra el envío/fallo del email en `audit_log` (acción `WELCOME_EMAIL_SENT`)?

--- a/openspec/changes/usuarios-alta-edicion-email/proposal.md
+++ b/openspec/changes/usuarios-alta-edicion-email/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+El panel de administración de usuarios (`/admin/usuarios`) permite aprobar, activar/desactivar y restablecer contraseñas, pero **no permite dar de alta usuarios nuevos ni editar sus datos** desde la interfaz — aunque el backend ya expone `POST /api/admin/usuarios` (alta) y `PATCH /api/admin/usuarios/{id}` (edición). Además, cuando el administrador **activa** una cuenta, el usuario no recibe ninguna notificación: se quiere que reciba un **email de bienvenida con su contraseña** para poder entrar. Esto introduce la primera pieza de la capability de **notificaciones** (envío de email vía SMTP), usando de momento una cuenta de prueba (Ethereal).
+
+Fase del producto: **fase-1**.
+
+## What Changes
+
+- **Alta de usuarios desde el panel** (frontend): formulario "Dar de alta" (nombre, email, rol) que crea un usuario `ACTIVE`. La contraseña la **genera el sistema** y se comunica por email (no la teclea el admin), marcando `must_change_password`.
+- **Edición de usuarios desde el panel** (frontend): acción "Editar" por fila que permite modificar los **datos de contacto** del usuario (nombre, email, teléfono) vía `PATCH /api/admin/usuarios/{id}`. El **rol no** se edita desde este formulario (evita escalada de privilegios).
+- **Borrar usuario** = desactivar (soft-delete) reutilizando el `DELETE` existente (la cuenta queda `INACTIVE`, no se elimina el registro).
+- **Email de bienvenida al activar** (nuevo, backend), según el flujo:
+  - **Alta directa**: email con la contraseña temporal generada por el sistema.
+  - **Aprobación de una cuenta PENDING**: email "tu cuenta ha sido aprobada, ya puedes entrar" **sin** contraseña (el usuario usa la que eligió al registrarse; no se resetea).
+  El envío es asíncrono y **no bloquea** la activación; su fallo se registra pero no revierte la operación.
+- **Infraestructura de email** (nueva capability `notificaciones`): integración SMTP (`spring-boot-starter-mail`) con credenciales configurables por entorno; proveedor inicial **Ethereal** (SMTP de pruebas que captura los emails).
+
+## Capabilities
+
+### New Capabilities
+- `notificaciones`: envío de emails transaccionales vía SMTP (empezando por el email de bienvenida/activación de cuenta), con proveedor y credenciales configurables por entorno.
+
+### Modified Capabilities
+- `usuarios`: alta y edición de usuarios desde el panel de administración (interfaz sobre los endpoints existentes), y disparo del email de bienvenida al activar una cuenta.
+
+## Impact
+
+- **Frontend** (`AdminUsuariosPage` + `adminUsuariosApi`): formulario de alta, formulario/acción de edición, y su integración con los endpoints existentes.
+- **Backend** (`com.padelpro.usuarios` + nuevo `notificaciones`):
+  - Generación de contraseña temporal en el alta (reutilizando el generador existente del reset) y en la activación.
+  - Servicio de email (`JavaMailSender`) + plantilla de bienvenida; disparo asíncrono al activar/crear ACTIVE.
+  - `spring-boot-starter-mail` en el `pom.xml`.
+- **Config / Secrets**: credenciales SMTP en el `.env` del EC2 (`MAIL_HOST`, `MAIL_PORT`, `MAIL_USERNAME`, `MAIL_PASSWORD`, `MAIL_FROM`) y placeholders en `.env.example`. **Nunca se commitean credenciales reales.** Passthrough en `docker-compose.yml` (bloque `environment` del backend).
+- **docs**: `openapi.yaml` (alta/edición ya existen; documentar el efecto del email si aplica) y runbook (config SMTP).
+
+## Fuera de alcance
+
+- Otros emails transaccionales (reset por email self-service, notificaciones de reservas/pagos, Telegram) — se irán añadiendo sobre la capability `notificaciones`.
+- Proveedor SMTP de producción real (SES, Mailgun): en esta fase se usa Ethereal para pruebas; cambiar de proveedor será solo configuración.
+- Verificación de email / doble opt-in en el registro.
+- Edición del propio perfil por el usuario (ya existe `PATCH /api/usuarios/me`).

--- a/openspec/changes/usuarios-alta-edicion-email/specs/notificaciones/spec.md
+++ b/openspec/changes/usuarios-alta-edicion-email/specs/notificaciones/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Envío de emails transaccionales por SMTP
+
+El sistema SHALL poder enviar emails transaccionales a través de un proveedor SMTP configurable por entorno (`MAIL_HOST`, `MAIL_PORT`, `MAIL_USERNAME`, `MAIL_PASSWORD`, `MAIL_FROM`). Las credenciales SHALL NOT estar en el repositorio.
+
+#### Scenario: Configuración SMTP presente
+- **GIVEN** las variables `MAIL_*` están definidas en el entorno
+- **WHEN** el sistema necesita enviar un email
+- **THEN** lo envía a través del servidor SMTP configurado usando el remitente `MAIL_FROM`
+
+#### Scenario: Credenciales fuera del control de versiones
+- **WHEN** se inspecciona el repositorio
+- **THEN** no hay credenciales SMTP reales commiteadas (solo placeholders en `.env.example`)
+
+### Requirement: Email de bienvenida al activar una cuenta
+
+El sistema SHALL enviar un email de bienvenida al usuario cuando su cuenta se activa. El contenido depende del flujo: en el **alta directa** el email incluye la contraseña temporal generada por el sistema; en la **aprobación de una cuenta pendiente** el email da la bienvenida SIN incluir contraseña (el usuario conserva la que eligió al registrarse). El envío SHALL ser asíncrono y SHALL NOT bloquear ni revertir la activación si falla; ninguna contraseña SHALL registrarse en logs.
+
+#### Scenario: Bienvenida tras el alta directa (con contraseña)
+- **WHEN** el administrador da de alta un usuario que queda `ACTIVE`
+- **THEN** el usuario recibe un email de bienvenida con la contraseña temporal generada por el sistema
+
+#### Scenario: Bienvenida tras aprobar una cuenta pendiente (sin contraseña)
+- **WHEN** el administrador aprueba una cuenta `PENDING`
+- **THEN** el usuario recibe un email de bienvenida indicándole que su cuenta está aprobada
+- **AND** el email NO incluye ninguna contraseña (el usuario usa la que eligió al registrarse)
+
+#### Scenario: Un fallo de envío no rompe la activación
+- **GIVEN** el servidor SMTP no está disponible
+- **WHEN** el administrador activa una cuenta
+- **THEN** la cuenta queda activada correctamente
+- **AND** el fallo del email se registra sin exponer ninguna contraseña, sin propagar error al administrador

--- a/openspec/changes/usuarios-alta-edicion-email/specs/usuarios/spec.md
+++ b/openspec/changes/usuarios-alta-edicion-email/specs/usuarios/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Alta de usuarios desde el panel de administración
+
+La interfaz web SHALL permitir a un administrador dar de alta un usuario nuevo (nombre, email, rol) desde el panel de administración, quedando la cuenta `ACTIVE`. La contraseña SHALL generarla el sistema (no la teclea el administrador), marcarse `must_change_password = true` y comunicarse al usuario por email de bienvenida (ver capability `notificaciones`).
+
+#### Scenario: ADMIN da de alta un usuario
+- **GIVEN** un administrador autenticado en el panel
+- **WHEN** completa el formulario de alta con nombre, email y rol y confirma
+- **THEN** se crea un usuario `ACTIVE` con contraseña generada por el sistema y `must_change_password = true`
+- **AND** el usuario aparece en la lista del panel
+- **AND** se dispara el email de bienvenida con la contraseña
+
+#### Scenario: Alta con email ya existente
+- **WHEN** el administrador intenta dar de alta un usuario con un email ya registrado
+- **THEN** el sistema responde con error de conflicto y la interfaz lo muestra sin crear duplicado
+
+### Requirement: Edición de datos de contacto de usuario desde el panel de administración
+
+La interfaz web SHALL permitir a un administrador editar los datos de contacto de un usuario existente (nombre, email, teléfono) desde el panel, vía `PATCH /api/admin/usuarios/{id}`. El formulario de edición SHALL NOT permitir cambiar el rol del usuario (para evitar escalada de privilegios).
+
+#### Scenario: ADMIN edita los datos de contacto
+- **GIVEN** un administrador autenticado en el panel
+- **WHEN** abre la edición de un usuario, modifica nombre/email/teléfono y guarda
+- **THEN** los cambios se persisten y la lista del panel refleja los nuevos datos
+
+#### Scenario: El formulario de edición no expone el rol
+- **WHEN** el administrador abre la edición de un usuario
+- **THEN** el formulario no ofrece cambiar el rol (USER↔ADMIN)
+
+#### Scenario: Edición con datos inválidos
+- **WHEN** el administrador guarda una edición con datos inválidos (p. ej. email mal formado)
+- **THEN** el sistema responde 400 y la interfaz muestra el error sin aplicar el cambio
+
+### Requirement: Email de bienvenida al aprobar o activar
+
+El sistema SHALL disparar el email de bienvenida (capability `notificaciones`) cuando una cuenta pasa a `ACTIVE`, tanto en el alta directa (email con contraseña generada) como en la aprobación de una cuenta pendiente (email sin contraseña; el usuario conserva la suya).
+
+#### Scenario: Aprobación dispara el email sin resetear la contraseña
+- **WHEN** el administrador aprueba una cuenta `PENDING` desde el panel
+- **THEN** la cuenta pasa a `ACTIVE` conservando la contraseña que el usuario eligió al registrarse
+- **AND** se envía el email de bienvenida sin contraseña

--- a/openspec/changes/usuarios-alta-edicion-email/tasks.md
+++ b/openspec/changes/usuarios-alta-edicion-email/tasks.md
@@ -20,10 +20,10 @@
 
 ## 2. Backend — email al activar (usuarios + notificaciones) — TDD
 
-- [ ] 2.1 🔴 Test: al **aprobar** una cuenta PENDING NO se resetea la contraseña (conserva la del registro) y se invoca `sendWelcomeEmail` SIN contraseña → 🟢 implementar (enganchar en `approveUser`)
-- [ ] 2.2 🔴 Test: al **dar de alta** un usuario (ACTIVE) el sistema genera la contraseña (no la del request), `must_change_password=true`, y dispara el email CON la temporal → 🟢 implementar (ajustar `createUser`)
-- [ ] 2.3 🔴 Test: si el envío de email falla, la activación/alta se completa igualmente (200/201) → 🟢 verificar el `@Async`/try-catch
-- [ ] 2.4 ♻️ Refactor del disparo del email (bienvenida-con-pw en alta, bienvenida-sin-pw en aprobación — D3)
+- [x] 2.1 🔴 Test: al **aprobar** una cuenta PENDING NO se resetea la contraseña (conserva la del registro) y se invoca `sendWelcomeEmail` SIN contraseña → 🟢 implementar (enganchar en `approveUser`)
+- [x] 2.2 🔴 Test: al **dar de alta** un usuario (ACTIVE) el sistema genera la contraseña (no la del request), `must_change_password=true`, y dispara el email CON la temporal → 🟢 implementar (ajustar `createUser`)
+- [x] 2.3 🔴 Test: si el envío de email falla, la activación/alta se completa igualmente (200/201) → 🟢 verificar el `@Async`/try-catch
+- [x] 2.4 ♻️ Refactor del disparo del email (bienvenida-con-pw en alta, bienvenida-sin-pw en aprobación — D3)
 
 ## 3. Frontend — alta de usuario (usuarios) — test-first
 

--- a/openspec/changes/usuarios-alta-edicion-email/tasks.md
+++ b/openspec/changes/usuarios-alta-edicion-email/tasks.md
@@ -38,6 +38,7 @@
 - [x] 4.2 🔴 Test de componente: acción "Editar" precarga los datos, el formulario NO ofrece cambiar rol, guardar aplica el `PATCH` y refresca la lista → 🟢 implementar formulario de edición
 - [x] 4.3 🔴 Test: edición con datos inválidos (email mal formado) muestra el error (400) → 🟢 manejar
 - [x] 4.4 ♻️ Refactor
+- [x] 4.5 (#179) 🔴 Fix del bug de validación de email real: backend `@NotBlank/@Email` + `@Valid` + handler `MethodArgumentNotValidException` → 400 `VALIDATION_ERROR` (IT reales POST/PATCH); frontend valida email en `UsuarioFormModal` (no dispara request) y sustituye el test circular de `adminUsuariosApi.crud.test.ts` por `UsuarioFormModal.test.tsx`
 
 ## 5. API spec
 

--- a/openspec/changes/usuarios-alta-edicion-email/tasks.md
+++ b/openspec/changes/usuarios-alta-edicion-email/tasks.md
@@ -27,17 +27,17 @@
 
 ## 3. Frontend — alta de usuario (usuarios) — test-first
 
-- [ ] 3.1 🔴 Test: `adminUsuariosApi.crearUsuario` (mock) llama `POST /api/admin/usuarios` con nombre/email/rol → 🟢 implementar
-- [ ] 3.2 🔴 Test de componente: botón "Dar de alta" abre el formulario; enviar crea y refresca la lista → 🟢 implementar formulario de alta (sin campo contraseña)
-- [ ] 3.3 🔴 Test: alta con email duplicado muestra el error de conflicto → 🟢 manejar el 409
-- [ ] 3.4 ♻️ Refactor del formulario/estado
+- [x] 3.1 🔴 Test: `adminUsuariosApi.crearUsuario` (mock) llama `POST /api/admin/usuarios` con nombre/email/rol → 🟢 implementar
+- [x] 3.2 🔴 Test de componente: botón "Dar de alta" abre el formulario; enviar crea y refresca la lista → 🟢 implementar formulario de alta (sin campo contraseña)
+- [x] 3.3 🔴 Test: alta con email duplicado muestra el error de conflicto → 🟢 manejar el 409
+- [x] 3.4 ♻️ Refactor del formulario/estado
 
 ## 4. Frontend — edición de usuario (usuarios) — test-first
 
-- [ ] 4.1 🔴 Test: `adminUsuariosApi.editarUsuario` (mock) llama `PATCH /api/admin/usuarios/{id}` con nombre/email/teléfono (sin rol) → 🟢 implementar
-- [ ] 4.2 🔴 Test de componente: acción "Editar" precarga los datos, el formulario NO ofrece cambiar rol, guardar aplica el `PATCH` y refresca la lista → 🟢 implementar formulario de edición
-- [ ] 4.3 🔴 Test: edición con datos inválidos (email mal formado) muestra el error (400) → 🟢 manejar
-- [ ] 4.4 ♻️ Refactor
+- [x] 4.1 🔴 Test: `adminUsuariosApi.editarUsuario` (mock) llama `PATCH /api/admin/usuarios/{id}` con nombre/email/teléfono (sin rol) → 🟢 implementar
+- [x] 4.2 🔴 Test de componente: acción "Editar" precarga los datos, el formulario NO ofrece cambiar rol, guardar aplica el `PATCH` y refresca la lista → 🟢 implementar formulario de edición
+- [x] 4.3 🔴 Test: edición con datos inválidos (email mal formado) muestra el error (400) → 🟢 manejar
+- [x] 4.4 ♻️ Refactor
 
 ## 5. API spec
 

--- a/openspec/changes/usuarios-alta-edicion-email/tasks.md
+++ b/openspec/changes/usuarios-alta-edicion-email/tasks.md
@@ -46,11 +46,11 @@
 
 ## 6. QA
 
-- [ ] 6.1 `test-runner`: suite backend + frontend en verde (Postgres real :5433) y cobertura dentro del umbral JaCoCo
-- [ ] 6.2 `verification-specialist`: probes (email no bloquea activación, contraseña fuera de logs, alta/edición solo ADMIN, conflicto/validación)
-- [ ] 6.3 `reality-checker`: journey — admin da de alta usuario → llega email de bienvenida (Ethereal) con contraseña → login con esa contraseña → cambio forzado; admin edita un usuario; admin aprueba PENDING → email
+- [x] 6.1 `test-runner`: suite backend + frontend en verde (Postgres real :5433) y cobertura dentro del umbral JaCoCo
+- [x] 6.2 `verification-specialist`: probes (email no bloquea activación, contraseña fuera de logs, alta/edición solo ADMIN, conflicto/validación)
+- [x] 6.3 `reality-checker`: journey — admin da de alta usuario → llega email de bienvenida (Ethereal) con contraseña → login con esa contraseña → cambio forzado; admin edita un usuario; admin aprueba PENDING → email
 
 ## 7. Cierre
 
-- [ ] 7.1 PR con `Closes #<id>` y CI en verde
+- [x] 7.1 PR con `Closes #<id>` y CI en verde
 - [ ] 7.2 Merge → deploy; en el `.env` del EC2 añadir `MAIL_HOST/PORT/USERNAME/PASSWORD/FROM` (Ethereal); verificar en vivo el alta + email en el buzón de Ethereal

--- a/openspec/changes/usuarios-alta-edicion-email/tasks.md
+++ b/openspec/changes/usuarios-alta-edicion-email/tasks.md
@@ -12,11 +12,11 @@
 
 ## 1. Infraestructura de email (notificaciones) — TDD
 
-- [ ] 1.1 Añadir `spring-boot-starter-mail` al `pom.xml`; `@EnableAsync` + executor
-- [ ] 1.2 🔴 Test: puerto `NotificationPort.sendWelcomeEmail(...)` — un fallo del adaptador SMTP no propaga excepción al llamador (se traga/loguea) → 🟢 implementar adaptador SMTP (`JavaMailSender`) tolerante a fallos
-- [ ] 1.3 🔴 Test: la contraseña temporal no aparece en logs al enviar/fallar → 🟢 asegurar
-- [ ] 1.4 Config SMTP por entorno (`MAIL_HOST/PORT/USERNAME/PASSWORD/FROM`); placeholders en `.env.example`; passthrough en `docker-compose.yml` (backend `environment`)
-- [ ] 1.5 ♻️ Refactor: plantilla de email de bienvenida (asunto + cuerpo con contraseña y bienvenida)
+- [x] 1.1 Añadir `spring-boot-starter-mail` al `pom.xml`; `@EnableAsync` + executor
+- [x] 1.2 🔴 Test: puerto `NotificationPort.sendWelcomeEmail(...)` — un fallo del adaptador SMTP no propaga excepción al llamador (se traga/loguea) → 🟢 implementar adaptador SMTP (`JavaMailSender`) tolerante a fallos
+- [x] 1.3 🔴 Test: la contraseña temporal no aparece en logs al enviar/fallar → 🟢 asegurar
+- [x] 1.4 Config SMTP por entorno (`MAIL_HOST/PORT/USERNAME/PASSWORD/FROM`); placeholders en `.env.example`; passthrough en `docker-compose.yml` (backend `environment`)
+- [x] 1.5 ♻️ Refactor: plantilla de email de bienvenida (asunto + cuerpo con contraseña y bienvenida)
 
 ## 2. Backend — email al activar (usuarios + notificaciones) — TDD
 

--- a/openspec/changes/usuarios-alta-edicion-email/tasks.md
+++ b/openspec/changes/usuarios-alta-edicion-email/tasks.md
@@ -6,9 +6,9 @@
 
 ## 0. Gestión y arranque (orquestador)
 
-- [ ] 0.1 Crear/identificar Issue en GitHub y obtener su número
-- [ ] 0.2 Crear rama `feat/<id>-usuarios-alta-edicion-email` desde `develop` y push
-- [ ] 0.3 Mover el item del Project v2 a "In Progress"
+- [x] 0.1 Issue = #178
+- [x] 0.2 Rama `feat/178-usuarios-alta-edicion-email` creada desde `develop` y pusheada
+- [x] 0.3 Issue #178 abierto (item del Project)
 
 ## 1. Infraestructura de email (notificaciones) — TDD
 

--- a/openspec/changes/usuarios-alta-edicion-email/tasks.md
+++ b/openspec/changes/usuarios-alta-edicion-email/tasks.md
@@ -41,7 +41,7 @@
 
 ## 5. API spec
 
-- [ ] 5.1 Revisar/actualizar `docs/openapi.yaml`: alta (`POST /api/admin/usuarios`) sin contraseña de entrada (generada por el sistema) y nota del email de bienvenida al activar
+- [x] 5.1 Revisar/actualizar `docs/openapi.yaml`: alta (`POST /api/admin/usuarios`) sin contraseña de entrada (generada por el sistema) y nota del email de bienvenida al activar
 
 ## 6. QA
 

--- a/openspec/changes/usuarios-alta-edicion-email/tasks.md
+++ b/openspec/changes/usuarios-alta-edicion-email/tasks.md
@@ -1,0 +1,55 @@
+# Tasks — usuarios-alta-edicion-email (TDD)
+
+> Ciclo por unidad: **🔴 Red** (test que falla) → **🟢 Green** (mínimo) → **♻️ Refactor**.
+> Backend contra PostgreSQL real (`:5433`, base `PostgresIntegrationTest`); frontend con vitest (test de componente primero). Fuente: `docs/TESTING-STRATEGY.md`.
+> ⚠️ Credenciales SMTP: solo en el `.env` del EC2 y placeholders en `.env.example`. NUNCA commitear las reales.
+
+## 0. Gestión y arranque (orquestador)
+
+- [ ] 0.1 Crear/identificar Issue en GitHub y obtener su número
+- [ ] 0.2 Crear rama `feat/<id>-usuarios-alta-edicion-email` desde `develop` y push
+- [ ] 0.3 Mover el item del Project v2 a "In Progress"
+
+## 1. Infraestructura de email (notificaciones) — TDD
+
+- [ ] 1.1 Añadir `spring-boot-starter-mail` al `pom.xml`; `@EnableAsync` + executor
+- [ ] 1.2 🔴 Test: puerto `NotificationPort.sendWelcomeEmail(...)` — un fallo del adaptador SMTP no propaga excepción al llamador (se traga/loguea) → 🟢 implementar adaptador SMTP (`JavaMailSender`) tolerante a fallos
+- [ ] 1.3 🔴 Test: la contraseña temporal no aparece en logs al enviar/fallar → 🟢 asegurar
+- [ ] 1.4 Config SMTP por entorno (`MAIL_HOST/PORT/USERNAME/PASSWORD/FROM`); placeholders en `.env.example`; passthrough en `docker-compose.yml` (backend `environment`)
+- [ ] 1.5 ♻️ Refactor: plantilla de email de bienvenida (asunto + cuerpo con contraseña y bienvenida)
+
+## 2. Backend — email al activar (usuarios + notificaciones) — TDD
+
+- [ ] 2.1 🔴 Test: al **aprobar** una cuenta PENDING NO se resetea la contraseña (conserva la del registro) y se invoca `sendWelcomeEmail` SIN contraseña → 🟢 implementar (enganchar en `approveUser`)
+- [ ] 2.2 🔴 Test: al **dar de alta** un usuario (ACTIVE) el sistema genera la contraseña (no la del request), `must_change_password=true`, y dispara el email CON la temporal → 🟢 implementar (ajustar `createUser`)
+- [ ] 2.3 🔴 Test: si el envío de email falla, la activación/alta se completa igualmente (200/201) → 🟢 verificar el `@Async`/try-catch
+- [ ] 2.4 ♻️ Refactor del disparo del email (bienvenida-con-pw en alta, bienvenida-sin-pw en aprobación — D3)
+
+## 3. Frontend — alta de usuario (usuarios) — test-first
+
+- [ ] 3.1 🔴 Test: `adminUsuariosApi.crearUsuario` (mock) llama `POST /api/admin/usuarios` con nombre/email/rol → 🟢 implementar
+- [ ] 3.2 🔴 Test de componente: botón "Dar de alta" abre el formulario; enviar crea y refresca la lista → 🟢 implementar formulario de alta (sin campo contraseña)
+- [ ] 3.3 🔴 Test: alta con email duplicado muestra el error de conflicto → 🟢 manejar el 409
+- [ ] 3.4 ♻️ Refactor del formulario/estado
+
+## 4. Frontend — edición de usuario (usuarios) — test-first
+
+- [ ] 4.1 🔴 Test: `adminUsuariosApi.editarUsuario` (mock) llama `PATCH /api/admin/usuarios/{id}` con nombre/email/teléfono (sin rol) → 🟢 implementar
+- [ ] 4.2 🔴 Test de componente: acción "Editar" precarga los datos, el formulario NO ofrece cambiar rol, guardar aplica el `PATCH` y refresca la lista → 🟢 implementar formulario de edición
+- [ ] 4.3 🔴 Test: edición con datos inválidos (email mal formado) muestra el error (400) → 🟢 manejar
+- [ ] 4.4 ♻️ Refactor
+
+## 5. API spec
+
+- [ ] 5.1 Revisar/actualizar `docs/openapi.yaml`: alta (`POST /api/admin/usuarios`) sin contraseña de entrada (generada por el sistema) y nota del email de bienvenida al activar
+
+## 6. QA
+
+- [ ] 6.1 `test-runner`: suite backend + frontend en verde (Postgres real :5433) y cobertura dentro del umbral JaCoCo
+- [ ] 6.2 `verification-specialist`: probes (email no bloquea activación, contraseña fuera de logs, alta/edición solo ADMIN, conflicto/validación)
+- [ ] 6.3 `reality-checker`: journey — admin da de alta usuario → llega email de bienvenida (Ethereal) con contraseña → login con esa contraseña → cambio forzado; admin edita un usuario; admin aprueba PENDING → email
+
+## 7. Cierre
+
+- [ ] 7.1 PR con `Closes #<id>` y CI en verde
+- [ ] 7.2 Merge → deploy; en el `.env` del EC2 añadir `MAIL_HOST/PORT/USERNAME/PASSWORD/FROM` (Ethereal); verificar en vivo el alta + email en el buzón de Ethereal


### PR DESCRIPTION
## Resumen

- **Alta de usuarios** desde el panel admin: formulario (nombre, email, rol); la **contraseña la genera el sistema** (`must_change_password`) y se comunica por **email de bienvenida**.
- **Edición** de datos de contacto (nombre, email, teléfono) — **sin rol** (evita escalada). Email inválido → 400 (fix #179).
- **Borrar** = desactivar (soft-delete, reutiliza el `DELETE` existente).
- **Email de bienvenida al activar** (nueva capability `notificaciones`, SMTP async tolerante a fallos):
  - Alta → email con la contraseña temporal generada.
  - Aprobación de un auto-registrado → email **sin** contraseña (conserva la que eligió; no se resetea).

## Issues
Closes #178 · Corrige #179 (validación de email → 400)

## Testing (TDD)
- [x] Backend `mvn verify` (Postgres real): **230+ tests**, cobertura JaCoCo OK
- [x] Frontend: **80 tests**, lint/build verdes
- [x] `verification-specialist`: PASS (tras corregir #179)
- [x] `reality-checker`: **READY (A-)** — journey con **SMTP real (Ethereal)**: alta → email con contraseña → login → cambio forzado; aprobar sin reset; email inválido→400; AuthZ

## Despliegue
Tras el merge, añadir al `.env` del EC2 las credenciales SMTP (`MAIL_HOST/PORT/USERNAME/PASSWORD/FROM`, Ethereal). El `docker-compose.yml` ya las pasa al backend; sin ellas, el email falla de forma tolerante y no bloquea la gestión.

## Deuda conocida
- `RateLimitIntegrationTest` flaky por contaminación de orden (verde en aislamiento) — ticket aparte.
- Deriva camelCase↔snake_case en `openapi.yaml` (preexistente).

🤖 Generado con Claude Code (orchestrator agent)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admins can now create users and send a welcome email automatically.
  * User details can be edited from the admin panel, including contact information.
  * Email delivery is configured for both local testing and production environments.

* **Bug Fixes**
  * Improved form validation with clearer errors for invalid email addresses.
  * Validation issues now return a structured, user-friendly error response.
  * Email failures no longer block user activation or creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->