### PR TITLE
feat(reservas): correcciones y mejoras UI del jugador (#188)

### DIFF
--- a/backend/src/main/java/com/padelpro/auth/domain/port/out/UserRepositoryPort.java
+++ b/backend/src/main/java/com/padelpro/auth/domain/port/out/UserRepositoryPort.java
@@ -56,6 +56,19 @@ public interface UserRepositoryPort {
     boolean existsByEmailAndIdNot(String email, Long id);
 
     /**
+     * Check whether a user exists with the given id and status.
+     *
+     * <p>Used to validate that a registered participant attached to a reservation refers to a real
+     * member in the expected lifecycle state (security: prevents a caller from attaching an arbitrary
+     * or forged {@code userId}, or a non-{@code ACTIVE} account, to their reservation).
+     *
+     * @param id     the user id to check
+     * @param status the required lifecycle status
+     * @return {@code true} if a user with this id and status exists
+     */
+    boolean existsByIdAndStatus(Long id, UserStatus status);
+
+    /**
      * Check whether a user with the given login already exists.
      */
     boolean existsByLogin(String login);

--- a/backend/src/main/java/com/padelpro/auth/domain/port/out/UserRepositoryPort.java
+++ b/backend/src/main/java/com/padelpro/auth/domain/port/out/UserRepositoryPort.java
@@ -5,6 +5,7 @@ import com.padelpro.auth.domain.model.UserStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -74,4 +75,15 @@ public interface UserRepositoryPort {
      * Used by the admin-seed bootstrap (D1) to stay idempotent.
      */
     boolean existsByRole(com.padelpro.auth.domain.model.UserRole role);
+
+    /**
+     * Search ACTIVE users whose first name, last name, full name or email contains the given term
+     * (case-insensitive, partial match). Used by the registered-partner selector (D5). The email is
+     * only a filter criterion — callers must never project it into the response (RN-RGPD).
+     *
+     * @param term     the search term (already trimmed and length-validated by the caller)
+     * @param pageable limits the result size to avoid dumping the directory
+     * @return the matching users, ordered by name; empty if none match
+     */
+    List<User> searchByNameOrEmail(String term, Pageable pageable);
 }

--- a/backend/src/main/java/com/padelpro/auth/infrastructure/config/SecurityConfig.java
+++ b/backend/src/main/java/com/padelpro/auth/infrastructure/config/SecurityConfig.java
@@ -53,6 +53,8 @@ public class SecurityConfig {
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .requestMatchers("/api/usuarios/me").authenticated()
+                        // Partner search (D5): any authenticated user (USER or ADMIN); 401 if anonymous.
+                        .requestMatchers("/api/usuarios/buscar").authenticated()
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(ex -> ex

--- a/backend/src/main/java/com/padelpro/auth/infrastructure/persistence/UserRepository.java
+++ b/backend/src/main/java/com/padelpro/auth/infrastructure/persistence/UserRepository.java
@@ -52,6 +52,13 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
     boolean existsByEmailAndIdNot(String email, Long id);
 
     /**
+     * Check whether a user with the given id exists in the given lifecycle status. Used to validate
+     * registered participants on reservation creation (a forged/inactive {@code userId} must be
+     * rejected).
+     */
+    boolean existsByIdAndStatus(Long id, UserStatus status);
+
+    /**
      * Check whether a user with the given login already exists.
      */
     boolean existsByLogin(String login);
@@ -71,10 +78,10 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
             SELECT u FROM User u
             WHERE u.status = com.padelpro.auth.domain.model.UserStatus.ACTIVE
               AND (
-                    LOWER(u.firstName) LIKE LOWER(CONCAT('%', :term, '%'))
-                 OR LOWER(u.lastName) LIKE LOWER(CONCAT('%', :term, '%'))
-                 OR LOWER(CONCAT(u.firstName, ' ', u.lastName)) LIKE LOWER(CONCAT('%', :term, '%'))
-                 OR LOWER(u.email) LIKE LOWER(CONCAT('%', :term, '%'))
+                    LOWER(u.firstName) LIKE LOWER(CONCAT('%', :term, '%')) ESCAPE '\\'
+                 OR LOWER(u.lastName) LIKE LOWER(CONCAT('%', :term, '%')) ESCAPE '\\'
+                 OR LOWER(CONCAT(u.firstName, ' ', u.lastName)) LIKE LOWER(CONCAT('%', :term, '%')) ESCAPE '\\'
+                 OR LOWER(u.email) LIKE LOWER(CONCAT('%', :term, '%')) ESCAPE '\\'
               )
             ORDER BY u.firstName ASC, u.lastName ASC
             """)

--- a/backend/src/main/java/com/padelpro/auth/infrastructure/persistence/UserRepository.java
+++ b/backend/src/main/java/com/padelpro/auth/infrastructure/persistence/UserRepository.java
@@ -6,8 +6,11 @@ import com.padelpro.auth.domain.port.out.UserRepositoryPort;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -57,4 +60,23 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
      * Return a page of users filtered by status.
      */
     Page<User> findByStatus(UserStatus status, Pageable pageable);
+
+    /**
+     * Search ACTIVE users by first name, last name, full name or email (case-insensitive, partial
+     * match). Only ACTIVE accounts are returned — PENDING/INACTIVE users are not selectable as
+     * partners. The email participates in the WHERE clause only; it is never selected into the
+     * response DTO (RN-RGPD). {@code pageable} caps the number of rows.
+     */
+    @Query("""
+            SELECT u FROM User u
+            WHERE u.status = com.padelpro.auth.domain.model.UserStatus.ACTIVE
+              AND (
+                    LOWER(u.firstName) LIKE LOWER(CONCAT('%', :term, '%'))
+                 OR LOWER(u.lastName) LIKE LOWER(CONCAT('%', :term, '%'))
+                 OR LOWER(CONCAT(u.firstName, ' ', u.lastName)) LIKE LOWER(CONCAT('%', :term, '%'))
+                 OR LOWER(u.email) LIKE LOWER(CONCAT('%', :term, '%'))
+              )
+            ORDER BY u.firstName ASC, u.lastName ASC
+            """)
+    List<User> searchByNameOrEmail(@Param("term") String term, Pageable pageable);
 }

--- a/backend/src/main/java/com/padelpro/reservas/application/service/CrearReservaService.java
+++ b/backend/src/main/java/com/padelpro/reservas/application/service/CrearReservaService.java
@@ -2,7 +2,9 @@ package com.padelpro.reservas.application.service;
 
 import com.padelpro.auth.domain.exception.ValidationException;
 import com.padelpro.auth.domain.model.SystemConfig;
+import com.padelpro.auth.domain.model.UserStatus;
 import com.padelpro.auth.domain.port.out.SystemConfigRepositoryPort;
+import com.padelpro.auth.domain.port.out.UserRepositoryPort;
 import com.padelpro.reservas.application.dto.CrearReservaRequest;
 import com.padelpro.reservas.application.dto.ReservaResponse;
 import com.padelpro.reservas.domain.exception.InvalidReservaStateException;
@@ -44,15 +46,18 @@ public class CrearReservaService {
     private final ReservationCommandPort reservationCommandPort;
     private final PaymentCommandPort paymentCommandPort;
     private final SystemConfigRepositoryPort systemConfigRepositoryPort;
+    private final UserRepositoryPort userRepositoryPort;
     private final DisponibilidadCacheInvalidator cacheInvalidator;
 
     public CrearReservaService(ReservationCommandPort reservationCommandPort,
                                PaymentCommandPort paymentCommandPort,
                                SystemConfigRepositoryPort systemConfigRepositoryPort,
+                               UserRepositoryPort userRepositoryPort,
                                DisponibilidadCacheInvalidator cacheInvalidator) {
         this.reservationCommandPort = reservationCommandPort;
         this.paymentCommandPort = paymentCommandPort;
         this.systemConfigRepositoryPort = systemConfigRepositoryPort;
+        this.userRepositoryPort = userRepositoryPort;
         this.cacheInvalidator = cacheInvalidator;
     }
 
@@ -130,6 +135,14 @@ public class CrearReservaService {
                         "Cada participante adicional debe ser un usuario registrado o un invitado externo, no ambos ni ninguno");
             }
             if (hasUser) {
+                // Security: a registered participant must reference a real, ACTIVE member. Without this
+                // check a caller could attach an arbitrary or forged userId (or an inactive account) to
+                // their reservation.
+                if (!userRepositoryPort.existsByIdAndStatus(p.userId(), UserStatus.ACTIVE)) {
+                    throw new InvalidReservaStateException(
+                            "PARTICIPANT_NOT_FOUND",
+                            "El participante registrado no existe o no es un usuario activo");
+                }
                 reservation.addParticipant(
                         Participant.registered(p.userId(), slot, ReservationChannel.WEB));
             } else {

--- a/backend/src/main/java/com/padelpro/reservas/infrastructure/config/ReservasConfig.java
+++ b/backend/src/main/java/com/padelpro/reservas/infrastructure/config/ReservasConfig.java
@@ -1,6 +1,7 @@
 package com.padelpro.reservas.infrastructure.config;
 
 import com.padelpro.auth.domain.port.out.SystemConfigRepositoryPort;
+import com.padelpro.auth.domain.port.out.UserRepositoryPort;
 import com.padelpro.reservas.application.service.AdminReservaService;
 import com.padelpro.reservas.application.service.CancelarReservaService;
 import com.padelpro.reservas.application.service.CrearReservaService;
@@ -28,9 +29,10 @@ public class ReservasConfig {
             ReservationCommandPort reservationCommandPort,
             PaymentCommandPort paymentCommandPort,
             SystemConfigRepositoryPort systemConfigRepositoryPort,
+            UserRepositoryPort userRepositoryPort,
             @Qualifier("disponibilidadCacheInvalidator") DisponibilidadCacheInvalidator cacheInvalidator) {
         return new CrearReservaService(reservationCommandPort, paymentCommandPort,
-                systemConfigRepositoryPort, cacheInvalidator);
+                systemConfigRepositoryPort, userRepositoryPort, cacheInvalidator);
     }
 
     @Bean

--- a/backend/src/main/java/com/padelpro/usuarios/application/dto/UserSearchResult.java
+++ b/backend/src/main/java/com/padelpro/usuarios/application/dto/UserSearchResult.java
@@ -1,0 +1,14 @@
+package com.padelpro.usuarios.application.dto;
+
+/**
+ * Response DTO for the authenticated user search (GET /api/usuarios/buscar).
+ *
+ * <p>Deliberately minimal (D5): only {@code id} and a display {@code nombre}. It never carries
+ * email, password hash, role, status or any other field, so the endpoint cannot be used to dump
+ * the member directory or leak PII (RN-RGPD). The email — used only to filter matches — is never
+ * projected here.
+ */
+public record UserSearchResult(
+        Long id,
+        String nombre
+) {}

--- a/backend/src/main/java/com/padelpro/usuarios/application/service/UserSearchService.java
+++ b/backend/src/main/java/com/padelpro/usuarios/application/service/UserSearchService.java
@@ -1,0 +1,76 @@
+package com.padelpro.usuarios.application.service;
+
+import com.padelpro.auth.domain.model.User;
+import com.padelpro.auth.domain.port.out.UserRepositoryPort;
+import com.padelpro.usuarios.application.dto.UserSearchResult;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * Application service backing the registered-partner search (D5).
+ *
+ * <p>Returns a bounded list of {@link UserSearchResult} (id + display name only) for a name/email
+ * term. Two guardrails keep it from leaking the member directory (RN-RGPD): a minimum term length
+ * (short terms short-circuit to an empty list without touching the DB) and a hard result cap.
+ *
+ * <p>RN-RGPD: the search term is never logged (it may contain a personal name/email), and the
+ * projection deliberately excludes email, password hash, role and status.
+ */
+@Service
+public class UserSearchService {
+
+    /** Terms shorter than this never hit the database — avoids dumping the directory on `a`, `` … */
+    static final int MIN_TERM_LENGTH = 2;
+
+    /** Hard cap on returned rows regardless of how many users match. */
+    static final int MAX_RESULTS = 10;
+
+    private final UserRepositoryPort userRepositoryPort;
+
+    public UserSearchService(UserRepositoryPort userRepositoryPort) {
+        this.userRepositoryPort = userRepositoryPort;
+    }
+
+    /**
+     * Search ACTIVE users by name or email.
+     *
+     * @param rawTerm the raw query term from the request (may be null/blank)
+     * @return up to {@link #MAX_RESULTS} matches (id + display name); empty list if the term is too
+     *         short or nothing matches
+     */
+    @Transactional(readOnly = true)
+    public List<UserSearchResult> search(String rawTerm) {
+        if (rawTerm == null) {
+            return List.of();
+        }
+        String term = rawTerm.trim();
+        if (term.length() < MIN_TERM_LENGTH) {
+            return List.of();
+        }
+
+        Pageable limit = PageRequest.of(0, MAX_RESULTS);
+        return userRepositoryPort.searchByNameOrEmail(escapeLike(term), limit).stream()
+                .map(UserSearchService::toResult)
+                .toList();
+    }
+
+    private static UserSearchResult toResult(User user) {
+        String nombre = (user.getFirstName() + " " + user.getLastName()).trim();
+        return new UserSearchResult(user.getId(), nombre);
+    }
+
+    /**
+     * Escape the LIKE wildcards ({@code %}, {@code _}) and the escape char itself ({@code \}) so a
+     * caller cannot pass {@code %} to match every user and dump the directory. Relies on PostgreSQL's
+     * default backslash escape character for LIKE.
+     */
+    private static String escapeLike(String term) {
+        return term.replace("\\", "\\\\")
+                .replace("%", "\\%")
+                .replace("_", "\\_");
+    }
+}

--- a/backend/src/main/java/com/padelpro/usuarios/infrastructure/web/UsuariosBuscarController.java
+++ b/backend/src/main/java/com/padelpro/usuarios/infrastructure/web/UsuariosBuscarController.java
@@ -1,0 +1,40 @@
+package com.padelpro.usuarios.infrastructure.web;
+
+import com.padelpro.usuarios.application.dto.UserSearchResult;
+import com.padelpro.usuarios.application.service.UserSearchService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * REST controller for the registered-partner search (D5).
+ *
+ * <p>GET /api/usuarios/buscar?q=&lt;term&gt; — search ACTIVE users by name or email, returning a
+ * bounded list of {@code {id, nombre}}. Any authenticated user (USER or ADMIN) may call it; the
+ * security chain rejects anonymous callers with 401. It deliberately returns only id + display
+ * name so it cannot be used to harvest emails or the full member directory (RN-RGPD).
+ */
+@RestController
+@RequestMapping("/api/usuarios")
+public class UsuariosBuscarController {
+
+    private final UserSearchService userSearchService;
+
+    public UsuariosBuscarController(UserSearchService userSearchService) {
+        this.userSearchService = userSearchService;
+    }
+
+    /**
+     * GET /api/usuarios/buscar?q=&lt;term&gt;
+     * Returns matching users (id + display name). A missing or too-short term yields an empty list.
+     */
+    @GetMapping("/buscar")
+    public ResponseEntity<List<UserSearchResult>> buscar(
+            @RequestParam(value = "q", required = false, defaultValue = "") String q) {
+        return ResponseEntity.ok(userSearchService.search(q));
+    }
+}

--- a/backend/src/test/java/com/padelpro/reservas/infrastructure/web/ReservaControllerIntegrationTest.java
+++ b/backend/src/test/java/com/padelpro/reservas/infrastructure/web/ReservaControllerIntegrationTest.java
@@ -95,6 +95,14 @@ class ReservaControllerIntegrationTest extends PostgresIntegrationTest {
                 futureDate.toString(), startTime, durationMinutes, "test", null));
     }
 
+    /** Build a create-reservation body with a single registered-participant {@code userId}. */
+    private String reservaJsonWithRegisteredParticipant(String startTime, int durationMinutes, Long userId)
+            throws Exception {
+        return objectMapper.writeValueAsString(new CrearReservaRequest(
+                futureDate.toString(), startTime, durationMinutes, "test",
+                java.util.List.of(new CrearReservaRequest.ParticipanteAdicional(userId, null, null))));
+    }
+
     private MvcResult createReserva(String token, String startTime, int duration, String idempotencyKey)
             throws Exception {
         var req = post("/api/reservas")
@@ -428,5 +436,60 @@ class ReservaControllerIntegrationTest extends PostgresIntegrationTest {
                         .content(reservaJson("18:15", 60)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error", is("VALIDATION_ERROR")));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // registered-participant validation (security): a userId attached to a
+    // reservation must reference a real, ACTIVE member.
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("seguridad: participante con userId inexistente → 422 PARTICIPANT_NOT_FOUND (no persiste)")
+    void should_return_422_when_registered_participant_does_not_exist() throws Exception {
+        mockMvc.perform(post("/api/reservas")
+                        .header("Authorization", "Bearer " + ownerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reservaJsonWithRegisteredParticipant("18:00", 60, 999999L)))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.error", is("PARTICIPANT_NOT_FOUND")));
+
+        // Rolled back: nothing was persisted.
+        assertThat(reservationRepository.findAll()).isEmpty();
+        assertThat(paymentRepository.findAll()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("seguridad: participante con userId de usuario no-ACTIVE → 422 (no persiste)")
+    void should_return_422_when_registered_participant_not_active() throws Exception {
+        OffsetDateTime now = OffsetDateTime.now();
+        User pending = userRepository.saveAndFlush(new User(
+                "pending.user", passwordEncoder.encode("Password1"), "Pending", "User",
+                "pending@example.com", UserRole.USER, UserStatus.PENDING, now, now));
+
+        mockMvc.perform(post("/api/reservas")
+                        .header("Authorization", "Bearer " + ownerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reservaJsonWithRegisteredParticipant("18:00", 60, pending.getId())))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.error", is("PARTICIPANT_NOT_FOUND")));
+
+        assertThat(reservationRepository.findAll()).isEmpty();
+        assertThat(paymentRepository.findAll()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("seguridad: participante con userId ACTIVE válido → 201 con 2 participantes")
+    void should_create_reservation_when_registered_participant_is_active() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/reservas")
+                        .header("Authorization", "Bearer " + ownerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reservaJsonWithRegisteredParticipant("18:00", 60, otherUser.getId())))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.participants", org.hamcrest.Matchers.hasSize(2)))
+                .andReturn();
+
+        UUID reservationId = UUID.fromString(extractId(result));
+        assertThat(reservationRepository.findByIdWithParticipants(reservationId).orElseThrow()
+                .getParticipants()).hasSize(2);
     }
 }

--- a/backend/src/test/java/com/padelpro/usuarios/infrastructure/web/UsuariosBuscarControllerIntegrationTest.java
+++ b/backend/src/test/java/com/padelpro/usuarios/infrastructure/web/UsuariosBuscarControllerIntegrationTest.java
@@ -138,4 +138,36 @@ class UsuariosBuscarControllerIntegrationTest extends PostgresIntegrationTest {
         mockMvc.perform(get("/api/usuarios/buscar").param("q", "ana"))
                 .andExpect(status().isUnauthorized());
     }
+
+    @Test
+    @DisplayName("GET /api/usuarios/buscar excludes non-ACTIVE (PENDING/INACTIVE) users")
+    void search_excludes_non_active_users() throws Exception {
+        OffsetDateTime now = OffsetDateTime.now();
+        // Same searchable name, but neither is ACTIVE → must not appear.
+        persist("ana.pending", "Ana", "Pending", "ana.pending@club.com",
+                UserRole.USER, UserStatus.PENDING, now);
+        persist("ana.inactive", "Ana", "Inactive", "ana.inactive@club.com",
+                UserRole.USER, UserStatus.INACTIVE, now);
+
+        mockMvc.perform(get("/api/usuarios/buscar")
+                        .param("q", "ana")
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isOk())
+                // Only the ACTIVE "Ana Lopez" from setUp() matches.
+                .andExpect(jsonPath("$", org.hamcrest.Matchers.hasSize(1)))
+                .andExpect(jsonPath("$[0].nombre", is("Ana Lopez")));
+    }
+
+    @Test
+    @DisplayName("GET /api/usuarios/buscar with a '%' wildcard term does not dump the directory")
+    void search_percent_wildcard_does_not_return_all() throws Exception {
+        // "a%" (length ≥ MIN_TERM_LENGTH so it reaches the query): escapeLike turns the '%' into '\%',
+        // and the explicit ESCAPE '\' makes the DB treat it as a literal percent sign. No member has a
+        // literal '%' in their name/email → empty result, i.e. the wildcard cannot dump the directory.
+        mockMvc.perform(get("/api/usuarios/buscar")
+                        .param("q", "a%")
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", org.hamcrest.Matchers.hasSize(0)));
+    }
 }

--- a/backend/src/test/java/com/padelpro/usuarios/infrastructure/web/UsuariosBuscarControllerIntegrationTest.java
+++ b/backend/src/test/java/com/padelpro/usuarios/infrastructure/web/UsuariosBuscarControllerIntegrationTest.java
@@ -1,0 +1,141 @@
+package com.padelpro.usuarios.infrastructure.web;
+
+import com.padelpro.auth.application.service.JwtService;
+import com.padelpro.auth.domain.model.User;
+import com.padelpro.auth.domain.model.UserRole;
+import com.padelpro.auth.domain.model.UserStatus;
+import com.padelpro.auth.infrastructure.persistence.UserRepository;
+import com.padelpro.shared.PostgresIntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.OffsetDateTime;
+
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Integration tests for {@link UsuariosBuscarController} (GET /api/usuarios/buscar) — the
+ * registered-partner search (D5, tasks 3.1/3.2).
+ *
+ * <p>Verifies: match by name and by email returns {@code [{id, nombre}]}; no matches → 200 [];
+ * anonymous → 401; short term → []; and that no sensitive field (email, passwordHash, role,
+ * status) is ever projected into the response.
+ */
+class UsuariosBuscarControllerIntegrationTest extends PostgresIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private BCryptPasswordEncoder passwordEncoder;
+
+    @Autowired
+    private JwtService jwtService;
+
+    private String userToken;
+
+    @BeforeEach
+    void setUp() {
+        OffsetDateTime now = OffsetDateTime.now();
+
+        // The caller (an authenticated USER).
+        User caller = persist("caller", "Caller", "One", "caller@example.com",
+                UserRole.USER, UserStatus.ACTIVE, now);
+        userToken = jwtService.generateAccessToken(caller);
+
+        // Searchable ACTIVE members.
+        persist("ana.lopez", "Ana", "Lopez", "ana.lopez@club.com",
+                UserRole.USER, UserStatus.ACTIVE, now);
+        persist("juan.perez", "Juan", "Perez", "juan.perez@mail.com",
+                UserRole.USER, UserStatus.ACTIVE, now);
+    }
+
+    private User persist(String login, String firstName, String lastName, String email,
+                         UserRole role, UserStatus status, OffsetDateTime now) {
+        User u = new User(login, passwordEncoder.encode("Password1"),
+                firstName, lastName, email, role, status, now, now);
+        return userRepository.saveAndFlush(u);
+    }
+
+    @Test
+    @DisplayName("GET /api/usuarios/buscar by name returns 200 with [{id, nombre}]")
+    void search_by_name_returns_id_and_nombre() throws Exception {
+        mockMvc.perform(get("/api/usuarios/buscar")
+                        .param("q", "ana")
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", org.hamcrest.Matchers.hasSize(1)))
+                .andExpect(jsonPath("$[0].id", notNullValue()))
+                .andExpect(jsonPath("$[0].nombre", is("Ana Lopez")));
+    }
+
+    @Test
+    @DisplayName("GET /api/usuarios/buscar by email matches but never returns the email")
+    void search_by_email_matches_without_exposing_email() throws Exception {
+        mockMvc.perform(get("/api/usuarios/buscar")
+                        .param("q", "juan.perez@mail")
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", org.hamcrest.Matchers.hasSize(1)))
+                .andExpect(jsonPath("$[0].nombre", is("Juan Perez")))
+                // No sensitive fields leaked: only id + nombre keys are present.
+                .andExpect(jsonPath("$[0]", not(hasKey("email"))))
+                .andExpect(jsonPath("$[0]", not(hasKey("passwordHash"))))
+                .andExpect(jsonPath("$[0]", not(hasKey("role"))))
+                .andExpect(jsonPath("$[0]", not(hasKey("status"))));
+    }
+
+    @Test
+    @DisplayName("GET /api/usuarios/buscar every result exposes only id and nombre")
+    void search_results_expose_only_id_and_nombre() throws Exception {
+        mockMvc.perform(get("/api/usuarios/buscar")
+                        .param("q", "an")          // matches "Ana Lopez" and "Juan Perez"
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", org.hamcrest.Matchers.hasSize(2)))
+                .andExpect(jsonPath("$[*]", everyItem(hasKey("id"))))
+                .andExpect(jsonPath("$[*]", everyItem(hasKey("nombre"))))
+                .andExpect(jsonPath("$[*]", everyItem(not(hasKey("email")))));
+    }
+
+    @Test
+    @DisplayName("GET /api/usuarios/buscar with no matches returns 200 []")
+    void search_no_matches_returns_empty_array() throws Exception {
+        mockMvc.perform(get("/api/usuarios/buscar")
+                        .param("q", "zzzznotexist")
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", org.hamcrest.Matchers.hasSize(0)));
+    }
+
+    @Test
+    @DisplayName("GET /api/usuarios/buscar with a short term returns 200 []")
+    void search_short_term_returns_empty_array() throws Exception {
+        mockMvc.perform(get("/api/usuarios/buscar")
+                        .param("q", "a")
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", org.hamcrest.Matchers.hasSize(0)));
+    }
+
+    @Test
+    @DisplayName("GET /api/usuarios/buscar without JWT returns 401")
+    void search_without_jwt_returns_401() throws Exception {
+        mockMvc.perform(get("/api/usuarios/buscar").param("q", "ana"))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1390,13 +1390,17 @@ components:
 
     ErrorResponse:
       type: object
-      description: Respuesta de error estándar de la API
+      description: >-
+        Respuesta de error estándar de la API, emitida por GlobalExceptionHandler.
+        El código de aplicación va en `error`; `details` sólo aparece en errores que
+        aportan una lista de violaciones (p. ej. INVALID_PASSWORD) y se omite en el
+        resto (JSON con `NON_NULL`).
       required:
-        - code
+        - error
         - message
-        - errors
+        - timestamp
       properties:
-        code:
+        error:
           type: string
           description: Código de error de aplicación
           example: VALIDATION_ERROR
@@ -1404,36 +1408,35 @@ components:
           type: string
           description: Descripción legible del error
           example: "Los datos de la solicitud no son válidos."
-        errors:
+        timestamp:
+          type: string
+          format: date-time
+          description: Instante (UTC, ISO-8601) en que se generó el error
+          example: "2026-07-05T18:30:00Z"
+        details:
           type: array
-          description: Lista de errores de campo (vacía si el error no es de validación)
+          description: >-
+            Lista opcional de detalles/violaciones del error (cadenas). Se omite del
+            cuerpo cuando no aplica.
           items:
-            $ref: '#/components/schemas/FieldError'
+            type: string
+          example:
+            - "La contraseña debe tener al menos 8 caracteres"
       examples:
         validacionFallida:
-          summary: Error de validación de campos
+          summary: Error de validación
           value:
-            code: "VALIDATION_ERROR"
+            error: "VALIDATION_ERROR"
             message: "Los datos de la solicitud no son válidos."
-            errors:
-              - field: "email"
-                message: "El formato del email no es válido."
-
-    FieldError:
-      type: object
-      description: Detalle de un error de campo específico
-      required:
-        - field
-        - message
-      properties:
-        field:
-          type: string
-          description: Nombre del campo con error
-          example: email
-        message:
-          type: string
-          description: Descripción del error de validación del campo
-          example: "El formato del email no es válido."
+            timestamp: "2026-07-05T18:30:00Z"
+        passwordInvalida:
+          summary: Error con lista de detalles
+          value:
+            error: "INVALID_PASSWORD"
+            message: "La contraseña no cumple los requisitos"
+            timestamp: "2026-07-05T18:30:00Z"
+            details:
+              - "La contraseña debe tener al menos 8 caracteres"
 
     MessageResponse:
       type: object

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -310,6 +310,40 @@ paths:
 
   # ─── Usuarios — perfil propio ──────────────────────────────────────────────
 
+  /usuarios/buscar:
+    get:
+      tags: [Usuarios]
+      operationId: buscarUsuarios
+      summary: Buscar usuarios (selector de compañero registrado)
+      description: |
+        Busca usuarios ACTIVOS por nombre o email (case-insensitive, coincidencia parcial) para
+        alimentar el selector de compañero registrado de la UI de reserva (D5). Accesible por
+        cualquier usuario autenticado (ROLE_USER o ROLE_ADMIN).
+
+        Salvaguardas RGPD: la respuesta contiene **únicamente** `id` y `nombre` (nombre a mostrar) —
+        nunca email, hash de contraseña, rol ni estado. El email se usa solo para filtrar, no se
+        devuelve. Un término con menos de 2 caracteres (o ausente) devuelve `[]` sin consultar la
+        base de datos, evitando volcar el directorio. Los resultados están acotados (máx. 10).
+      parameters:
+        - name: q
+          in: query
+          required: false
+          description: Término de búsqueda (nombre o email). Menos de 2 caracteres devuelve `[]`.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: |
+            Lista acotada de coincidencias (posiblemente vacía). Sin coincidencias o término corto → `[]`.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/UsuarioBusquedaResult'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
   /usuarios/me:
     get:
       tags: [Usuarios]
@@ -1680,6 +1714,25 @@ components:
           format: date-time
           description: Última modificación del perfil
           example: "2025-03-10T14:22:00Z"
+
+    UsuarioBusquedaResult:
+      type: object
+      description: |
+        Resultado mínimo de la búsqueda de usuarios (selector de compañero, D5). Contiene solo los
+        campos necesarios para mostrar y seleccionar; nunca email, hash, rol ni estado (RGPD).
+      required:
+        - id
+        - nombre
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: Identificador único del usuario (para fijar `userId` en el payload de reserva)
+          example: 42
+        nombre:
+          type: string
+          description: Nombre a mostrar (nombre y apellidos)
+          example: "Ana Lopez"
 
     UsuarioPatchRequest:
       type: object

--- a/frontend/src/components/ParticipanteSelector.module.css
+++ b/frontend/src/components/ParticipanteSelector.module.css
@@ -1,0 +1,157 @@
+/* ParticipanteSelector — fila de participante (socio / externo) */
+
+.row {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 14px;
+  border: 1px solid var(--line, #e5e3d8);
+  border-radius: 14px;
+  background: var(--white);
+}
+
+.rowHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.rowTitle {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.removeBtn {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  border: 1.5px solid rgba(13, 13, 13, 0.2);
+  background: transparent;
+  color: var(--muted);
+  font-size: 18px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.removeBtn:hover {
+  border-color: var(--error);
+  color: var(--error);
+}
+
+/* --- Conmutador de tipo --- */
+.toggle {
+  display: flex;
+  gap: 6px;
+  background: rgba(13, 13, 13, 0.04);
+  border-radius: 10px;
+  padding: 4px;
+}
+
+.toggleBtn {
+  flex: 1;
+  padding: 8px 10px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--muted);
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.toggleOn {
+  background: var(--ink);
+  color: var(--cream);
+}
+
+/* --- Bloques socio / externo --- */
+.socioBlock,
+.externoBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.fieldLabel {
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.textInput {
+  border: none;
+  border-bottom: 1.5px solid rgba(13, 13, 13, 0.2);
+  padding: 8px 0;
+  font-size: 15px;
+  color: var(--ink);
+  background: transparent;
+  outline: none;
+}
+
+.textInput:focus {
+  border-bottom-color: var(--ink);
+}
+
+.hint {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.resultList {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  border: 1px solid var(--line, #e5e3d8);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.resultBtn {
+  width: 100%;
+  text-align: left;
+  padding: 10px 12px;
+  border: none;
+  background: var(--white);
+  color: var(--ink);
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.resultBtn:hover {
+  background: rgba(13, 13, 13, 0.04);
+}
+
+.socioSelected {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--line, #e5e3d8);
+  border-radius: 10px;
+}
+
+.socioName {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.linkBtn {
+  background: transparent;
+  border: none;
+  color: var(--ink);
+  text-decoration: underline;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}

--- a/frontend/src/components/ParticipanteSelector.tsx
+++ b/frontend/src/components/ParticipanteSelector.tsx
@@ -1,0 +1,190 @@
+// reservas-ui-jugador-fixes (Grupo 3, D4/D5) — selector de participante adicional.
+// Conmutador "socio registrado / invitado externo":
+//   - socio: buscador que consume GET /api/usuarios/buscar y fija `userId`.
+//   - externo: nombre (+ teléfono opcional) que fijan `externalName`/`externalPhone`.
+// El estado guarda ambos lados pero el payload se construye XOR en el padre
+// (ConfirmarReservaPage): exactamente uno por participante, acorde al backend.
+//
+// El modo por defecto es "externo" para mantener el flujo simple del jugador que
+// invita a alguien sin cuenta; cambiar de modo limpia los datos del otro lado para
+// que nunca queden a la vez `userId` y `externalName` (ambigüedad).
+import { useEffect, useRef, useState } from 'react';
+import { buscarUsuariosApi, UsuarioBusqueda } from '../services/usuariosApi';
+import { ParticipanteInput, TipoParticipante } from './participanteModel';
+import styles from './ParticipanteSelector.module.css';
+
+/** Longitud mínima del término antes de consultar el buscador de socios (D5). */
+const MIN_QUERY = 2;
+
+interface Props {
+  index: number;
+  value: ParticipanteInput;
+  token: string;
+  onChange: (next: ParticipanteInput) => void;
+  onRemove: () => void;
+}
+
+export function ParticipanteSelector({ index, value, token, onChange, onRemove }: Props) {
+  const [query, setQuery] = useState('');
+  const [resultados, setResultados] = useState<UsuarioBusqueda[]>([]);
+  const [buscando, setBuscando] = useState(false);
+  // Evita aplicar resultados de una búsqueda obsoleta (última query gana).
+  const queryRef = useRef('');
+
+  useEffect(() => {
+    queryRef.current = query;
+    const term = query.trim();
+    if (value.tipo !== 'socio' || term.length < MIN_QUERY) {
+      setResultados([]);
+      setBuscando(false);
+      return;
+    }
+    setBuscando(true);
+    const handle = setTimeout(async () => {
+      try {
+        const res = await buscarUsuariosApi(token, term);
+        if (queryRef.current === query) setResultados(res);
+      } catch {
+        if (queryRef.current === query) setResultados([]);
+      } finally {
+        if (queryRef.current === query) setBuscando(false);
+      }
+    }, 200);
+    return () => clearTimeout(handle);
+  }, [query, token, value.tipo]);
+
+  function setTipo(tipo: TipoParticipante) {
+    if (tipo === value.tipo) return;
+    setQuery('');
+    setResultados([]);
+    // Limpiar el lado contrario evita la ambigüedad (XOR).
+    onChange(
+      tipo === 'socio'
+        ? { ...value, tipo, externalName: '', externalPhone: '' }
+        : { ...value, tipo, userId: null, socioNombre: '' }
+    );
+  }
+
+  function seleccionarSocio(u: UsuarioBusqueda) {
+    onChange({ ...value, userId: u.id, socioNombre: u.nombre });
+    setQuery('');
+    setResultados([]);
+  }
+
+  function limpiarSocio() {
+    onChange({ ...value, userId: null, socioNombre: '' });
+  }
+
+  const numero = index + 1;
+
+  return (
+    <div className={styles.row}>
+      <div className={styles.rowHead}>
+        <span className={styles.rowTitle}>Compañero {numero}</span>
+        <button
+          type="button"
+          className={styles.removeBtn}
+          onClick={onRemove}
+          aria-label={`Quitar compañero ${numero}`}
+        >
+          ×
+        </button>
+      </div>
+
+      {/* Conmutador de tipo (D4) */}
+      <div className={styles.toggle} role="group" aria-label={`Tipo de compañero ${numero}`}>
+        <button
+          type="button"
+          className={`${styles.toggleBtn} ${value.tipo === 'socio' ? styles.toggleOn : ''}`}
+          aria-pressed={value.tipo === 'socio'}
+          onClick={() => setTipo('socio')}
+        >
+          Socio registrado
+        </button>
+        <button
+          type="button"
+          className={`${styles.toggleBtn} ${value.tipo === 'externo' ? styles.toggleOn : ''}`}
+          aria-pressed={value.tipo === 'externo'}
+          onClick={() => setTipo('externo')}
+        >
+          Invitado externo
+        </button>
+      </div>
+
+      {value.tipo === 'socio' ? (
+        <div className={styles.socioBlock}>
+          {value.userId != null ? (
+            <div className={styles.socioSelected}>
+              <span className={styles.socioName}>{value.socioNombre}</span>
+              <button type="button" className={styles.linkBtn} onClick={limpiarSocio}>
+                Cambiar
+              </button>
+            </div>
+          ) : (
+            <>
+              <label className={styles.fieldLabel} htmlFor={`socio-buscar-${index}`}>
+                Buscar socio {numero}
+              </label>
+              <input
+                id={`socio-buscar-${index}`}
+                className={styles.textInput}
+                type="text"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Nombre o email del socio"
+                autoComplete="off"
+                role="combobox"
+                aria-expanded={resultados.length > 0}
+                aria-controls={`socio-resultados-${index}`}
+              />
+              {buscando && <span className={styles.hint}>Buscando…</span>}
+              {!buscando && query.trim().length >= MIN_QUERY && resultados.length === 0 && (
+                <span className={styles.hint}>Sin coincidencias</span>
+              )}
+              {resultados.length > 0 && (
+                <ul id={`socio-resultados-${index}`} className={styles.resultList} role="listbox">
+                  {resultados.map((u) => (
+                    <li key={u.id}>
+                      <button
+                        type="button"
+                        className={styles.resultBtn}
+                        onClick={() => seleccionarSocio(u)}
+                      >
+                        {u.nombre}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </>
+          )}
+        </div>
+      ) : (
+        <div className={styles.externoBlock}>
+          <label className={styles.fieldLabel} htmlFor={`externo-nombre-${index}`}>
+            Nombre del compañero {numero}
+          </label>
+          <input
+            id={`externo-nombre-${index}`}
+            className={styles.textInput}
+            type="text"
+            value={value.externalName}
+            onChange={(e) => onChange({ ...value, externalName: e.target.value })}
+            placeholder="Nombre y apellido"
+          />
+          <label className={styles.fieldLabel} htmlFor={`externo-tel-${index}`}>
+            Teléfono del compañero {numero} (opcional)
+          </label>
+          <input
+            id={`externo-tel-${index}`}
+            className={styles.textInput}
+            type="tel"
+            value={value.externalPhone}
+            onChange={(e) => onChange({ ...value, externalPhone: e.target.value })}
+            placeholder="Teléfono"
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/participanteModel.ts
+++ b/frontend/src/components/participanteModel.ts
@@ -1,0 +1,23 @@
+// reservas-ui-jugador-fixes (Grupo 3, D4/D5) — modelo del participante adicional.
+// Tipos y helpers puros del selector socio/externo, separados del componente para
+// no romper el fast-refresh (un fichero de componente solo debe exportar componentes).
+export type TipoParticipante = 'socio' | 'externo';
+
+export interface ParticipanteInput {
+  tipo: TipoParticipante;
+  externalName: string;
+  externalPhone: string;
+  userId: number | null;
+  /** Nombre del socio seleccionado (solo para mostrar). */
+  socioNombre: string;
+}
+
+/** Estado inicial de una fila de participante (modo externo por defecto). */
+export function emptyParticipante(): ParticipanteInput {
+  return { tipo: 'externo', externalName: '', externalPhone: '', userId: null, socioNombre: '' };
+}
+
+/** Un participante está completo si aporta exactamente uno de los dos lados (XOR). */
+export function participanteCompleto(p: ParticipanteInput): boolean {
+  return p.tipo === 'socio' ? p.userId != null : p.externalName.trim() !== '';
+}

--- a/frontend/src/pages/ConfirmarReservaPage.module.css
+++ b/frontend/src/pages/ConfirmarReservaPage.module.css
@@ -19,6 +19,60 @@
   gap: 12px;
 }
 
+.homeBtn {
+  background: transparent;
+  border: 1.5px solid rgba(13, 13, 13, 0.25);
+  border-radius: 999px;
+  padding: 6px 14px;
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ink);
+  cursor: pointer;
+  transition: border-color 0.15s ease;
+}
+
+.homeBtn:hover {
+  border-color: var(--ink);
+}
+
+/* --- Selector de duración (D3) --- */
+.durationBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px 0 16px;
+}
+
+.durationOptions {
+  display: flex;
+  gap: 8px;
+}
+
+.durationBtn {
+  flex: 1;
+  padding: 12px 8px;
+  border: 1.5px solid rgba(13, 13, 13, 0.2);
+  border-radius: 12px;
+  background: transparent;
+  color: var(--ink);
+  font-family: var(--font-body);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.durationBtn:hover {
+  border-color: var(--ink);
+}
+
+.durationOn {
+  background: var(--ink);
+  color: var(--cream);
+  border-color: var(--ink);
+}
+
 .titleBlock {
   padding: 24px 0 8px;
 }

--- a/frontend/src/pages/ConfirmarReservaPage.tsx
+++ b/frontend/src/pages/ConfirmarReservaPage.tsx
@@ -1,14 +1,21 @@
 // Grupo 5 — ConfirmarReservaPage (mockup 04).
-// Muestra el tramo elegido (fecha/hora/duración leídos de la query, D3) y crea la
-// reserva con POST /api/reservas. El precio total lo muestra tal cual lo devuelve
-// el backend (priceTotal), NUNCA se calcula ni se envía desde el cliente (RN-RES-03).
+// Muestra el tramo elegido (fecha/hora leídos de la query) y crea la reserva con
+// POST /api/reservas. El precio total lo muestra tal cual lo devuelve el backend
+// (priceTotal), NUNCA se calcula ni se envía desde el cliente (RN-RES-03).
+//
+// reservas-ui-jugador-fixes:
+//  - D3: selector de duración 60/90/120 (default 60), acotado por `maxDuracion` de
+//    la query (disponibilidad contigua real); se envía en `durationMinutes` y se
+//    refleja en el resumen. El 409 del backend es la red de seguridad.
+//  - D4/D5: cada participante adicional se añade con un conmutador socio/externo
+//    (ParticipanteSelector); el payload es XOR (userId | externalName[+phone]).
+//  - D2: 401 AUTH_REQUIRED → mensaje de sesión caducada + redirección a login. El
+//    mapeo de error lee el contrato real (`error` como código, `details[0]` como
+//    detalle); el genérico solo para 5xx sin código / error de red.
 //
 // Idempotency-Key (D2): se genera con crypto.randomUUID() por intento. Se reutiliza
 // en reintentos de red del mismo envío (misma firma de formulario) y se regenera si
 // el usuario cambia los datos (fecha/hora/duración/participantes).
-//
-// Errores por `code` (D6): 409 CONFLICT (D5, botón volver/refrescar), 400
-// VALIDATION_ERROR, 422 PARTICIPANTS_LIMIT_EXCEEDED / INVALID_STATE_TRANSITION.
 import { useMemo, useRef, useState } from 'react';
 import { Navigate, useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
@@ -16,16 +23,24 @@ import {
   crearReserva,
   isReservaApiError,
   CrearReservaPayload,
+  ParticipanteAdicional,
   ReservaResponse,
   ReservaApiError,
 } from '../services/reservasApi';
+import { ParticipanteSelector } from '../components/ParticipanteSelector';
+import {
+  ParticipanteInput,
+  emptyParticipante,
+  participanteCompleto,
+} from '../components/participanteModel';
 import { reservasPaths } from './reservasPaths';
 import './pages.css';
 import styles from './ConfirmarReservaPage.module.css';
 
-interface ParticipanteInput {
-  externalName: string;
-}
+/** Duraciones ofrecidas en la UI (D3). El backend acepta hasta 180, pero esta fase
+ *  solo expone 60/90/120. */
+const DURACIONES = [60, 90, 120] as const;
+const DEFAULT_DURACION = 60;
 
 /** Formatea un importe (number) como euros. El valor viene del backend. */
 function formatPrecio(amount: number): string {
@@ -35,23 +50,43 @@ function formatPrecio(amount: number): string {
   }).format(amount);
 }
 
-/** Traduce el error de negocio (por `code`) a copy accionable. `null` = error de
- *  franja ocupada, que se maneja como pantalla dedicada (D5). */
+/** Traduce el error (por `code`) a copy accionable, leyendo el contrato real del
+ *  backend (`details[0]` para VALIDATION_ERROR). El genérico queda reservado para
+ *  fallos verdaderamente desconocidos. */
 function messageForError(err: ReservaApiError): string {
   switch (err.code) {
+    case 'AUTH_REQUIRED':
+      return 'Tu sesión ha caducado. Vuelve a iniciar sesión.';
     case 'PARTICIPANTS_LIMIT_EXCEEDED':
       return 'Has superado el número máximo de participantes permitido.';
     case 'INVALID_STATE_TRANSITION':
       return 'La operación no es válida para el estado actual de la reserva.';
     case 'VALIDATION_ERROR': {
-      const first = err.fieldErrors[0];
-      return first
-        ? `Revisa los datos: ${first.message}`
-        : 'Revisa los datos de la reserva e inténtalo de nuevo.';
+      const detalle = err.details[0] ?? err.fieldErrors[0]?.message;
+      return detalle
+        ? `Revisa los datos: ${detalle}`
+        : 'Revisa los datos de la reserva; alguno no es válido e inténtalo de nuevo.';
     }
+    case 'NOT_FOUND':
+      return 'La franja ya no está disponible. Vuelve a la búsqueda para elegir otra.';
+    case 'SERVER_ERROR':
+      return 'Ha ocurrido un error en el servidor. Inténtalo de nuevo en unos momentos.';
+    case 'NETWORK_ERROR':
+      return 'No se pudo conectar con el servidor. Comprueba tu conexión e inténtalo de nuevo.';
     default:
       return 'No se pudo completar la reserva. Inténtalo de nuevo.';
   }
+}
+
+/** Construye el participante XOR del payload a partir del input de la fila. */
+function toPayloadParticipante(p: ParticipanteInput): ParticipanteAdicional | null {
+  if (p.tipo === 'socio') {
+    return p.userId != null ? { userId: p.userId } : null;
+  }
+  const externalName = p.externalName.trim();
+  if (!externalName) return null;
+  const externalPhone = p.externalPhone.trim();
+  return externalPhone ? { externalName, externalPhone } : { externalName };
 }
 
 export function ConfirmarReservaPage() {
@@ -61,11 +96,17 @@ export function ConfirmarReservaPage() {
 
   const fecha = params.get('fecha') ?? '';
   const hora = params.get('hora') ?? '';
-  const duracion = params.get('duracion') ?? '';
+  const maxDuracion = Number(params.get('maxDuracion')) || 0;
 
+  // Opciones de duración válidas para la franja (D3): acotadas por `maxDuracion`
+  // (disponibilidad contigua). Sin `maxDuracion` se ofrecen todas.
+  const opcionesDuracion = useMemo(
+    () => DURACIONES.filter((d) => (maxDuracion > 0 ? d <= maxDuracion : true)),
+    [maxDuracion]
+  );
+
+  const [duracion, setDuracion] = useState<number>(DEFAULT_DURACION);
   const [participantes, setParticipantes] = useState<ParticipanteInput[]>([]);
-  // El campo de notas aún no tiene UI (pendiente en Grupo 5); se mantiene el valor
-  // por defecto vacío para que el payload lo omita (notes.trim() === '').
   const [notes] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [reserva, setReserva] = useState<ReservaResponse | null>(null);
@@ -73,11 +114,12 @@ export function ConfirmarReservaPage() {
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
   // ── Idempotency-Key por intento (D2) ────────────────────────────────────────
-  // La firma resume los datos del formulario; si cambia, se regenera la key.
-  const nombresParticipantes = participantes.map((p) => p.externalName.trim());
+  const participantesSig = participantes.map((p) =>
+    p.tipo === 'socio' ? `s:${p.userId ?? ''}` : `e:${p.externalName.trim()}:${p.externalPhone.trim()}`
+  );
   const signature = useMemo(
-    () => JSON.stringify({ fecha, hora, duracion, notes: notes.trim(), nombresParticipantes }),
-    [fecha, hora, duracion, notes, nombresParticipantes]
+    () => JSON.stringify({ fecha, hora, duracion, notes: notes.trim(), participantesSig }),
+    [fecha, hora, duracion, notes, participantesSig]
   );
   const idemRef = useRef<{ sig: string; key: string } | null>(null);
 
@@ -93,13 +135,11 @@ export function ConfirmarReservaPage() {
   }
 
   function addParticipante() {
-    setParticipantes((prev) => [...prev, { externalName: '' }]);
+    setParticipantes((prev) => [...prev, emptyParticipante()]);
   }
 
-  function updateParticipante(index: number, value: string) {
-    setParticipantes((prev) =>
-      prev.map((p, i) => (i === index ? { externalName: value } : p))
-    );
+  function updateParticipante(index: number, next: ParticipanteInput) {
+    setParticipantes((prev) => prev.map((p, i) => (i === index ? next : p)));
   }
 
   function removeParticipante(index: number) {
@@ -108,20 +148,28 @@ export function ConfirmarReservaPage() {
 
   async function handleConfirm() {
     if (!accessToken) return;
+
+    // Bloquea si algún participante está incompleto/ambiguo (XOR): socio sin
+    // seleccionar o externo sin nombre.
+    if (participantes.some((p) => !participanteCompleto(p))) {
+      setConflict(false);
+      setErrorMsg('Completa los datos de cada compañero: elige un socio o indica el nombre del invitado.');
+      return;
+    }
+
     setSubmitting(true);
     setErrorMsg(null);
     setConflict(false);
 
     const adicionales = participantes
-      .map((p) => p.externalName.trim())
-      .filter(Boolean)
-      .map((externalName) => ({ externalName }));
+      .map(toPayloadParticipante)
+      .filter((p): p is ParticipanteAdicional => p !== null);
 
     // Payload sin importe alguno (RN-RES-03): el backend congela el precio.
     const payload: CrearReservaPayload = {
       reservationDate: fecha,
       startTime: hora,
-      durationMinutes: Number(duracion),
+      durationMinutes: duracion,
       ...(adicionales.length ? { participantesAdicionales: adicionales } : {}),
       ...(notes.trim() ? { notes: notes.trim() } : {}),
     };
@@ -130,6 +178,11 @@ export function ConfirmarReservaPage() {
       const created = await crearReserva(accessToken, payload, idempotencyKey());
       setReserva(created);
     } catch (err) {
+      if (isReservaApiError(err) && err.code === 'AUTH_REQUIRED') {
+        // Sesión caducada (D2): no reintentar la misma petición; re-autenticar.
+        navigate('/login', { replace: true });
+        return;
+      }
       if (isReservaApiError(err) && err.code === 'CONFLICT') {
         setConflict(true);
       } else if (isReservaApiError(err)) {
@@ -208,6 +261,13 @@ export function ConfirmarReservaPage() {
           <span className="p-dot" />
           PadelPro
         </div>
+        <button
+          type="button"
+          className={styles.homeBtn}
+          onClick={() => navigate(reservasPaths.home)}
+        >
+          Inicio
+        </button>
       </header>
 
       <div className={styles.titleBlock}>
@@ -218,7 +278,7 @@ export function ConfirmarReservaPage() {
         </h1>
       </div>
 
-      {/* Resumen del tramo elegido (D3): valores ya resueltos por el backend */}
+      {/* Resumen del tramo elegido: fecha/hora de la query, duración elegida (D3) */}
       <div className={styles.summary}>
         <div className={styles.summaryRow}>
           <span className={styles.summaryLab}>Fecha</span>
@@ -230,37 +290,40 @@ export function ConfirmarReservaPage() {
         </div>
         <div className={styles.summaryRow}>
           <span className={styles.summaryLab}>Duración</span>
-          <span className={styles.summaryVal}>{duracion} min</span>
+          <span className={styles.summaryVal} data-testid="resumen-duracion">{duracion} min</span>
         </div>
       </div>
 
-      {/* Participantes adicionales (D4: solo externalName en v1) */}
+      {/* Selector de duración (D3) */}
+      <div className={styles.durationBlock}>
+        <p className={styles.sectionTitle} id="duracion-label">Duración</p>
+        <div className={styles.durationOptions} role="group" aria-labelledby="duracion-label">
+          {opcionesDuracion.map((d) => (
+            <button
+              key={d}
+              type="button"
+              className={`${styles.durationBtn} ${duracion === d ? styles.durationOn : ''}`}
+              aria-pressed={duracion === d}
+              onClick={() => setDuracion(d)}
+            >
+              {d} min
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Participantes adicionales (D4/D5: socio registrado o invitado externo) */}
       <div className={styles.participantesBlock}>
         <p className={styles.sectionTitle}>Participantes adicionales</p>
         {participantes.map((p, i) => (
-          <div key={i} className={styles.participanteRow}>
-            <label className={styles.fieldLabel} htmlFor={`participante-${i}`}>
-              Nombre del compañero {i + 1}
-            </label>
-            <div className={styles.participanteInputRow}>
-              <input
-                id={`participante-${i}`}
-                className={styles.textInput}
-                type="text"
-                value={p.externalName}
-                onChange={(e) => updateParticipante(i, e.target.value)}
-                placeholder="Nombre y apellido"
-              />
-              <button
-                type="button"
-                className={styles.removeBtn}
-                onClick={() => removeParticipante(i)}
-                aria-label={`Quitar compañero ${i + 1}`}
-              >
-                ×
-              </button>
-            </div>
-          </div>
+          <ParticipanteSelector
+            key={i}
+            index={i}
+            value={p}
+            token={accessToken ?? ''}
+            onChange={(next) => updateParticipante(i, next)}
+            onRemove={() => removeParticipante(i)}
+          />
         ))}
         <button type="button" className={styles.addBtn} onClick={addParticipante}>
           + Añadir compañero

--- a/frontend/src/pages/DetalleReservaPage.module.css
+++ b/frontend/src/pages/DetalleReservaPage.module.css
@@ -11,6 +11,30 @@
   padding: 0 0 48px;
 }
 
+/* --- Top bar con control de Inicio --- */
+.topBar {
+  display: flex;
+  justify-content: flex-start;
+  padding: 16px 24px 0;
+}
+
+.homeBtn {
+  background: transparent;
+  border: 1.5px solid rgba(13, 13, 13, 0.25);
+  border-radius: 999px;
+  padding: 6px 14px;
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ink);
+  cursor: pointer;
+  transition: border-color 0.15s ease;
+}
+
+.homeBtn:hover {
+  border-color: var(--ink);
+}
+
 /* --- Hero olive --- */
 .hero {
   background: var(--olive);

--- a/frontend/src/pages/DetalleReservaPage.tsx
+++ b/frontend/src/pages/DetalleReservaPage.tsx
@@ -5,7 +5,7 @@
 // Se respetan 403 (ajena, RN-RGPD-03) y 404 (inexistente) sin exponer datos; el
 // 422 CANCELLATION_DEADLINE_PASSED informa de fuera de plazo y no reembolso (RN-RES-04).
 import { useCallback, useEffect, useState } from 'react';
-import { Navigate, useParams } from 'react-router-dom';
+import { Navigate, useNavigate, useParams } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import {
   getReserva,
@@ -15,6 +15,7 @@ import {
   ReservationStatus,
 } from '../services/reservasApi';
 import { EstadoBadge } from '../components/EstadoBadge';
+import { reservasPaths } from './reservasPaths';
 import './pages.css';
 import styles from './DetalleReservaPage.module.css';
 
@@ -30,6 +31,7 @@ function formatPrecio(amount: number): string {
 
 export function DetalleReservaPage() {
   const { accessToken, userId, loadUserId, isAuthenticated } = useAuth();
+  const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
 
   const [reserva, setReserva] = useState<ReservaResponse | null>(null);
@@ -118,6 +120,15 @@ export function DetalleReservaPage() {
           : 'No se pudo cargar la reserva. Inténtalo de nuevo.';
     return (
       <div className={styles.page}>
+        <div className={styles.topBar}>
+          <button
+            type="button"
+            className={styles.homeBtn}
+            onClick={() => navigate(reservasPaths.home)}
+          >
+            Inicio
+          </button>
+        </div>
         <p className="p-error" role="alert">
           {msg}
         </p>
@@ -129,6 +140,15 @@ export function DetalleReservaPage() {
 
   return (
     <div className={styles.page}>
+      <div className={styles.topBar}>
+        <button
+          type="button"
+          className={styles.homeBtn}
+          onClick={() => navigate(reservasPaths.home)}
+        >
+          Inicio
+        </button>
+      </div>
       <header className={styles.hero}>
         <div className={styles.heroBadges}>
           <EstadoBadge kind="reserva" status={reserva.status} />

--- a/frontend/src/pages/DisponibilidadPage.module.css
+++ b/frontend/src/pages/DisponibilidadPage.module.css
@@ -19,6 +19,23 @@
   gap: 12px;
 }
 
+.homeBtn {
+  background: transparent;
+  border: 1.5px solid rgba(13, 13, 13, 0.25);
+  border-radius: 999px;
+  padding: 6px 14px;
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ink);
+  cursor: pointer;
+  transition: border-color 0.15s ease;
+}
+
+.homeBtn:hover {
+  border-color: var(--ink);
+}
+
 .titleBlock {
   padding: 24px 0 8px;
 }

--- a/frontend/src/pages/DisponibilidadPage.tsx
+++ b/frontend/src/pages/DisponibilidadPage.tsx
@@ -8,7 +8,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { Navigate, useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { getDisponibilidad, Tramo } from '../services/reservasApi';
-import { confirmarReservaPath } from './reservasPaths';
+import { confirmarReservaPath, reservasPaths } from './reservasPaths';
 import './pages.css';
 import styles from './DisponibilidadPage.module.css';
 
@@ -19,6 +19,32 @@ function todayISO(): string {
   const m = String(now.getMonth() + 1).padStart(2, '0');
   const d = String(now.getDate()).padStart(2, '0');
   return `${y}-${m}-${d}`;
+}
+
+/** "HH:MM" → minutos desde medianoche. */
+function toMinutes(hhmm: string): number {
+  const [h, m] = hhmm.split(':').map(Number);
+  return (h || 0) * 60 + (m || 0);
+}
+
+/** Duración máxima contigua reservable desde un tramo (D3): suma los tramos
+ *  siguientes `creable` que arrancan justo donde termina el anterior, con tope de
+ *  120 min (máximo ofrecido por la UI). Acota las opciones del selector de duración
+ *  en la confirmación; el 409 del backend sigue siendo la autoridad. */
+function maxDuracionContigua(tramos: Tramo[], index: number): number {
+  const base = tramos[index];
+  let total = base.duracionMinutos;
+  let endMin = toMinutes(base.horaInicio) + base.duracionMinutos;
+  for (let i = index + 1; i < tramos.length; i++) {
+    const t = tramos[i];
+    if (t.creable === true && toMinutes(t.horaInicio) === endMin) {
+      total += t.duracionMinutos;
+      endMin += t.duracionMinutos;
+    } else {
+      break;
+    }
+  }
+  return Math.min(total, 120);
 }
 
 export function DisponibilidadPage() {
@@ -53,8 +79,15 @@ export function DisponibilidadPage() {
     return <Navigate to="/login" replace />;
   }
 
-  function handleReservar(tramo: Tramo) {
-    navigate(confirmarReservaPath(fecha, tramo.horaInicio, tramo.duracionMinutos));
+  function handleReservar(tramo: Tramo, index: number) {
+    navigate(
+      confirmarReservaPath(
+        fecha,
+        tramo.horaInicio,
+        tramo.duracionMinutos,
+        maxDuracionContigua(tramos, index)
+      )
+    );
   }
 
   return (
@@ -64,6 +97,13 @@ export function DisponibilidadPage() {
           <span className="p-dot" />
           PadelPro
         </div>
+        <button
+          type="button"
+          className={styles.homeBtn}
+          onClick={() => navigate(reservasPaths.home)}
+        >
+          Inicio
+        </button>
       </header>
 
       <div className={styles.titleBlock}>
@@ -101,7 +141,7 @@ export function DisponibilidadPage() {
         <p className={styles.empty}>No hay tramos disponibles para esta fecha.</p>
       ) : (
         <ul className={styles.tramoList}>
-          {tramos.map((tramo) => {
+          {tramos.map((tramo, index) => {
             const creable = tramo.creable === true; // fail-safe (D7)
             return (
               <li
@@ -117,7 +157,7 @@ export function DisponibilidadPage() {
                   <button
                     type="button"
                     className={`p-btn p-btn-primary ${styles.reservarBtn}`}
-                    onClick={() => handleReservar(tramo)}
+                    onClick={() => handleReservar(tramo, index)}
                   >
                     Reservar {tramo.horaInicio}
                   </button>

--- a/frontend/src/pages/MisReservasPage.module.css
+++ b/frontend/src/pages/MisReservasPage.module.css
@@ -19,6 +19,23 @@
   gap: 12px;
 }
 
+.homeBtn {
+  background: transparent;
+  border: 1.5px solid rgba(13, 13, 13, 0.25);
+  border-radius: 999px;
+  padding: 6px 14px;
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ink);
+  cursor: pointer;
+  transition: border-color 0.15s ease;
+}
+
+.homeBtn:hover {
+  border-color: var(--ink);
+}
+
 .titleBlock {
   padding: 24px 0 16px;
 }
@@ -115,6 +132,134 @@
   font-size: 11px;
   letter-spacing: 0.06em;
   color: var(--muted);
+}
+
+/* --- Acciones inline por tarjeta (D6) --- */
+.actions {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px 18px 16px;
+  border-top: 1px solid var(--line, #e5e3d8);
+}
+
+.actionsLabel {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.pagoBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.pagoBtns {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.pagoBtn {
+  flex: 1;
+  min-width: 130px;
+  padding: 10px 12px;
+  border: 1.5px solid rgba(13, 13, 13, 0.2);
+  border-radius: 10px;
+  background: transparent;
+  color: var(--ink);
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: border-color 0.15s ease;
+}
+
+.pagoBtn:hover {
+  border-color: var(--ink);
+}
+
+.pagoBtnDisabled {
+  flex: 1;
+  min-width: 130px;
+  padding: 10px 12px;
+  border: 1.5px dashed rgba(13, 13, 13, 0.2);
+  border-radius: 10px;
+  background: transparent;
+  color: var(--muted-light, #a8a49a);
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: not-allowed;
+}
+
+.pagoInfo {
+  font-size: 13px;
+  line-height: 1.4;
+  color: var(--muted);
+  background: rgba(13, 13, 13, 0.03);
+  border-radius: 8px;
+  padding: 10px 12px;
+}
+
+.cancelBtn {
+  align-self: flex-start;
+  padding: 9px 16px;
+  border: 1.5px solid var(--error);
+  border-radius: 10px;
+  background: transparent;
+  color: var(--error);
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.cancelBtn:hover:not(:disabled) {
+  background: var(--error);
+  color: var(--white);
+}
+
+.cancelBtn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.confirmRow {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.confirmText {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.confirmBtns {
+  display: flex;
+  gap: 8px;
+}
+
+.volverBtn {
+  padding: 9px 16px;
+  border: 1.5px solid rgba(13, 13, 13, 0.25);
+  border-radius: 10px;
+  background: transparent;
+  color: var(--ink);
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.volverBtn:hover:not(:disabled) {
+  border-color: var(--ink);
 }
 
 .empty {

--- a/frontend/src/pages/MisReservasPage.tsx
+++ b/frontend/src/pages/MisReservasPage.tsx
@@ -1,22 +1,49 @@
-// Grupo 6 — MisReservasPage (mockup 05).
-// Lista las reservas del usuario (GET /api/reservas: owner o participante) con el
-// estado de la reserva y el estado del pago asociado. Estado vacío con acceso a
-// buscar disponibilidad.
+// Grupo 6 / reservas-ui-jugador-fixes (Grupo 5, D6) — MisReservasPage (mockup 05).
+// Lista las reservas del usuario (GET /api/reservas) con el estado de la reserva y
+// del pago. Por cada tarjeta, sin entrar al detalle:
+//   - Cancelar inline (DELETE /api/reservas/{id}), solo si owner y estado cancelable;
+//     refresca la lista tras cancelar.
+//   - Método de pago: "pago en diferido" (cobro presencial, sin llamada) y "pagar
+//     ahora" DESHABILITADO/informativo hasta el change `pagos-redsys`.
+// Las acciones no aplicables por estado se ocultan. Control de "volver a Inicio".
 import { useCallback, useEffect, useState } from 'react';
-import { Link, Navigate } from 'react-router-dom';
+import { Link, Navigate, useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
-import { getMisReservas, ReservaResponse } from '../services/reservasApi';
+import {
+  getMisReservas,
+  cancelarReserva,
+  isReservaApiError,
+  ReservaResponse,
+  ReservationStatus,
+} from '../services/reservasApi';
 import { EstadoBadge } from '../components/EstadoBadge';
 import { reservasPaths } from './reservasPaths';
 import './pages.css';
 import styles from './MisReservasPage.module.css';
 
+/** Estados en los que una reserva admite cancelación desde la UI. La barrera real
+ *  la impone el backend (422 INVALID_STATE_TRANSITION / CANCELLATION_DEADLINE_PASSED). */
+const ESTADOS_CANCELABLES: ReservationStatus[] = ['PENDING_CONFIRMATION', 'CONFIRMED'];
+
 export function MisReservasPage() {
-  const { accessToken, isAuthenticated } = useAuth();
+  const { accessToken, isAuthenticated, userId, loadUserId } = useAuth();
+  const navigate = useNavigate();
 
   const [reservas, setReservas] = useState<ReservaResponse[]>([]);
   const [loading, setLoading] = useState(true);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  // Estado por-tarjeta de las acciones inline.
+  const [confirmingId, setConfirmingId] = useState<string | null>(null);
+  const [cancellingId, setCancellingId] = useState<string | null>(null);
+  const [cancelError, setCancelError] = useState<{ id: string; msg: string } | null>(null);
+  const [diferidoId, setDiferidoId] = useState<string | null>(null);
+
+  // Id del usuario (D8) para decidir la propiedad de cada reserva (botón cancelar).
+  useEffect(() => {
+    void loadUserId();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const load = useCallback(async () => {
     if (!accessToken) return;
@@ -40,6 +67,25 @@ export function MisReservasPage() {
     return <Navigate to="/login" replace />;
   }
 
+  async function handleCancel(id: string) {
+    if (!accessToken) return;
+    setCancellingId(id);
+    setCancelError(null);
+    try {
+      await cancelarReserva(accessToken, id);
+      setConfirmingId(null);
+      await load();
+    } catch (err) {
+      const msg =
+        isReservaApiError(err) && err.code === 'CANCELLATION_DEADLINE_PASSED'
+          ? 'La cancelación está fuera de plazo; no aplica reembolso (política del club).'
+          : 'No se pudo cancelar la reserva. Inténtalo de nuevo.';
+      setCancelError({ id, msg });
+    } finally {
+      setCancellingId(null);
+    }
+  }
+
   return (
     <div className={styles.page}>
       <header className={styles.header}>
@@ -47,6 +93,13 @@ export function MisReservasPage() {
           <span className="p-dot" />
           PadelPro
         </div>
+        <button
+          type="button"
+          className={styles.homeBtn}
+          onClick={() => navigate(reservasPaths.home)}
+        >
+          Inicio
+        </button>
       </header>
 
       <div className={styles.titleBlock}>
@@ -75,26 +128,113 @@ export function MisReservasPage() {
         </div>
       ) : (
         <ul className={styles.list}>
-          {reservas.map((r) => (
-            <li key={r.id} className={styles.card}>
-              <Link to={reservasPaths.detalle(r.id)} className={styles.cardLink}>
-                <div className={styles.cardHead}>
-                  <EstadoBadge kind="reserva" status={r.status} />
-                  {r.pago && <EstadoBadge kind="pago" status={r.pago.status} />}
-                </div>
-                <div className={styles.cardBody}>
-                  <div className={styles.timeBlock}>
-                    <span className={styles.hora}>{r.startTime}</span>
-                    <span className={styles.dur}>{r.durationMinutes} min</span>
+          {reservas.map((r) => {
+            const isOwner = r.ownerId != null && userId != null && r.ownerId === userId;
+            const canCancel = isOwner && ESTADOS_CANCELABLES.includes(r.status);
+            const pagoPendiente =
+              r.pago != null && (r.pago.status === 'PENDING' || r.pago.status === 'IN_PROGRESS');
+            const mostrarPago = pagoPendiente && r.status !== 'CANCELLED';
+
+            return (
+              <li key={r.id} className={styles.card}>
+                <Link to={reservasPaths.detalle(r.id)} className={styles.cardLink}>
+                  <div className={styles.cardHead}>
+                    <EstadoBadge kind="reserva" status={r.status} />
+                    {r.pago && <EstadoBadge kind="pago" status={r.pago.status} />}
                   </div>
-                  <div className={styles.info}>
-                    <span className={styles.fecha}>{r.reservationDate}</span>
-                    <span className={styles.code}>{r.id}</span>
+                  <div className={styles.cardBody}>
+                    <div className={styles.timeBlock}>
+                      <span className={styles.hora}>{r.startTime}</span>
+                      <span className={styles.dur}>{r.durationMinutes} min</span>
+                    </div>
+                    <div className={styles.info}>
+                      <span className={styles.fecha}>{r.reservationDate}</span>
+                      <span className={styles.code}>{r.id}</span>
+                    </div>
                   </div>
-                </div>
-              </Link>
-            </li>
-          ))}
+                </Link>
+
+                {/* Acciones inline (fuera del Link para no anidar interactivos) */}
+                {(canCancel || mostrarPago) && (
+                  <div className={styles.actions}>
+                    {/* Método de pago (D6): diferido operativo, "pagar ahora" deshabilitado */}
+                    {mostrarPago && (
+                      <div className={styles.pagoBlock}>
+                        <span className={styles.actionsLabel}>Método de pago</span>
+                        <div className={styles.pagoBtns}>
+                          <button
+                            type="button"
+                            className={styles.pagoBtn}
+                            onClick={() => setDiferidoId(r.id)}
+                          >
+                            Pago en diferido
+                          </button>
+                          <button
+                            type="button"
+                            className={styles.pagoBtnDisabled}
+                            disabled
+                            title="El pago online estará disponible próximamente"
+                          >
+                            Pagar ahora (disponible próximamente)
+                          </button>
+                        </div>
+                        {diferidoId === r.id && (
+                          <p className={styles.pagoInfo} role="status">
+                            El cobro se realizará de forma presencial en el club. No es necesario
+                            pagar ahora.
+                          </p>
+                        )}
+                      </div>
+                    )}
+
+                    {/* Cancelar inline (D6) */}
+                    {canCancel && confirmingId !== r.id && (
+                      <button
+                        type="button"
+                        className={styles.cancelBtn}
+                        onClick={() => {
+                          setCancelError(null);
+                          setConfirmingId(r.id);
+                        }}
+                      >
+                        Cancelar
+                      </button>
+                    )}
+
+                    {canCancel && confirmingId === r.id && (
+                      <div className={styles.confirmRow}>
+                        <span className={styles.confirmText}>¿Cancelar esta reserva?</span>
+                        <div className={styles.confirmBtns}>
+                          <button
+                            type="button"
+                            className={styles.volverBtn}
+                            onClick={() => setConfirmingId(null)}
+                            disabled={cancellingId === r.id}
+                          >
+                            Volver
+                          </button>
+                          <button
+                            type="button"
+                            className={styles.cancelBtn}
+                            onClick={() => handleCancel(r.id)}
+                            disabled={cancellingId === r.id}
+                          >
+                            {cancellingId === r.id ? 'Cancelando…' : 'Confirmar cancelación'}
+                          </button>
+                        </div>
+                      </div>
+                    )}
+
+                    {cancelError?.id === r.id && (
+                      <p className="p-error" role="alert">
+                        {cancelError.msg}
+                      </p>
+                    )}
+                  </div>
+                )}
+              </li>
+            );
+          })}
         </ul>
       )}
     </div>

--- a/frontend/src/pages/reservasPaths.ts
+++ b/frontend/src/pages/reservasPaths.ts
@@ -4,6 +4,8 @@
 // literales duplicados y desincronizados.
 
 export const reservasPaths = {
+  /** Pantalla de Inicio (Home) del jugador — destino del control "volver a Inicio". */
+  home: '/home',
   disponibilidad: '/reservas/disponibilidad',
   confirmar: '/reservas/confirmar',
   mias: '/reservas/mias',
@@ -15,16 +17,25 @@ export const reservasPaths = {
  * Construye el path (string) de "Confirmar reserva" con el tramo elegido en la
  * query (fecha + hora + duración). La confirmación lee estos valores con
  * `useSearchParams` (D3: la UI consume tramos ya resueltos por el backend).
+ *
+ * `maxDuracion` (opcional, D3) acota la duración máxima ofrecida en el selector de
+ * la confirmación según la disponibilidad contigua real de la franja; si se omite,
+ * la confirmación ofrece todas las opciones (60/90/120) y confía en el 409 del
+ * backend como red de seguridad.
  */
 export function confirmarReservaPath(
   fecha: string,
   startTime: string,
-  durationMinutes: number
+  durationMinutes: number,
+  maxDuracion?: number
 ): string {
   const params = new URLSearchParams({
     fecha,
     hora: startTime,
     duracion: String(durationMinutes),
   });
+  if (maxDuracion != null) {
+    params.set('maxDuracion', String(maxDuracion));
+  }
   return `${reservasPaths.confirmar}?${params.toString()}`;
 }

--- a/frontend/src/services/reservasApi.ts
+++ b/frontend/src/services/reservasApi.ts
@@ -96,11 +96,15 @@ export interface ReservaResponse {
   updatedAt?: string;
 }
 
-/** Participante adicional (v1: solo `externalName`, D4). */
-export interface ParticipanteAdicional {
-  externalName: string;
-  externalPhone?: string;
-}
+/**
+ * Participante adicional (D4). XOR estricto acorde a la validación del backend:
+ *  - socio registrado → `{ userId }` (sin datos de externo)
+ *  - invitado externo → `{ externalName }` (+ `externalPhone` opcional)
+ * El payload envía exactamente una de las dos formas por participante.
+ */
+export type ParticipanteAdicional =
+  | { userId: number }
+  | { externalName: string; externalPhone?: string };
 
 /** Payload de creación. NUNCA incluye importe (RN-RES-03): el precio lo
  *  calcula y congela el backend. */
@@ -115,6 +119,7 @@ export interface CrearReservaPayload {
 // ─── Errores tipados (D6) ─────────────────────────────────────────────────────
 
 export type ReservaErrorCode =
+  | 'AUTH_REQUIRED'
   | 'CONFLICT'
   | 'VALIDATION_ERROR'
   | 'PARTICIPANTS_LIMIT_EXCEEDED'
@@ -122,6 +127,8 @@ export type ReservaErrorCode =
   | 'CANCELLATION_DEADLINE_PASSED'
   | 'FORBIDDEN'
   | 'NOT_FOUND'
+  | 'SERVER_ERROR'
+  | 'NETWORK_ERROR'
   | 'UNKNOWN';
 
 export interface FieldError {
@@ -134,13 +141,22 @@ export class ReservaApiError extends Error {
   readonly code: ReservaErrorCode;
   readonly status: number;
   readonly fieldErrors: FieldError[];
+  /** Lista de detalles textuales del backend (contrato real: `details`). */
+  readonly details: string[];
 
-  constructor(code: ReservaErrorCode, message: string, status: number, fieldErrors: FieldError[] = []) {
+  constructor(
+    code: ReservaErrorCode,
+    message: string,
+    status: number,
+    fieldErrors: FieldError[] = [],
+    details: string[] = []
+  ) {
     super(message);
     this.name = 'ReservaApiError';
     this.code = code;
     this.status = status;
     this.fieldErrors = fieldErrors;
+    this.details = details;
     Object.setPrototypeOf(this, ReservaApiError.prototype);
   }
 }
@@ -155,10 +171,17 @@ interface BackendErrorBody {
   error?: string;
   code?: string;
   message?: string;
+  /** Contrato real: lista de detalles del error (p. ej. campos inválidos). */
+  details?: string[];
+  /** Compat: algunos endpoints devolvían `errors[]` tipado por campo. */
   errors?: FieldError[];
 }
 
+/** Códigos de negocio que llegan en el cuerpo (`error`) del backend. Los códigos
+ *  derivados del status (AUTH_REQUIRED, SERVER_ERROR, NETWORK_ERROR) NO se listan
+ *  aquí: se infieren de `codeFromStatus`. */
 const KNOWN_CODES: ReservaErrorCode[] = [
+  'AUTH_REQUIRED',
   'CONFLICT',
   'VALIDATION_ERROR',
   'PARTICIPANTS_LIMIT_EXCEEDED',
@@ -168,11 +191,14 @@ const KNOWN_CODES: ReservaErrorCode[] = [
   'NOT_FOUND',
 ];
 
-/** Traduce el status HTTP a un `code` cuando el cuerpo no trae uno reconocible. */
+/** Traduce el status HTTP a un `code` cuando el cuerpo no trae uno reconocible.
+ *  Diferencia el 401 (sesión), el 5xx (servidor) y el error de red (status 0). */
 function codeFromStatus(status: number): ReservaErrorCode {
   switch (status) {
     case 400:
       return 'VALIDATION_ERROR';
+    case 401:
+      return 'AUTH_REQUIRED';
     case 403:
       return 'FORBIDDEN';
     case 404:
@@ -180,17 +206,20 @@ function codeFromStatus(status: number): ReservaErrorCode {
     case 409:
       return 'CONFLICT';
     default:
+      if (status === 0) return 'NETWORK_ERROR';
+      if (status >= 500) return 'SERVER_ERROR';
       return 'UNKNOWN';
   }
 }
 
 /** Convierte cualquier fallo axios en un ReservaApiError tipado. El backend en vivo
- *  responde `{ error, message, timestamp }` (la clave del código es `error`, no `code`)
- *  y usa HTTP 422 para los tres errores de negocio (PARTICIPANTS_LIMIT_EXCEEDED,
- *  INVALID_STATE_TRANSITION, CANCELLATION_DEADLINE_PASSED), que comparten status.
- *  Por eso el código se toma SIEMPRE del valor textual del cuerpo cuando es un
- *  `ReservaErrorCode` conocido; solo se cae a `codeFromStatus` si el cuerpo no lo
- *  trae. Re-lanza. */
+ *  responde `{ error, message, timestamp, details? }` (la clave del código es `error`,
+ *  no `code`; la lista es `details`, no `fieldErrors`) y usa HTTP 422 para los tres
+ *  errores de negocio (PARTICIPANTS_LIMIT_EXCEEDED, INVALID_STATE_TRANSITION,
+ *  CANCELLATION_DEADLINE_PASSED), que comparten status. Por eso el código se toma
+ *  SIEMPRE del valor textual del cuerpo cuando es un `ReservaErrorCode` conocido; solo
+ *  se cae a `codeFromStatus` si el cuerpo no lo trae (401 sesión, 5xx servidor, red).
+ *  Re-lanza. */
 function toReservaApiError(error: unknown): never {
   const axErr = error as AxiosError<BackendErrorBody>;
   const status = axErr.response?.status ?? 0;
@@ -204,8 +233,11 @@ function toReservaApiError(error: unknown): never {
 
   const message = body?.message ?? axErr.message ?? 'Error inesperado';
   const fieldErrors = Array.isArray(body?.errors) ? body!.errors! : [];
+  const details = Array.isArray(body?.details)
+    ? body!.details!.filter((d): d is string => typeof d === 'string')
+    : [];
 
-  throw new ReservaApiError(code, message, status, fieldErrors);
+  throw new ReservaApiError(code, message, status, fieldErrors, details);
 }
 
 // ─── Endpoints ────────────────────────────────────────────────────────────────

--- a/frontend/src/services/usuariosApi.ts
+++ b/frontend/src/services/usuariosApi.ts
@@ -52,3 +52,23 @@ export async function changeMyPasswordApi(
     _skipAuthRefresh: true,
   });
 }
+
+// reservas-ui-jugador-fixes (D5) — búsqueda de socios para el buscador de
+// participante registrado. GET /api/usuarios/buscar?q=<term> → [{ id, nombre }].
+// Resultados mínimos (id + nombre) y acotados; el backend exige término mínimo y
+// autenticación. Un término corto o sin coincidencias devuelve un array vacío.
+export interface UsuarioBusqueda {
+  id: number;
+  nombre: string;
+}
+
+export async function buscarUsuariosApi(
+  token: string,
+  q: string
+): Promise<UsuarioBusqueda[]> {
+  const { data } = await api.get<UsuarioBusqueda[]>('/usuarios/buscar', {
+    headers: { Authorization: `Bearer ${token}` },
+    params: { q },
+  });
+  return Array.isArray(data) ? data : [];
+}

--- a/frontend/src/test/ConfirmarReservaPage.fixes.test.tsx
+++ b/frontend/src/test/ConfirmarReservaPage.fixes.test.tsx
@@ -1,0 +1,189 @@
+// reservas-ui-jugador-fixes — ConfirmarReservaPage — TDD de los grupos 1-4.
+//  G1: 401 AUTH_REQUIRED (tras refresh fallido) → redirección a login.
+//  G2: selector de duración 60/90/120 (default 60, filtrado por maxDuracion).
+//  G3: payload XOR socio (userId) vs externo (externalName[+phone]); bloqueo si
+//      un participante está incompleto.
+//  G4: control "Inicio" navega a Home.
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, afterEach } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { http, HttpResponse } from 'msw';
+import { AuthContext } from '../context/AuthContext';
+import { ConfirmarReservaPage } from '../pages/ConfirmarReservaPage';
+import { server } from './mocks/server';
+
+afterEach(() => server.resetHandlers());
+
+const authValue = {
+  accessToken: 'user.jwt.token',
+  role: 'USER',
+  mustChangePassword: false,
+  userId: 42,
+  isAuthenticated: true,
+  setAccessToken: () => {},
+  setSession: () => {},
+  clearMustChangePassword: () => {},
+  loadUserId: async () => {},
+};
+
+function renderPage(query = '?fecha=2026-07-10&hora=20:00&duracion=60') {
+  return render(
+    <AuthContext.Provider value={authValue}>
+      <MemoryRouter initialEntries={[`/reservas/confirmar${query}`]}>
+        <Routes>
+          <Route path="/reservas/confirmar" element={<ConfirmarReservaPage />} />
+          <Route path="/login" element={<div>Pantalla de login</div>} />
+          <Route path="/home" element={<div>Pantalla de inicio</div>} />
+          <Route path="/reservas/disponibilidad" element={<div>Buscar disponibilidad</div>} />
+        </Routes>
+      </MemoryRouter>
+    </AuthContext.Provider>
+  );
+}
+
+function reservaResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'r-1',
+    reservationDate: '2026-07-10',
+    startTime: '20:00',
+    durationMinutes: 60,
+    status: 'PENDING_CONFIRMATION',
+    channel: 'WEB',
+    ownerId: 42,
+    priceTotal: 16,
+    participants: [],
+    pago: null,
+    createdAt: '2026-07-04T10:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('ConfirmarReservaPage — Grupo 1 (sesión caducada)', () => {
+  it('401 AUTH_REQUIRED (refresh fallido) redirige a login', async () => {
+    server.use(
+      http.post('/api/reservas', () =>
+        HttpResponse.json({ error: 'AUTH_REQUIRED', message: 'token', timestamp: 't' }, { status: 401 })
+      ),
+      http.post('/api/auth/refresh', () => HttpResponse.json({ error: 'AUTH_REQUIRED' }, { status: 401 }))
+    );
+    renderPage();
+
+    await userEvent.click(screen.getByRole('button', { name: /confirmar reserva/i }));
+
+    expect(await screen.findByText('Pantalla de login')).toBeInTheDocument();
+  });
+});
+
+describe('ConfirmarReservaPage — Grupo 2 (duración)', () => {
+  it('elegir 90 min envía durationMinutes:90 y lo refleja en el resumen', async () => {
+    let capturedBody: Record<string, unknown> | null = null;
+    server.use(
+      http.post('/api/reservas', async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(reservaResponse({ durationMinutes: 90 }), { status: 201 });
+      })
+    );
+    renderPage();
+
+    await userEvent.click(screen.getByRole('button', { name: '90 min' }));
+    expect(screen.getByTestId('resumen-duracion')).toHaveTextContent('90 min');
+
+    await userEvent.click(screen.getByRole('button', { name: /confirmar reserva/i }));
+    await waitFor(() => expect(capturedBody).not.toBeNull());
+    expect(capturedBody!.durationMinutes).toBe(90);
+  });
+
+  it('default 60 min cuando no se elige duración', async () => {
+    let capturedBody: Record<string, unknown> | null = null;
+    server.use(
+      http.post('/api/reservas', async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(reservaResponse(), { status: 201 });
+      })
+    );
+    renderPage();
+
+    await userEvent.click(screen.getByRole('button', { name: /confirmar reserva/i }));
+    await waitFor(() => expect(capturedBody).not.toBeNull());
+    expect(capturedBody!.durationMinutes).toBe(60);
+  });
+
+  it('maxDuracion=90 no ofrece la opción de 120 min', async () => {
+    renderPage('?fecha=2026-07-10&hora=20:00&duracion=60&maxDuracion=90');
+
+    expect(screen.getByRole('button', { name: '60 min' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '90 min' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '120 min' })).toBeNull();
+  });
+});
+
+describe('ConfirmarReservaPage — Grupo 3 (participante XOR)', () => {
+  it('socio registrado → payload con userId y sin externalName', async () => {
+    let capturedBody: Record<string, unknown> | null = null;
+    server.use(
+      http.get('/api/usuarios/buscar', () => HttpResponse.json([{ id: 7, nombre: 'Ana García' }])),
+      http.post('/api/reservas', async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(reservaResponse(), { status: 201 });
+      })
+    );
+    renderPage();
+
+    await userEvent.click(screen.getByRole('button', { name: /añadir compañero/i }));
+    await userEvent.click(screen.getByRole('button', { name: /socio registrado/i }));
+    await userEvent.type(screen.getByLabelText(/buscar socio/i), 'Ana');
+    await userEvent.click(await screen.findByRole('button', { name: 'Ana García' }));
+
+    await userEvent.click(screen.getByRole('button', { name: /confirmar reserva/i }));
+    await waitFor(() => expect(capturedBody).not.toBeNull());
+    expect(capturedBody!.participantesAdicionales).toEqual([{ userId: 7 }]);
+  });
+
+  it('invitado externo → payload con externalName (+phone) y sin userId', async () => {
+    let capturedBody: Record<string, unknown> | null = null;
+    server.use(
+      http.post('/api/reservas', async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(reservaResponse(), { status: 201 });
+      })
+    );
+    renderPage();
+
+    await userEvent.click(screen.getByRole('button', { name: /añadir compañero/i }));
+    await userEvent.type(screen.getByLabelText(/nombre del compañero/i), 'Marcos R.');
+    await userEvent.type(screen.getByLabelText(/teléfono/i), '600111222');
+
+    await userEvent.click(screen.getByRole('button', { name: /confirmar reserva/i }));
+    await waitFor(() => expect(capturedBody).not.toBeNull());
+    expect(capturedBody!.participantesAdicionales).toEqual([
+      { externalName: 'Marcos R.', externalPhone: '600111222' },
+    ]);
+  });
+
+  it('participante incompleto (externo sin nombre) bloquea el submit', async () => {
+    let called = false;
+    server.use(
+      http.post('/api/reservas', () => {
+        called = true;
+        return HttpResponse.json(reservaResponse(), { status: 201 });
+      })
+    );
+    renderPage();
+
+    await userEvent.click(screen.getByRole('button', { name: /añadir compañero/i }));
+    // No se rellena el nombre → submit bloqueado.
+    await userEvent.click(screen.getByRole('button', { name: /confirmar reserva|reintentar/i }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/completa los datos/i);
+    expect(called).toBe(false);
+  });
+});
+
+describe('ConfirmarReservaPage — Grupo 4 (navegación)', () => {
+  it('el control "Inicio" navega a Home', async () => {
+    renderPage();
+    await userEvent.click(screen.getByRole('button', { name: /inicio/i }));
+    expect(await screen.findByText('Pantalla de inicio')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/ConfirmarReservaPage.test.tsx
+++ b/frontend/src/test/ConfirmarReservaPage.test.tsx
@@ -62,9 +62,9 @@ describe('ConfirmarReservaPage (Grupo 5)', () => {
     server.use(http.post('/api/reservas', () => HttpResponse.json(reservaResponse(), { status: 201 })));
     renderPage();
 
-    // Resumen del tramo elegido (query params).
+    // Resumen del tramo elegido (query params); la duración por defecto es 60 min.
     expect(screen.getByText(/20:00/)).toBeInTheDocument();
-    expect(screen.getByText(/60/)).toBeInTheDocument();
+    expect(screen.getByTestId('resumen-duracion')).toHaveTextContent('60 min');
     expect(screen.getByText(/2026-07-10/)).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('button', { name: /confirmar|reservar/i }));

--- a/frontend/src/test/MisReservasPage.acciones.test.tsx
+++ b/frontend/src/test/MisReservasPage.acciones.test.tsx
@@ -1,0 +1,148 @@
+// reservas-ui-jugador-fixes (Grupo 5, D6) — MisReservasPage acciones inline — TDD.
+//  - Cancelar desde la lista (DELETE) refresca el estado.
+//  - Estado de pago visible por tarjeta.
+//  - "Pago en diferido" no dispara pago; "pagar ahora" deshabilitado/informativo.
+//  - Acciones ocultas por estado (reserva cancelada / no owner).
+//  - Control "Inicio" navega a Home.
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, afterEach } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { http, HttpResponse } from 'msw';
+import { AuthContext } from '../context/AuthContext';
+import { MisReservasPage } from '../pages/MisReservasPage';
+import { server } from './mocks/server';
+
+afterEach(() => server.resetHandlers());
+
+function authValue(userId: number | null = 42) {
+  return {
+    accessToken: 'user.jwt.token',
+    role: 'USER',
+    mustChangePassword: false,
+    userId,
+    isAuthenticated: true,
+    setAccessToken: () => {},
+    setSession: () => {},
+    clearMustChangePassword: () => {},
+    loadUserId: async () => {},
+  };
+}
+
+function renderPage(userId: number | null = 42) {
+  return render(
+    <AuthContext.Provider value={authValue(userId)}>
+      <MemoryRouter initialEntries={['/reservas/mias']}>
+        <Routes>
+          <Route path="/reservas/mias" element={<MisReservasPage />} />
+          <Route path="/home" element={<div>Pantalla de inicio</div>} />
+          <Route path="/reservas/disponibilidad" element={<div>Buscar disponibilidad</div>} />
+          <Route path="/reservas/detalle/:id" element={<div>Detalle</div>} />
+        </Routes>
+      </MemoryRouter>
+    </AuthContext.Provider>
+  );
+}
+
+function reserva(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'r-1',
+    reservationDate: '2026-07-10',
+    startTime: '20:00',
+    durationMinutes: 60,
+    status: 'CONFIRMED',
+    channel: 'WEB',
+    ownerId: 42,
+    priceTotal: 16,
+    participants: [],
+    pago: { id: 'p-1', reservaId: 'r-1', amount: 16, status: 'PENDING', createdAt: 't' },
+    createdAt: 't',
+    ...overrides,
+  };
+}
+
+describe('MisReservasPage — acciones (Grupo 5)', () => {
+  it('cancelar desde la lista (DELETE) refresca el estado a cancelada', async () => {
+    let estado = 'CONFIRMED';
+    server.use(
+      http.get('/api/reservas', () =>
+        HttpResponse.json([reserva({ status: estado })])
+      ),
+      http.delete('/api/reservas/r-1', () => {
+        estado = 'CANCELLED';
+        return new HttpResponse(null, { status: 204 });
+      })
+    );
+    renderPage();
+
+    await screen.findByText('20:00');
+    await userEvent.click(screen.getByRole('button', { name: 'Cancelar' }));
+    await userEvent.click(screen.getByRole('button', { name: /confirmar cancelaci/i }));
+
+    await waitFor(() => expect(screen.getByText(/cancelada/i)).toBeInTheDocument());
+    // Tras cancelar, la acción de cancelar ya no se ofrece.
+    expect(screen.queryByRole('button', { name: 'Cancelar' })).toBeNull();
+  });
+
+  it('muestra el estado de pago de cada tarjeta', async () => {
+    server.use(http.get('/api/reservas', () => HttpResponse.json([reserva()])));
+    renderPage();
+    expect(await screen.findByText(/pago pendiente/i)).toBeInTheDocument();
+  });
+
+  it('"pago en diferido" informa cobro presencial sin llamar a ningún endpoint', async () => {
+    let pagoCalled = false;
+    server.use(
+      http.get('/api/reservas', () => HttpResponse.json([reserva()])),
+      http.post('/api/pagos', () => {
+        pagoCalled = true;
+        return HttpResponse.json({}, { status: 201 });
+      })
+    );
+    renderPage();
+
+    await screen.findByText('20:00');
+    await userEvent.click(screen.getByRole('button', { name: /pago en diferido/i }));
+
+    expect(await screen.findByText(/presencial/i)).toBeInTheDocument();
+    expect(pagoCalled).toBe(false);
+  });
+
+  it('"pagar ahora" está deshabilitado (disponible próximamente)', async () => {
+    server.use(http.get('/api/reservas', () => HttpResponse.json([reserva()])));
+    renderPage();
+
+    await screen.findByText('20:00');
+    const btn = screen.getByRole('button', { name: /pagar ahora/i });
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveTextContent(/próximamente/i);
+  });
+
+  it('oculta acciones cuando la reserva no es cancelable (CANCELLED)', async () => {
+    server.use(
+      http.get('/api/reservas', () =>
+        HttpResponse.json([reserva({ status: 'CANCELLED', pago: { id: 'p', amount: 16, status: 'REFUNDED', createdAt: 't' } })])
+      )
+    );
+    renderPage();
+
+    await screen.findByText('20:00');
+    expect(screen.queryByRole('button', { name: 'Cancelar' })).toBeNull();
+    expect(screen.queryByRole('button', { name: /pagar ahora/i })).toBeNull();
+  });
+
+  it('oculta "Cancelar" cuando el usuario no es owner', async () => {
+    server.use(http.get('/api/reservas', () => HttpResponse.json([reserva()])));
+    renderPage(99);
+
+    await screen.findByText('20:00');
+    expect(screen.queryByRole('button', { name: 'Cancelar' })).toBeNull();
+  });
+
+  it('el control "Inicio" navega a Home', async () => {
+    server.use(http.get('/api/reservas', () => HttpResponse.json([reserva()])));
+    renderPage();
+    await userEvent.click(screen.getByRole('button', { name: /inicio/i }));
+    expect(await screen.findByText('Pantalla de inicio')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/ParticipanteSelector.test.tsx
+++ b/frontend/src/test/ParticipanteSelector.test.tsx
@@ -1,0 +1,107 @@
+// reservas-ui-jugador-fixes (Grupo 3, D4/D5) — ParticipanteSelector — TDD.
+// Conmutador socio/externo; modo socio consume GET /api/usuarios/buscar y fija
+// userId; modo externo captura nombre/teléfono. Se prueba el buscador con MSW y
+// la exclusividad XOR (cambiar de modo limpia el lado contrario).
+import { useState } from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from './mocks/server';
+import { ParticipanteSelector } from '../components/ParticipanteSelector';
+import {
+  ParticipanteInput,
+  emptyParticipante,
+  participanteCompleto,
+} from '../components/participanteModel';
+
+afterEach(() => server.resetHandlers());
+
+// Wrapper con estado que expone el último valor vía callback para las aserciones.
+function Harness({ onValue }: { onValue?: (v: ParticipanteInput) => void }) {
+  const [value, setValue] = useState<ParticipanteInput>(emptyParticipante());
+  return (
+    <ParticipanteSelector
+      index={0}
+      value={value}
+      token="user.jwt.token"
+      onChange={(n) => {
+        onValue?.(n);
+        setValue(n);
+      }}
+      onRemove={() => {}}
+    />
+  );
+}
+
+describe('ParticipanteSelector (Grupo 3)', () => {
+  it('modo socio: el buscador consulta /api/usuarios/buscar y muestra resultados', async () => {
+    let capturedQ = '';
+    server.use(
+      http.get('/api/usuarios/buscar', ({ request }) => {
+        capturedQ = new URL(request.url).searchParams.get('q') ?? '';
+        return HttpResponse.json([
+          { id: 7, nombre: 'Ana García' },
+          { id: 9, nombre: 'Ana Ruiz' },
+        ]);
+      })
+    );
+
+    render(<Harness />);
+    await userEvent.click(screen.getByRole('button', { name: /socio registrado/i }));
+    await userEvent.type(screen.getByLabelText(/buscar socio/i), 'Ana');
+
+    expect(await screen.findByText('Ana García')).toBeInTheDocument();
+    expect(screen.getByText('Ana Ruiz')).toBeInTheDocument();
+    expect(capturedQ).toBe('Ana');
+  });
+
+  it('seleccionar un socio fija userId y limpia el lado externo (XOR)', async () => {
+    server.use(
+      http.get('/api/usuarios/buscar', () => HttpResponse.json([{ id: 7, nombre: 'Ana García' }]))
+    );
+
+    let latest: ParticipanteInput | null = null;
+    render(<Harness onValue={(v) => (latest = v)} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /socio registrado/i }));
+    await userEvent.type(screen.getByLabelText(/buscar socio/i), 'Ana');
+    await userEvent.click(await screen.findByRole('button', { name: 'Ana García' }));
+
+    expect(latest).not.toBeNull();
+    expect(latest!.userId).toBe(7);
+    expect(latest!.externalName).toBe('');
+    expect(participanteCompleto(latest!)).toBe(true);
+  });
+
+  it('término corto (<2) no dispara la búsqueda', async () => {
+    const spy = vi.fn();
+    server.use(
+      http.get('/api/usuarios/buscar', () => {
+        spy();
+        return HttpResponse.json([]);
+      })
+    );
+
+    render(<Harness />);
+    await userEvent.click(screen.getByRole('button', { name: /socio registrado/i }));
+    await userEvent.type(screen.getByLabelText(/buscar socio/i), 'A');
+
+    // Margen para un posible debounce; confirmamos que no se llamó.
+    await new Promise((r) => setTimeout(r, 350));
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('modo externo captura nombre y teléfono (sin userId)', async () => {
+    let latest: ParticipanteInput | null = null;
+    render(<Harness onValue={(v) => (latest = v)} />);
+
+    await userEvent.type(screen.getByLabelText(/nombre del compañero/i), 'Marcos R.');
+    await userEvent.type(screen.getByLabelText(/teléfono/i), '600111222');
+
+    expect(latest).not.toBeNull();
+    expect(latest!.externalName).toBe('Marcos R.');
+    expect(latest!.externalPhone).toBe('600111222');
+    expect(latest!.userId).toBeNull();
+  });
+});

--- a/frontend/src/test/reservas.navegacion.test.tsx
+++ b/frontend/src/test/reservas.navegacion.test.tsx
@@ -1,0 +1,84 @@
+// reservas-ui-jugador-fixes (Grupo 4) — navegación a Inicio desde las páginas de
+// reservas. Disponibilidad y Detalle exponen un control visible "Inicio" que lleva
+// a Home. (Confirmar y Mis Reservas se cubren en sus propias suites.)
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, afterEach } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { http, HttpResponse } from 'msw';
+import { AuthContext } from '../context/AuthContext';
+import { DisponibilidadPage } from '../pages/DisponibilidadPage';
+import { DetalleReservaPage } from '../pages/DetalleReservaPage';
+import { server } from './mocks/server';
+
+afterEach(() => server.resetHandlers());
+
+const authValue = {
+  accessToken: 'user.jwt.token',
+  role: 'USER',
+  mustChangePassword: false,
+  userId: 42,
+  isAuthenticated: true,
+  setAccessToken: () => {},
+  setSession: () => {},
+  clearMustChangePassword: () => {},
+  loadUserId: async () => {},
+};
+
+describe('Navegación a Inicio (Grupo 4)', () => {
+  it('Disponibilidad: "Inicio" navega a Home', async () => {
+    server.use(
+      http.get('/api/reservas/disponibles', () =>
+        HttpResponse.json({ fecha: '2026-07-10', tramosDisponibles: [] })
+      )
+    );
+    render(
+      <AuthContext.Provider value={authValue}>
+        <MemoryRouter initialEntries={['/reservas/disponibilidad']}>
+          <Routes>
+            <Route path="/reservas/disponibilidad" element={<DisponibilidadPage />} />
+            <Route path="/home" element={<div>Pantalla de inicio</div>} />
+          </Routes>
+        </MemoryRouter>
+      </AuthContext.Provider>
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /inicio/i }));
+    expect(await screen.findByText('Pantalla de inicio')).toBeInTheDocument();
+  });
+
+  it('Detalle: "Inicio" navega a Home', async () => {
+    server.use(
+      http.get('/api/reservas/r-1', () =>
+        HttpResponse.json({
+          id: 'r-1',
+          reservationDate: '2026-07-10',
+          startTime: '20:00',
+          endTime: '21:00',
+          durationMinutes: 60,
+          status: 'CONFIRMED',
+          channel: 'WEB',
+          ownerId: 42,
+          priceTotal: 16,
+          participants: [{ userId: 42, externalName: null, externalPhone: null, slotPosition: 1, owner: true }],
+          pago: null,
+          createdAt: 't',
+        })
+      )
+    );
+    render(
+      <AuthContext.Provider value={authValue}>
+        <MemoryRouter initialEntries={['/reservas/detalle/r-1']}>
+          <Routes>
+            <Route path="/reservas/detalle/:id" element={<DetalleReservaPage />} />
+            <Route path="/home" element={<div>Pantalla de inicio</div>} />
+          </Routes>
+        </MemoryRouter>
+      </AuthContext.Provider>
+    );
+
+    await screen.findByText('20:00');
+    await userEvent.click(screen.getByRole('button', { name: /inicio/i }));
+    expect(await screen.findByText('Pantalla de inicio')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/reservasApi.errors.test.ts
+++ b/frontend/src/test/reservasApi.errors.test.ts
@@ -1,0 +1,75 @@
+// reservas-ui-jugador-fixes (Grupo 1, D2) — mapeo de errores al contrato real.
+// El backend emite `{ error, message, timestamp, details? }`. Se verifica que:
+//  - 401 → AUTH_REQUIRED (sesión), diferenciado del genérico.
+//  - 400 VALIDATION_ERROR con `details` → el detalle queda disponible en `.details`.
+//  - 5xx → SERVER_ERROR (servidor), distinto de un error de datos.
+//  - error de red (sin respuesta) → NETWORK_ERROR.
+import { describe, it, expect, afterEach } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from './mocks/server';
+import { crearReserva, type CrearReservaPayload } from '../services/reservasApi';
+
+const TOKEN = 'user.jwt.token';
+const payload: CrearReservaPayload = {
+  reservationDate: '2026-07-10',
+  startTime: '20:00',
+  durationMinutes: 60,
+};
+
+afterEach(() => server.resetHandlers());
+
+describe('reservasApi — mapeo de errores (Grupo 1)', () => {
+  it('401 AUTH_REQUIRED se mapea a code AUTH_REQUIRED (tras fallar el refresh)', async () => {
+    server.use(
+      http.post('/api/reservas', () =>
+        HttpResponse.json({ error: 'AUTH_REQUIRED', message: 'token', timestamp: 't' }, { status: 401 })
+      ),
+      // El interceptor intentará refrescar; el refresh también falla (401).
+      http.post('/api/auth/refresh', () => HttpResponse.json({ error: 'AUTH_REQUIRED' }, { status: 401 }))
+    );
+
+    const err = await crearReserva(TOKEN, payload, 'k').catch((e) => e);
+    expect(err.code).toBe('AUTH_REQUIRED');
+    expect(err.status).toBe(401);
+  });
+
+  it('400 VALIDATION_ERROR con details expone el primer detalle en .details', async () => {
+    server.use(
+      http.post('/api/reservas', () =>
+        HttpResponse.json(
+          {
+            error: 'VALIDATION_ERROR',
+            message: 'Datos inválidos',
+            details: ['startTime debe estar en punto o y media'],
+            timestamp: 't',
+          },
+          { status: 400 }
+        )
+      )
+    );
+
+    const err = await crearReserva(TOKEN, payload, 'k').catch((e) => e);
+    expect(err.code).toBe('VALIDATION_ERROR');
+    expect(err.details[0]).toContain('startTime');
+  });
+
+  it('5xx se mapea a SERVER_ERROR (no a error de datos)', async () => {
+    server.use(
+      http.post('/api/reservas', () =>
+        HttpResponse.json({ error: 'INTERNAL', message: 'boom', timestamp: 't' }, { status: 500 })
+      )
+    );
+
+    const err = await crearReserva(TOKEN, payload, 'k').catch((e) => e);
+    expect(err.code).toBe('SERVER_ERROR');
+    expect(err.status).toBe(500);
+  });
+
+  it('error de red (sin respuesta) se mapea a NETWORK_ERROR', async () => {
+    server.use(http.post('/api/reservas', () => HttpResponse.error()));
+
+    const err = await crearReserva(TOKEN, payload, 'k').catch((e) => e);
+    expect(err.code).toBe('NETWORK_ERROR');
+    expect(err.status).toBe(0);
+  });
+});

--- a/openspec/changes/reservas-ui-jugador-fixes/.openspec.yaml
+++ b/openspec/changes/reservas-ui-jugador-fixes/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-05

--- a/openspec/changes/reservas-ui-jugador-fixes/design.md
+++ b/openspec/changes/reservas-ui-jugador-fixes/design.md
@@ -1,0 +1,71 @@
+## Context
+
+El change `reservas-ui-jugador` entregó las 4 páginas del jugador (Disponibilidad, Confirmar, Mis Reservas, Detalle) y el servicio `reservasApi.ts`. En uso real (2026-07-05) el flujo no se completa y faltan funcionalidades. La exploración del código confirma que **el backend ya soporta casi todo lo que falta**:
+
+- Duraciones {60,90,120,150,180} con `startTime` en minutos 00/30 (`CrearReservaService.ALLOWED_DURATIONS`, refuerzo por CHECK en `V7`). RN-RES: franjas de media hora.
+- XOR de participante `userId` (registrado) vs `externalName`/`externalPhone` (externo), owner en slot 1, límite `max_participants_per_pista` (422 `PARTICIPANTS_LIMIT_EXCEEDED`).
+- Cancelación `DELETE /api/reservas/{id}` con política de plazo (RN-RES-04) y refund del pago si estaba PAID.
+- Al crear, el backend congela el precio (RN-RES-03) y crea un `Payment` en `PENDING`.
+
+Los gaps son por tanto **de frontend**, con un delta de backend acotado: el endpoint de búsqueda de usuarios para el buscador de socios. El pago online Redsys (`pagos-redsys`) y el refresh de sesión (`auth-session-refresh`) son piezas grandes que se separan a changes propios.
+
+**Bug de creación — causa raíz confirmada (E2E 2026-07-05):** el backend crea la reserva (HTTP 201). Reproducido contra el stack real: `system_config` presente (500 descartado), el módulo reservas no envía email (SMTP descartado), y una franja futura con token válido → 201. El error que ve el usuario es un **401 `AUTH_REQUIRED`** por access token caducado (15 min, solo en memoria, sin refresh). El contrato de error real es `{ error, message, timestamp, details? }` (el código va en `error`, no en `code`; la lista es `details`, no `fieldErrors`); el frontend `messageForError` lee `err.fieldErrors` (inexistente) y `codeFromStatus` no contempla 401 → `UNKNOWN` → mensaje genérico. La corrección es de frontend: manejar el 401 (D2) y alinear el mapeo al contrato real.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Que una reserva válida se cree con éxito y que cada error muestre un mensaje específico (RN-RES-03/05).
+- Selector de duración 60/90/120 (backend ya acepta 150/180) en franjas de media hora.
+- Distinguir compañero registrado (`userId`) de invitado externo (`externalName`/`externalPhone`) en la UI, respetando el XOR del backend.
+- Volver a Inicio desde cualquier página de reservas.
+- "Mis Reservas" operativa: cancelar, ver estado de pago y elegir método de pago (diferido / ahora).
+- Entregar el núcleo (todo salvo "pagar ahora") **sin bloquear** con Redsys.
+
+**Non-Goals:**
+- Construir la pasarela Redsys completa (fase-2 `pagos-redsys`).
+- Vistas admin de reservas; unirse a partidas; notificaciones; rediseño visual.
+- Cambiar la lógica de dominio de creación/cancelación (ya correcta).
+
+## Decisions
+
+### D1 — Este change entrega el núcleo; el pago online Redsys va a un change propio
+Decidido en revisión: **este change (fase-1)** cubre bug de creación, selección de duración, tipos de participante, navegación Home y "Mis Reservas" con cancelar + estado de pago + método de pago con **"pago diferido" funcional**. La acción **"pagar ahora" queda como punto de entrada deshabilitado/informativo** ("disponible próximamente"). El **pago online Redsys se traslada a un change propio `pagos-redsys`** (fase-2), que se abordará cuando haya credenciales del comercio. Motiva RN-RES-03 (precio congelado por backend) y que Redsys no existe aún. *Alternativa descartada:* un único entregable con Redsys — bloquearía el valor inmediato (cancelar/duración/compañero) tras la integración de pasarela y credenciales.
+
+### D2 — Corrección del bug de creación: manejar el 401 de sesión caducada + alinear contrato de error
+**Causa raíz confirmada en vivo (E2E 2026-07-05):** el backend crea la reserva (HTTP 201); el error que ve el usuario es un **401 `AUTH_REQUIRED`** por access token caducado (TTL 900s, solo en memoria, sin refresh — ver `AuthContext.tsx`). `codeFromStatus` no contempla 401 → `UNKNOWN` → `messageForError` rama `default` → mensaje genérico. Decisión: en el flujo de reserva, **detectar el 401 y mostrar "sesión caducada" con redirección a login** (que el usuario se re-autentique y reanude), y **reescribir `messageForError`** para leer el contrato real (`error` como código, `details[0]` como detalle) en lugar de `fieldErrors`, de modo que 400/409/422 muestren mensaje específico. El backend **no** necesita cambios de dominio (verificado). Motiva RN-RES-05 (feedback claro). *Alternativa descartada:* silenciar/reintentar el 401 aquí con la cookie de refresh — es la solución correcta pero global; se separa a `auth-session-refresh` (ver D7) para no acoplar el arreglo de sesión al change de reservas.
+
+### D7 — El refresh silencioso de sesión es un change propio, no de reservas
+El defecto de fondo —access token de 15 min sin renovación— rompe **cualquier** escritura de la app tras 15 min; reservar es solo donde se detectó. La solución (interceptor axios que ante 401 llama a `POST /api/auth/refresh` con la cookie `refresh_token` de 7 días y reintenta la petición original) pertenece a `auth-local` y beneficia a toda la app. Decisión: **abordarlo en un change propio `auth-session-refresh`**; en *este* change solo el manejo local del 401 (D2). *Alternativa descartada:* meter el interceptor aquí — mezclaría un arreglo global de auth con una feature de reservas y complicaría la revisión y el archivado de specs.
+
+### D3 — Selector de duración (60/90/120) en la página de confirmación, filtrando por disponibilidad
+Decidido en revisión: la UI ofrece **60/90/120 min** (el backend acepta hasta 180, pero no se exponen 150/180 en esta fase). La duración pasa de valor fijo propagado por query-string a un selector con opciones válidas para la franja (no solaparse ni exceder el horario). El frontend deriva las opciones a partir de la disponibilidad ya consultada; si resulta insuficiente, se apoya en el 409 `CONFLICT` del backend como red de seguridad. Default 60 min. Motiva la RN de franjas de media hora. *Alternativa descartada:* elegir duración en Disponibilidad — obliga a recalcular tramos por cada duración; es más simple elegirla en Confirmar donde ya se conoce la franja base.
+
+### D4 — Participante: componente con conmutador "socio / externo"
+Cada fila de participante ofrece un conmutador de tipo. "Socio" muestra un buscador que consulta el endpoint de usuarios (D5) y fija `userId`; "externo" muestra nombre + teléfono y fija `externalName`/`externalPhone`. El payload envía exactamente uno (XOR), acorde a la validación del backend. *Alternativa descartada:* un único input de texto que "adivine" si es socio — ambiguo y propenso a errores; el backend exige XOR explícito.
+
+### D5 — Búsqueda de socios: buscador con endpoint mínimo de usuarios
+Decidido en revisión: **buscador de socios**. Se añade `GET` de búsqueda en `usuarios` que devuelve solo `id` + nombre, autenticado, con término mínimo y resultados acotados en tamaño. *Alternativa descartada:* pedir el email exacto del socio y resolverlo en el POST de reserva — evita el endpoint pero empeora la UX y filtra existencia de emails.
+
+### D6 — "Mis Reservas" con acciones inline
+Las tarjetas pasan de simple `Link` al detalle a incluir acciones: cancelar (reutiliza `DELETE /api/reservas/{id}`), badge de estado de pago (ya disponible en `ReservaResponse.pago`), y un control de método de pago. "Pago diferido" no llama a ningún endpoint (cobro presencial confirmado por admin, comportamiento actual). "Pagar ahora" queda deshabilitado/informativo hasta que se entregue el change `pagos-redsys`. Se mantiene el detalle para la vista completa.
+
+## Risks / Trade-offs
+
+- [El manejo local del 401 (mensaje + redirect) no evita que el usuario pierda el trabajo en curso al re-loguearse] → Mitigación aceptable en este change (el arreglo bueno es el refresh silencioso de `auth-session-refresh`, D7); documentar que reservar debe completarse dentro de la ventana de sesión hasta que ese change entregue el refresh.
+- [Filtrar duraciones válidas en cliente puede divergir de las reglas reales de solapamiento] → Mitigación: el 409 `CONFLICT` del backend sigue siendo la autoridad; el filtrado en cliente es solo UX, no regla de negocio.
+- [El endpoint de búsqueda de usuarios podría exponer el directorio de socios] → Mitigación: autenticación obligatoria, resultados mínimos (id+nombre), límite/paginación, y término mínimo antes de consultar.
+- [Ofrecer "pagar ahora" sin Redsys confunde al usuario] → Mitigación: la opción se muestra deshabilitada con texto "disponible próximamente"; solo se habilita al entregar el change `pagos-redsys`.
+- [El change hermano `reservas-ui-jugador` aún no está archivado; sus requirements no están en el spec principal] → Mitigación: los deltas de este change usan `ADDED` (no `MODIFIED`) para no depender de requirements aún no fusionados; al archivar ambos, sincronizar orden.
+
+## Migration Plan
+
+- Sin migraciones de base de datos en Fase A. Fase B (Redsys) reutiliza las columnas de gateway ya presentes en `Payment`; sin migración nueva prevista.
+- Despliegue Fase A: frontend + delta backend (mapeo de error, endpoint búsqueda) desplegables juntos; retrocompatibles (cambios aditivos). Rollback = revertir el frontend; el delta de backend es aditivo y no rompe consumidores existentes.
+- El pago online Redsys se despliega de forma independiente en el change `pagos-redsys` cuando esté listo y con credenciales del comercio configuradas.
+
+## Open Questions
+
+Resueltas en revisión (2026-07-05):
+- **Selector de socio** → buscador con endpoint de búsqueda de usuarios (D5).
+- **Pago online Redsys** → change propio `pagos-redsys`; aquí solo el punto de entrada deshabilitado (D1).
+- **Duraciones en UI** → 60/90/120 (D3).

--- a/openspec/changes/reservas-ui-jugador-fixes/proposal.md
+++ b/openspec/changes/reservas-ui-jugador-fixes/proposal.md
@@ -1,0 +1,52 @@
+## Why
+
+El change `reservas-ui-jugador` entregó las pantallas del jugador, pero en uso real (feedback 2026-07-05) el flujo central no se puede completar: **crear una reserva devuelve un error genérico** y varias funcionalidades acordadas no están: no se puede elegir la duración (solo 60 min), no se distingue un compañero registrado de uno externo, no hay forma de volver a Inicio, y **"Mis Reservas" no cumple su función** (solo enlaza al detalle; no permite cancelar, ver el estado del pago ni pagar). Sin estos ajustes, la funcionalidad núcleo del producto sigue siendo inutilizable para el jugador aunque la API ya soporte la mayor parte.
+
+**Causa raíz del error al crear, confirmada en vivo (E2E 2026-07-05):** el backend crea la reserva correctamente (HTTP 201); el fallo es de **sesión caducada en el frontend**. El access token JWT vive solo en memoria y caduca a los 15 min (900s), sin refresh silencioso ni interceptor de 401. Pasado ese tiempo, `POST /api/reservas` responde **401 `AUTH_REQUIRED`**, que el frontend no contempla (`codeFromStatus` ignora 401 → `UNKNOWN`) y traduce al mensaje genérico "No se pudo completar la reserva. Inténtalo de nuevo." No hay mensaje de "sesión caducada" ni redirección a login, así que reintentar vuelve a fallar. Es un defecto **global de sesión** (afecta a toda escritura de la app), no específico de reservas.
+
+## What Changes
+
+Corregir y completar la capa de interfaz del jugador. El backend ya soporta la mayoría de lo que falta; el grueso es frontend, con un delta de backend acotado para el bug de creación y (opcional) la búsqueda de socios.
+
+- **[BUG] Manejo de sesión caducada al crear reserva.** El frontend debe detectar el **401 `AUTH_REQUIRED`** y mostrar un mensaje claro de "sesión caducada" con **redirección a login**, en vez del genérico "No se pudo completar la reserva". Se corrige además el mapeo de errores para leer el contrato real (`error` como código + `details` como lista, no `err.fieldErrors`), de modo que 400/409/422 muestren mensaje específico. Una reserva válida con sesión vigente ya se crea con éxito (verificado: HTTP 201).
+  - **[Global, fuera de este change] Refresh silencioso de sesión.** El arreglo de fondo —interceptor que ante 401 renueva el access token con la cookie `refresh_token` (7 días) y reintenta— es un defecto de `auth-local` que afecta a toda la app; se aborda en un **change propio** (`auth-session-refresh`). Aquí solo se maneja el 401 localmente para que el jugador no quede atascado.
+
+- **Selector de duración** en el flujo de reserva: **60 / 90 / 120 min** en franjas de media hora, respetando `startTime` en minutos 00/30 (el backend acepta hasta 180, pero la UI ofrece estas tres). Hoy el frontend propaga una duración fija del tramo sin dar a elegir.
+
+- **Compañero registrado vs. invitado externo.** Al añadir un participante, distinguir dos tipos: (a) **socio registrado** — se elige mediante un **buscador de socios** (por nombre/email) y se envía `userId`; (b) **invitado externo** — se introduce nombre y teléfono y se envía `externalName`/`externalPhone`. El backend ya aplica el XOR `userId` vs `externalName`; falta la UI y un **endpoint nuevo de búsqueda de usuarios** que alimente el buscador.
+
+- **Navegación a Inicio** desde todas las páginas de reservas (Disponibilidad, Confirmar, Mis Reservas, Detalle): enlace/botón visible a Home. Hoy ninguna enlaza y el logo es texto estático.
+
+- **"Mis Reservas" funcional.** Desde la lista, para cada reserva: (a) **cancelar** (sin entrar al detalle); (b) **visualizar el estado del pago**; (c) **elegir método de pago**: *pago en diferido* (efectivo/presencial confirmado por el club — comportamiento actual del MVP) o *pagar ahora mediante Redsys*.
+
+- **"Pagar ahora" (Redsys) queda como punto de entrada deshabilitado.** La UI muestra la opción "pagar ahora" informativa/deshabilitada ("disponible próximamente"); el pago online se implementa en un **change propio `pagos-redsys`** (fuera de alcance aquí). Así cancelar + ver estado + pago en diferido se entregan **sin bloquear** con Redsys.
+
+## Capabilities
+
+### New Capabilities
+<!-- Ninguna capability nueva en este change. El pago online Redsys se aborda en un change propio `pagos-redsys` (ya existe el spec a nivel de diseño en openspec/specs/). -->
+
+### Modified Capabilities
+- `reservas`: se corrigen y amplían los requirements de la interfaz web del jugador — manejo de sesión caducada (401) al crear con mensaje claro + redirección a login, alineación del mapeo de error al contrato real, selección de duración, distinción de participante registrado vs. externo, navegación a Inicio, y acciones de cancelar / ver estado de pago / elegir método de pago desde "Mis Reservas" (con "pagar ahora" deshabilitado hasta el change `pagos-redsys`). La lógica de dominio del backend no cambia (crea reservas correctamente, ya soporta duraciones, XOR de participantes y cancelación); el arreglo del bug es de frontend.
+- `usuarios`: se añade un endpoint de **búsqueda de usuarios registrados** (por nombre/email, resultados mínimos: id + nombre) para alimentar el buscador de compañero registrado.
+
+## Impact
+
+- **Fase del producto**: fase-1 (`reservas` es fase-1; el pago diferido y las correcciones son fase-1). El pago online Redsys se aborda en el change propio `pagos-redsys` (fase-2), fuera de este change.
+- **Frontend** (`frontend/src/`): `reservasApi.ts` / `messageForError` (mapear 401 `AUTH_REQUIRED` a "sesión caducada" + alinear al contrato real `error`/`details`), `ConfirmarReservaPage` (manejo del 401 con redirección a login + selector de duración 60/90/120 + tipos de participante con buscador de socios), `MisReservasPage` (acciones cancelar / estado pago / método de pago con "pagar ahora" deshabilitado), navegación a Home en las 4 páginas, `reservasApi.ts` (búsqueda de usuarios). Nuevos componentes de selector de participante y de método de pago.
+- **Backend** (`backend/src/main/java/com/padelpro/`):
+  - `reservas`: sin cambios de dominio (crea reservas correctamente). Verificar únicamente el contrato del cuerpo de error (`error` + `details`) que consume el frontend.
+  - `usuarios`: endpoint `GET` de búsqueda de usuarios (nombre/email, paginado/limit, resultados mínimos id+nombre).
+- **Contrato / `docs/openapi.yaml`**: documentar el endpoint de búsqueda de usuarios; alinear el schema del cuerpo de error de reservas con lo que emite el backend.
+- **Datos / migraciones**: ninguna.
+- **Sin impacto** en autenticación, roles ni en el cálculo de disponibilidad.
+
+## Fuera de alcance
+
+- **Refresh silencioso de sesión / interceptor global de 401** (renovar el access token con la cookie `refresh_token` y reintentar la petición) — es un defecto global de `auth-local` que se aborda en un **change propio `auth-session-refresh`**. Este change solo maneja el 401 localmente en el flujo de reserva (mensaje "sesión caducada" + redirección a login).
+- **Pago online Redsys completo** (iniciar pago, firma HMAC, TPV, webhook, conciliación) — se traslada a un **change propio `pagos-redsys`**; este change solo deja el punto de entrada "pagar ahora" en la UI, deshabilitado e informativo.
+- Vistas de administración de reservas (calendario semanal, tabla del club, confirmar/cambiar estado desde UI) — change posterior.
+- Unirse a partidas / ocupar plazas libres de reservas de terceros — capability `partidas`.
+- Notificaciones de reserva (email/Telegram) — capability `notificaciones`.
+- Reembolsos automáticos más allá del marcado de estado existente al cancelar.
+- Rediseño visual de las pantallas; se mantienen los design tokens y mockups actuales.

--- a/openspec/changes/reservas-ui-jugador-fixes/specs/reservas/spec.md
+++ b/openspec/changes/reservas-ui-jugador-fixes/specs/reservas/spec.md
@@ -1,0 +1,87 @@
+## ADDED Requirements
+
+### Requirement: Manejo de sesión caducada al crear reserva (UI jugador)
+Cuando `POST /api/reservas` responde **401 `AUTH_REQUIRED`** (access token caducado o ausente), la UI SHALL mostrar un mensaje claro de sesión caducada y SHALL ofrecer/realizar la **redirección a la pantalla de login**, en lugar del mensaje genérico "No se pudo completar la reserva". No SHALL sugerir "reintentar" la misma petición sin re-autenticar.
+
+#### Scenario: Sesión caducada al confirmar
+- **WHEN** el usuario confirma la reserva y el backend responde 401 `AUTH_REQUIRED`
+- **THEN** la UI muestra "tu sesión ha caducado, vuelve a iniciar sesión" y lleva al usuario a la pantalla de login
+
+#### Scenario: Reserva válida con sesión vigente se crea con éxito
+- **WHEN** el usuario confirma una franja libre y futura con datos válidos y sesión no caducada
+- **THEN** el backend responde 201 y la UI muestra la reserva creada (estado pendiente de confirmación), sin ningún mensaje de error
+
+### Requirement: Manejo de errores accionable al crear reserva (UI jugador)
+La UI de confirmación de reserva SHALL traducir cada error del backend a un mensaje específico y accionable, leyendo el contrato de error real (`error` como código + `details` como lista), y SHALL reservar el mensaje genérico "No se pudo completar la reserva" únicamente para fallos verdaderamente desconocidos (5xx sin código o error de red).
+
+#### Scenario: Error de validación muestra el detalle del backend
+- **WHEN** el backend responde 400 `VALIDATION_ERROR` con `details` no vacío
+- **THEN** la UI muestra el primer detalle del backend (p. ej. el campo inválido), no el mensaje genérico
+
+#### Scenario: Franja no futura
+- **WHEN** el usuario intenta reservar una franja cuya fecha+hora ya pasó
+- **THEN** la UI muestra un mensaje claro indicando que la franja ya no es reservable y ofrece volver a disponibilidad
+
+#### Scenario: Fallo interno del servidor no se enmascara como dato inválido
+- **WHEN** el backend responde 5xx
+- **THEN** la UI muestra un mensaje de error del servidor con opción de reintentar, distinto de un error de datos del usuario
+
+### Requirement: Selección de duración de la reserva (UI jugador)
+La UI de reserva SHALL permitir al usuario elegir la duración entre **60, 90 y 120 minutos** en franjas de media hora, y SHALL enviar la duración elegida en `durationMinutes`. El `startTime` SHALL mantenerse en minutos 00 o 30. (El backend acepta también 150 y 180; la UI no los ofrece en esta fase.)
+
+#### Scenario: Elegir duración de 90 minutos
+- **WHEN** el usuario selecciona una franja y elige duración 90 min
+- **THEN** la UI envía `durationMinutes: 90` y el resumen refleja "90 min"
+
+#### Scenario: Solo se ofrecen duraciones válidas para la franja
+- **WHEN** una duración haría que la reserva solape con otra o supere el horario disponible
+- **THEN** esa duración no se ofrece como opción seleccionable
+
+#### Scenario: Duración por defecto
+- **WHEN** el usuario abre la confirmación sin elegir duración
+- **THEN** la UI preselecciona 60 min como valor por defecto
+
+### Requirement: Distinción entre compañero registrado e invitado externo (UI jugador)
+Al añadir un participante adicional, la UI SHALL permitir elegir entre (a) **socio registrado** —seleccionado de entre los usuarios dados de alta, enviando `userId`— o (b) **invitado externo** —introduciendo nombre y teléfono, enviando `externalName`/`externalPhone`—. La UI SHALL enviar exactamente uno de los dos (XOR), acorde a la validación del backend.
+
+#### Scenario: Añadir un socio registrado
+- **WHEN** el usuario elige el tipo "socio registrado" y selecciona un usuario de la lista
+- **THEN** el participante se envía con `userId` y sin `externalName`
+
+#### Scenario: Añadir un invitado externo
+- **WHEN** el usuario elige el tipo "invitado externo" e introduce nombre y teléfono
+- **THEN** el participante se envía con `externalName` (y `externalPhone` si se indicó) y sin `userId`
+
+#### Scenario: No se permite un participante ambiguo o vacío
+- **WHEN** un participante no tiene ni socio seleccionado ni nombre externo
+- **THEN** la UI impide continuar y señala que debe completarse ese participante
+
+### Requirement: Navegación a Inicio desde las páginas de reservas (UI jugador)
+Cada página del flujo de reservas (disponibilidad, confirmar, mis reservas, detalle) SHALL ofrecer un control visible para volver a la pantalla de Inicio (Home).
+
+#### Scenario: Volver a Inicio desde cualquier página de reservas
+- **WHEN** el usuario está en cualquiera de las páginas de reservas y activa el control de Inicio
+- **THEN** la aplicación navega a la pantalla Home
+
+### Requirement: Acciones sobre la reserva desde "Mis Reservas" (UI jugador)
+La pantalla "Mis Reservas" SHALL permitir, por cada reserva y sin necesidad de entrar al detalle: (a) **cancelar** la reserva cuando proceda según su estado y propiedad; (b) **visualizar el estado del pago**; (c) **elegir el método de pago** entre *pago en diferido* (presencial/efectivo confirmado por el club) o *pagar ahora* (pago online, dependiente de la capability `pagos-redsys`).
+
+#### Scenario: Cancelar desde la lista
+- **WHEN** el usuario es owner de una reserva cancelable y activa "Cancelar" en su tarjeta
+- **THEN** la reserva se cancela (DELETE `/api/reservas/{id}`) y la lista refleja el nuevo estado
+
+#### Scenario: Ver estado de pago
+- **WHEN** la reserva tiene un pago asociado
+- **THEN** la tarjeta muestra el estado del pago (p. ej. pendiente / pagado)
+
+#### Scenario: Elegir pago en diferido
+- **WHEN** el usuario elige "pago en diferido" para una reserva pendiente de pago
+- **THEN** la UI indica que el cobro se realizará de forma presencial y no inicia ningún pago online
+
+#### Scenario: Elegir pagar ahora sin pasarela disponible
+- **WHEN** el usuario elige "pagar ahora" y la capability `pagos-redsys` aún no está disponible
+- **THEN** la UI comunica que el pago online no está disponible todavía y mantiene la opción de pago en diferido
+
+#### Scenario: Acción no disponible por estado
+- **WHEN** una reserva está en un estado no cancelable o ya pagada
+- **THEN** la UI no ofrece la acción correspondiente y lo refleja visualmente

--- a/openspec/changes/reservas-ui-jugador-fixes/specs/usuarios/spec.md
+++ b/openspec/changes/reservas-ui-jugador-fixes/specs/usuarios/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Búsqueda de usuarios registrados para selección de compañero
+El sistema SHALL exponer un endpoint autenticado para buscar usuarios registrados por nombre o email, devolviendo un conjunto mínimo de datos (id y nombre para mostrar) suficiente para alimentar el selector de compañero registrado en la UI de reserva. Los resultados SHALL estar limitados en tamaño (paginación o límite) para evitar exponer el directorio completo de una sola vez.
+
+#### Scenario: Buscar por término coincidente
+- **WHEN** un usuario autenticado busca por un término que coincide con el nombre o email de socios existentes
+- **THEN** el endpoint devuelve una lista acotada de usuarios con al menos `id` y nombre para mostrar
+
+#### Scenario: Sin coincidencias
+- **WHEN** el término de búsqueda no coincide con ningún usuario
+- **THEN** el endpoint devuelve una lista vacía y código 200
+
+#### Scenario: Requiere autenticación
+- **WHEN** se llama al endpoint sin credenciales válidas
+- **THEN** el endpoint responde 401 y no devuelve datos de usuarios
+
+#### Scenario: No expone datos sensibles
+- **WHEN** el endpoint devuelve resultados
+- **THEN** cada resultado incluye únicamente los campos mínimos para el selector (id, nombre) y no datos sensibles (p. ej. hash de contraseña, roles internos)

--- a/openspec/changes/reservas-ui-jugador-fixes/tasks.md
+++ b/openspec/changes/reservas-ui-jugador-fixes/tasks.md
@@ -41,9 +41,9 @@
 
 ## 6. QA Fase A
 
-- [ ] 6.1 **[Refactor]** Limpieza del delta manteniendo la suite en verde
-- [ ] 6.2 `verification-specialist`: build + tests (frontend vitest, backend maven) + lint del delta
-- [ ] 6.3 `reality-checker`: journey end-to-end del jugador (buscar → elegir duración → añadir compañero socio y externo → confirmar → ver en Mis Reservas → cancelar → volver a Inicio) contra el stack real
+- [x] 6.1 **[Refactor]** Limpieza del delta manteniendo la suite en verde — helpers extraídos (`participanteModel.ts`), sin deuda
+- [x] 6.2 `verification-specialist`: PASS — backend IT 34 verdes (contra PG real :5433), frontend 155/155, tsc/eslint limpios. security-auditor: 0 críticos/altos; MEDIO (validar userId participante) corregido; rate-limit del buscador y oráculo email evaluados como aceptables/defensa en profundidad (seguimiento)
+- [ ] 6.3 `reality-checker`: journey end-to-end del jugador (buscar → elegir duración → añadir compañero socio y externo → confirmar → ver en Mis Reservas → cancelar → volver a Inicio) — **PENDIENTE de live E2E: requiere desplegar el build de la rama; cubierto a nivel de contrato/unidad por IT backend + tests MSW frontend**
 - [x] 6.4 Actualizar `docs/openapi.yaml` (endpoint búsqueda de usuarios; alinear schema del cuerpo de error de reservas con lo que emite el backend) — `ErrorResponse` reescrito a `{ error, message, timestamp, details[]:string }` (el schema viejo `{ code, message, errors[]:FieldError }` no coincidía con `ErrorResponse.java` + `GlobalExceptionHandler`); `FieldError` eliminado (quedaba huérfano).
 
 ### Notas — pasada de correcciones de seguridad/hardening (backend, #188)

--- a/openspec/changes/reservas-ui-jugador-fixes/tasks.md
+++ b/openspec/changes/reservas-ui-jugador-fixes/tasks.md
@@ -1,0 +1,51 @@
+# Corrección y mejora de la UI de reservas del jugador (fase-1)
+
+> Orden TDD (Red → Green → Refactor) en cada grupo: primero el/los test(s) que fallan, luego la implementación mínima que los pone en verde. Agente `tester-tdd` para el andamiaje; `test-runner` para ejecutar.
+>
+> Decisiones de revisión (2026-07-05): buscador de socios (endpoint nuevo) · duraciones 60/90/120 · pago online Redsys → change propio `pagos-redsys` (aquí "pagar ahora" queda deshabilitado).
+
+## 1. Bug de creación de reserva — sesión caducada (D2)
+
+> Causa raíz confirmada en vivo (E2E 2026-07-05): el backend crea la reserva (201); el usuario ve un **401 `AUTH_REQUIRED`** por token caducado que el frontend traduce al mensaje genérico. El refresh silencioso es un change aparte (`auth-session-refresh`, D7); aquí se maneja el 401 localmente.
+
+- [ ] 1.1 **[Red]** Test frontend: `POST /api/reservas` → 401 `AUTH_REQUIRED` → la UI muestra "sesión caducada" y redirige a login (hoy cae al genérico "No se pudo completar la reserva")
+- [ ] 1.2 **[Red]** Test frontend: 400 `VALIDATION_ERROR` con `details` → la UI muestra el detalle; 5xx → mensaje de servidor con reintentar; hoy ambos caen al genérico
+- [ ] 1.3 **[Green]** `reservasApi.ts`/`messageForError`: mapear 401 `AUTH_REQUIRED` a error de sesión; leer código en `error` y detalle en `details[0]` (no `fieldErrors`); diferenciar 4xx (datos) de 5xx (servidor); genérico solo para 5xx sin código / error de red
+- [ ] 1.4 **[Green]** `ConfirmarReservaPage`: ante error de sesión, mensaje claro + redirección a login (sin sugerir "reintentar" la misma petición)
+- [ ] 1.5 **[Green]** Verificar reserva válida con sesión vigente → 201 sin error (test del camino feliz en verde)
+
+## 2. Selector de duración (D3)
+
+- [ ] 2.1 **[Red]** Test: elegir 90 min envía `durationMinutes:90`; duración que solaparía la franja no se ofrece; default 60 min
+- [ ] 2.2 **[Green]** Selector de duración 60/90/120 en confirmación, default 60, enviando `durationMinutes` y reflejándolo en el resumen
+- [ ] 2.3 **[Green]** Filtrar opciones según disponibilidad de la franja (no solapar / no exceder horario); 409 del backend como red de seguridad
+
+## 3. Compañero registrado vs. externo (D4, D5)
+
+- [ ] 3.1 **[Red]** Test backend del endpoint de búsqueda de usuarios: coincidencias devuelven id+nombre; sin coincidencias 200 vacío; sin auth 401; no expone datos sensibles
+- [ ] 3.2 **[Green]** Endpoint `GET` de búsqueda de usuarios por nombre/email, autenticado, término mínimo, resultados mínimos (id+nombre) y acotados; documentar en `docs/openapi.yaml`
+- [ ] 3.3 **[Red]** Test frontend: socio → payload con `userId` sin `externalName`; externo → `externalName`(+phone) sin `userId`; participante ambiguo/vacío bloquea el submit (XOR)
+- [ ] 3.4 **[Green]** Componente de participante con conmutador "socio registrado / invitado externo"; modo socio (buscador de socios → `userId`) y modo externo (nombre + teléfono → `externalName`/`externalPhone`); construir payload XOR
+
+## 4. Navegación a Inicio (spec: navegación)
+
+- [ ] 4.1 **[Red]** Test: desde cada página de reservas (Disponibilidad, Confirmar, Mis Reservas, Detalle) el control "Inicio" navega a Home
+- [ ] 4.2 **[Green]** Añadir el control visible "volver a Inicio" en las 4 páginas
+
+## 5. "Mis Reservas" funcional — sin pago online (D6)
+
+- [ ] 5.1 **[Red]** Test: cancelar desde la lista actualiza el estado; estado de pago visible en la tarjeta; "pago diferido" no dispara pago; "pagar ahora" informa indisponibilidad; acciones ocultas según estado
+- [ ] 5.2 **[Green]** Estado de pago por tarjeta (desde `ReservaResponse.pago`)
+- [ ] 5.3 **[Green]** Acción "Cancelar" inline (reutiliza `DELETE /api/reservas/{id}`), visible solo si owner y estado cancelable; refrescar lista tras cancelar
+- [ ] 5.4 **[Green]** Control de método de pago por reserva: "pago en diferido" (sin llamada, cobro presencial) y "pagar ahora" (deshabilitado/informativo "disponible próximamente" hasta Fase B); inhabilitar acciones no aplicables por estado
+
+## 6. QA Fase A
+
+- [ ] 6.1 **[Refactor]** Limpieza del delta manteniendo la suite en verde
+- [ ] 6.2 `verification-specialist`: build + tests (frontend vitest, backend maven) + lint del delta
+- [ ] 6.3 `reality-checker`: journey end-to-end del jugador (buscar → elegir duración → añadir compañero socio y externo → confirmar → ver en Mis Reservas → cancelar → volver a Inicio) contra el stack real
+- [ ] 6.4 Actualizar `docs/openapi.yaml` (endpoint búsqueda de usuarios; alinear schema del cuerpo de error de reservas con lo que emite el backend)
+
+---
+
+> **Pago online Redsys** ("pagar ahora") se aborda en un **change propio `pagos-redsys`** (fase-2), fuera de este change. Aquí la opción queda deshabilitada/informativa (tarea 5.4). Ese change cubrirá: endpoint de iniciar pago (firma HMAC SHA-256, importe congelado, solo owner), webhook idempotente de confirmación, habilitar "pagar ahora" + pantalla de retorno en la UI, y QA de seguridad (`security-auditor`) y end-to-end (`reality-checker`) en el entorno de pruebas Redsys.

--- a/openspec/changes/reservas-ui-jugador-fixes/tasks.md
+++ b/openspec/changes/reservas-ui-jugador-fixes/tasks.md
@@ -8,36 +8,36 @@
 
 > Causa raíz confirmada en vivo (E2E 2026-07-05): el backend crea la reserva (201); el usuario ve un **401 `AUTH_REQUIRED`** por token caducado que el frontend traduce al mensaje genérico. El refresh silencioso es un change aparte (`auth-session-refresh`, D7); aquí se maneja el 401 localmente.
 
-- [ ] 1.1 **[Red]** Test frontend: `POST /api/reservas` → 401 `AUTH_REQUIRED` → la UI muestra "sesión caducada" y redirige a login (hoy cae al genérico "No se pudo completar la reserva")
-- [ ] 1.2 **[Red]** Test frontend: 400 `VALIDATION_ERROR` con `details` → la UI muestra el detalle; 5xx → mensaje de servidor con reintentar; hoy ambos caen al genérico
-- [ ] 1.3 **[Green]** `reservasApi.ts`/`messageForError`: mapear 401 `AUTH_REQUIRED` a error de sesión; leer código en `error` y detalle en `details[0]` (no `fieldErrors`); diferenciar 4xx (datos) de 5xx (servidor); genérico solo para 5xx sin código / error de red
-- [ ] 1.4 **[Green]** `ConfirmarReservaPage`: ante error de sesión, mensaje claro + redirección a login (sin sugerir "reintentar" la misma petición)
-- [ ] 1.5 **[Green]** Verificar reserva válida con sesión vigente → 201 sin error (test del camino feliz en verde)
+- [x] 1.1 **[Red]** Test frontend: `POST /api/reservas` → 401 `AUTH_REQUIRED` → la UI muestra "sesión caducada" y redirige a login (hoy cae al genérico "No se pudo completar la reserva")
+- [x] 1.2 **[Red]** Test frontend: 400 `VALIDATION_ERROR` con `details` → la UI muestra el detalle; 5xx → mensaje de servidor con reintentar; hoy ambos caen al genérico
+- [x] 1.3 **[Green]** `reservasApi.ts`/`messageForError`: mapear 401 `AUTH_REQUIRED` a error de sesión; leer código en `error` y detalle en `details[0]` (no `fieldErrors`); diferenciar 4xx (datos) de 5xx (servidor); genérico solo para 5xx sin código / error de red
+- [x] 1.4 **[Green]** `ConfirmarReservaPage`: ante error de sesión, mensaje claro + redirección a login (sin sugerir "reintentar" la misma petición)
+- [x] 1.5 **[Green]** Verificar reserva válida con sesión vigente → 201 sin error (test del camino feliz en verde)
 
 ## 2. Selector de duración (D3)
 
-- [ ] 2.1 **[Red]** Test: elegir 90 min envía `durationMinutes:90`; duración que solaparía la franja no se ofrece; default 60 min
-- [ ] 2.2 **[Green]** Selector de duración 60/90/120 en confirmación, default 60, enviando `durationMinutes` y reflejándolo en el resumen
-- [ ] 2.3 **[Green]** Filtrar opciones según disponibilidad de la franja (no solapar / no exceder horario); 409 del backend como red de seguridad
+- [x] 2.1 **[Red]** Test: elegir 90 min envía `durationMinutes:90`; duración que solaparía la franja no se ofrece; default 60 min
+- [x] 2.2 **[Green]** Selector de duración 60/90/120 en confirmación, default 60, enviando `durationMinutes` y reflejándolo en el resumen
+- [x] 2.3 **[Green]** Filtrar opciones según disponibilidad de la franja (no solapar / no exceder horario); 409 del backend como red de seguridad
 
 ## 3. Compañero registrado vs. externo (D4, D5)
 
 - [x] 3.1 **[Red]** Test backend del endpoint de búsqueda de usuarios: coincidencias devuelven id+nombre; sin coincidencias 200 vacío; sin auth 401; no expone datos sensibles
 - [x] 3.2 **[Green]** Endpoint `GET` de búsqueda de usuarios por nombre/email, autenticado, término mínimo, resultados mínimos (id+nombre) y acotados; documentar en `docs/openapi.yaml`
-- [ ] 3.3 **[Red]** Test frontend: socio → payload con `userId` sin `externalName`; externo → `externalName`(+phone) sin `userId`; participante ambiguo/vacío bloquea el submit (XOR)
-- [ ] 3.4 **[Green]** Componente de participante con conmutador "socio registrado / invitado externo"; modo socio (buscador de socios → `userId`) y modo externo (nombre + teléfono → `externalName`/`externalPhone`); construir payload XOR
+- [x] 3.3 **[Red]** Test frontend: socio → payload con `userId` sin `externalName`; externo → `externalName`(+phone) sin `userId`; participante ambiguo/vacío bloquea el submit (XOR)
+- [x] 3.4 **[Green]** Componente de participante con conmutador "socio registrado / invitado externo"; modo socio (buscador de socios → `userId`) y modo externo (nombre + teléfono → `externalName`/`externalPhone`); construir payload XOR
 
 ## 4. Navegación a Inicio (spec: navegación)
 
-- [ ] 4.1 **[Red]** Test: desde cada página de reservas (Disponibilidad, Confirmar, Mis Reservas, Detalle) el control "Inicio" navega a Home
-- [ ] 4.2 **[Green]** Añadir el control visible "volver a Inicio" en las 4 páginas
+- [x] 4.1 **[Red]** Test: desde cada página de reservas (Disponibilidad, Confirmar, Mis Reservas, Detalle) el control "Inicio" navega a Home
+- [x] 4.2 **[Green]** Añadir el control visible "volver a Inicio" en las 4 páginas
 
 ## 5. "Mis Reservas" funcional — sin pago online (D6)
 
-- [ ] 5.1 **[Red]** Test: cancelar desde la lista actualiza el estado; estado de pago visible en la tarjeta; "pago diferido" no dispara pago; "pagar ahora" informa indisponibilidad; acciones ocultas según estado
-- [ ] 5.2 **[Green]** Estado de pago por tarjeta (desde `ReservaResponse.pago`)
-- [ ] 5.3 **[Green]** Acción "Cancelar" inline (reutiliza `DELETE /api/reservas/{id}`), visible solo si owner y estado cancelable; refrescar lista tras cancelar
-- [ ] 5.4 **[Green]** Control de método de pago por reserva: "pago en diferido" (sin llamada, cobro presencial) y "pagar ahora" (deshabilitado/informativo "disponible próximamente" hasta Fase B); inhabilitar acciones no aplicables por estado
+- [x] 5.1 **[Red]** Test: cancelar desde la lista actualiza el estado; estado de pago visible en la tarjeta; "pago diferido" no dispara pago; "pagar ahora" informa indisponibilidad; acciones ocultas según estado
+- [x] 5.2 **[Green]** Estado de pago por tarjeta (desde `ReservaResponse.pago`)
+- [x] 5.3 **[Green]** Acción "Cancelar" inline (reutiliza `DELETE /api/reservas/{id}`), visible solo si owner y estado cancelable; refrescar lista tras cancelar
+- [x] 5.4 **[Green]** Control de método de pago por reserva: "pago en diferido" (sin llamada, cobro presencial) y "pagar ahora" (deshabilitado/informativo "disponible próximamente" hasta Fase B); inhabilitar acciones no aplicables por estado
 
 ## 6. QA Fase A
 

--- a/openspec/changes/reservas-ui-jugador-fixes/tasks.md
+++ b/openspec/changes/reservas-ui-jugador-fixes/tasks.md
@@ -22,8 +22,8 @@
 
 ## 3. Compañero registrado vs. externo (D4, D5)
 
-- [ ] 3.1 **[Red]** Test backend del endpoint de búsqueda de usuarios: coincidencias devuelven id+nombre; sin coincidencias 200 vacío; sin auth 401; no expone datos sensibles
-- [ ] 3.2 **[Green]** Endpoint `GET` de búsqueda de usuarios por nombre/email, autenticado, término mínimo, resultados mínimos (id+nombre) y acotados; documentar en `docs/openapi.yaml`
+- [x] 3.1 **[Red]** Test backend del endpoint de búsqueda de usuarios: coincidencias devuelven id+nombre; sin coincidencias 200 vacío; sin auth 401; no expone datos sensibles
+- [x] 3.2 **[Green]** Endpoint `GET` de búsqueda de usuarios por nombre/email, autenticado, término mínimo, resultados mínimos (id+nombre) y acotados; documentar en `docs/openapi.yaml`
 - [ ] 3.3 **[Red]** Test frontend: socio → payload con `userId` sin `externalName`; externo → `externalName`(+phone) sin `userId`; participante ambiguo/vacío bloquea el submit (XOR)
 - [ ] 3.4 **[Green]** Componente de participante con conmutador "socio registrado / invitado externo"; modo socio (buscador de socios → `userId`) y modo externo (nombre + teléfono → `externalName`/`externalPhone`); construir payload XOR
 

--- a/openspec/changes/reservas-ui-jugador-fixes/tasks.md
+++ b/openspec/changes/reservas-ui-jugador-fixes/tasks.md
@@ -44,7 +44,13 @@
 - [ ] 6.1 **[Refactor]** Limpieza del delta manteniendo la suite en verde
 - [ ] 6.2 `verification-specialist`: build + tests (frontend vitest, backend maven) + lint del delta
 - [ ] 6.3 `reality-checker`: journey end-to-end del jugador (buscar → elegir duración → añadir compañero socio y externo → confirmar → ver en Mis Reservas → cancelar → volver a Inicio) contra el stack real
-- [ ] 6.4 Actualizar `docs/openapi.yaml` (endpoint búsqueda de usuarios; alinear schema del cuerpo de error de reservas con lo que emite el backend)
+- [x] 6.4 Actualizar `docs/openapi.yaml` (endpoint búsqueda de usuarios; alinear schema del cuerpo de error de reservas con lo que emite el backend) — `ErrorResponse` reescrito a `{ error, message, timestamp, details[]:string }` (el schema viejo `{ code, message, errors[]:FieldError }` no coincidía con `ErrorResponse.java` + `GlobalExceptionHandler`); `FieldError` eliminado (quedaba huérfano).
+
+### Notas — pasada de correcciones de seguridad/hardening (backend, #188)
+
+- **[MEDIO — seguridad] Validar `userId` de participante registrado.** `CrearReservaService.addAdditionalParticipants` ahora valida que un participante con `userId` exista y esté `ACTIVE` vía el nuevo puerto `UserRepositoryPort.existsByIdAndStatus(id, ACTIVE)`; si no, lanza `InvalidReservaStateException("PARTICIPANT_NOT_FOUND", …)` → 422 (rollback, no persiste). La FK `participants.user_id → users(id)` (`fk_part_user`, `ON DELETE SET NULL`) **ya existía** en `V7`; no se añadió migración. Tests IT: userId inexistente → 422, userId no-ACTIVE → 422, userId ACTIVE → 201.
+- **[Gap de test] Exclusión de no-ACTIVE en la búsqueda.** Nuevo test en `UsuariosBuscarControllerIntegrationTest`: usuarios PENDING e INACTIVE con nombre coincidente NO aparecen (solo ACTIVE).
+- **[BAJO — hardening] `ESCAPE '\'` explícito en el LIKE.** `UserRepository.searchByNameOrEmail` añade `ESCAPE '\\'` a las 4 cláusulas LIKE; test de regresión: término con `%` no vuelca el directorio.
 
 ---
 


### PR DESCRIPTION
## Resumen

Corrige los 5 problemas reportados (2026-07-05) sobre la UI de reservas del jugador (#184).

1. **Bug "no puedo reservar"** — la causa raíz (sesión caducada) se resolvió en #186 (refresh silencioso). Aquí: mapeo de error alineado al contrato real del backend (`error`/`details`, no `fieldErrors`) y fallback local del 401 → login.
2. **Compañero registrado vs externo** — nuevo `ParticipanteSelector` con conmutador socio (buscador → `userId`) / invitado externo (nombre+teléfono → `externalName`/`externalPhone`), XOR estricto. Nuevo endpoint `GET /api/usuarios/buscar` (autenticado, solo id+nombre, solo ACTIVE).
3. **Selector de duración** 60/90/120 en franjas de media hora (default 60).
4. **Volver a Inicio** desde las 4 páginas de reservas.
5. **Mis Reservas funcional** — cancelar inline, estado de pago, método de pago (diferido / "pagar ahora" deshabilitado → change `pagos-redsys`).

## Issues vinculados

- Closes #188

## Seguridad (security-auditor: 0 críticos/altos)

- **MEDIO corregido**: `CrearReservaService` ahora valida que el `userId` de un participante registrado exista y esté ACTIVE → 422 `PARTICIPANT_NOT_FOUND` (antes se aceptaba cualquier id). FK `participants.user_id → users` ya existía.
- Buscador: query parametrizada, `ESCAPE '\'` explícito en LIKE, término mín. 2, cap 10, sin PII (solo id+nombre), sin logging del término.
- Diferido (defensa en profundidad, no bloqueante): rate-limit por usuario en el buscador; reevaluar matching por email; auditar inclusión de participantes.

## Spec / Docs

Change OpenSpec: `openspec/changes/reservas-ui-jugador-fixes/` · `docs/openapi.yaml` (`/usuarios/buscar` + `ErrorResponse` alineado al backend real).

## Testing

- [x] Backend IT: 34 verdes contra Postgres real (incl. validación de participante, exclusión no-ACTIVE, wildcard escapado).
- [x] Frontend: 155/155 (duración, ParticipanteSelector XOR, navegación, Mis Reservas, mapeo de error/401).
- [x] tsc + eslint limpios. verification-specialist: PASS.
- [ ] **Live E2E del journey (reality-checker): diferido** — requiere desplegar este build; cubierto por IT + tests MSW. Validar en CI/staging tras merge.

🤖 Generado con Claude Code (orchestrator agent)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authenticated user search with minimal result details.
  * Introduced a participant selector for choosing a registered user or entering an external guest.
  * Added duration selection and clearer navigation to the home screen across reservation pages.
  * Expanded “My Reservations” with payment status, deferred payment, and cancel actions.

* **Bug Fixes**
  * Improved handling for expired sessions by redirecting to login.
  * Updated reservation errors to show clearer, more specific messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->