### PR TITLE
feat(partidas): ver y unirse a partidas abiertas (#191)

### DIFF
--- a/backend/src/main/java/com/padelpro/auth/domain/port/out/UserRepositoryPort.java
+++ b/backend/src/main/java/com/padelpro/auth/domain/port/out/UserRepositoryPort.java
@@ -50,6 +50,16 @@ public interface UserRepositoryPort {
     Optional<User> findById(Long id);
 
     /**
+     * Batch-load users by id (anti-N+1). Used to resolve participant display names for the
+     * open-matches listing without one query per participant. The signature coincides with
+     * {@code JpaRepository.findAllById} under type erasure, so the Spring Data proxy supplies it.
+     *
+     * @param ids the user ids to fetch
+     * @return the matching users (order/size not guaranteed to match {@code ids})
+     */
+    List<User> findAllById(Iterable<Long> ids);
+
+    /**
      * Check if another user (different id) already uses this email.
      * Used to detect email conflicts on profile updates.
      */

--- a/backend/src/main/java/com/padelpro/auth/infrastructure/web/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/padelpro/auth/infrastructure/web/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import com.padelpro.auth.domain.exception.TokenInvalidException;
 import com.padelpro.auth.domain.exception.ValidationException;
 import com.padelpro.auth.infrastructure.web.dto.ErrorResponse;
 import com.padelpro.reservas.domain.exception.InvalidReservaStateException;
+import com.padelpro.reservas.domain.exception.ParticipacionDuplicadaException;
 import com.padelpro.reservas.domain.exception.ReservaForbiddenException;
 import com.padelpro.reservas.domain.exception.ReservaNotFoundException;
 import com.padelpro.reservas.domain.exception.SlotConflictException;
@@ -181,6 +182,16 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(SlotConflictException.class)
     public ResponseEntity<ErrorResponse> handleSlotConflict(SlotConflictException ex) {
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT)
+                .body(new ErrorResponse("CONFLICT", ex.getMessage()));
+    }
+
+    /**
+     * A user trying to join a reservation they already participate in (RN-AUTH-03) → 409 CONFLICT.
+     */
+    @ExceptionHandler(ParticipacionDuplicadaException.class)
+    public ResponseEntity<ErrorResponse> handleParticipacionDuplicada(ParticipacionDuplicadaException ex) {
         return ResponseEntity
                 .status(HttpStatus.CONFLICT)
                 .body(new ErrorResponse("CONFLICT", ex.getMessage()));

--- a/backend/src/main/java/com/padelpro/reservas/application/dto/PartidaAbiertaResponse.java
+++ b/backend/src/main/java/com/padelpro/reservas/application/dto/PartidaAbiertaResponse.java
@@ -1,0 +1,33 @@
+package com.padelpro.reservas.application.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+/**
+ * An open match: an active reservation ({@code PENDING_CONFIRMATION}/{@code CONFIRMED}) with at least
+ * one free seat, identified by its {@code reservaId} so the client can join it (capability partidas, D1).
+ *
+ * <p>Exposes only non-sensitive fields (RN-RGPD-03): participant display names, but no email/phone.
+ * {@code priceTotal} is the informative total of the reservation (RN-RES-03); the joining cost per
+ * player is derived on the client (total ÷ participants) and is NOT charged on join (D4).
+ *
+ * @param reservaId        reservation UUID as string
+ * @param reservationDate  date of the match
+ * @param startTime        start time
+ * @param durationMinutes  duration in minutes
+ * @param plazasLibres     free seats remaining ({@code max_participants − current participants})
+ * @param priceTotal       informative total price of the reservation
+ * @param participantes    current participants (display name, slot, owner flag)
+ */
+public record PartidaAbiertaResponse(
+        String reservaId,
+        LocalDate reservationDate,
+        LocalTime startTime,
+        Integer durationMinutes,
+        int plazasLibres,
+        BigDecimal priceTotal,
+        List<PartidaParticipanteResponse> participantes
+) {
+}

--- a/backend/src/main/java/com/padelpro/reservas/application/dto/PartidaParticipanteResponse.java
+++ b/backend/src/main/java/com/padelpro/reservas/application/dto/PartidaParticipanteResponse.java
@@ -1,0 +1,18 @@
+package com.padelpro.reservas.application.dto;
+
+/**
+ * Participant projection for the open-matches listing (capability partidas).
+ *
+ * <p>RGPD (RN-RGPD-03): only the display {@code nombre}, the {@code slotPosition} and the
+ * {@code owner} flag are exposed — never email or phone.
+ *
+ * @param nombre       display name of the participant (registered user's full name or guest name)
+ * @param slotPosition the participant's slot (1..4)
+ * @param owner        whether this participant is the reservation owner
+ */
+public record PartidaParticipanteResponse(
+        String nombre,
+        Integer slotPosition,
+        boolean owner
+) {
+}

--- a/backend/src/main/java/com/padelpro/reservas/application/dto/UnirseResponse.java
+++ b/backend/src/main/java/com/padelpro/reservas/application/dto/UnirseResponse.java
@@ -1,0 +1,22 @@
+package com.padelpro.reservas.application.dto;
+
+/**
+ * Confirmation returned by {@code POST /api/reservas/{id}/unirse} (capability partidas, D2).
+ *
+ * <p>Joining does NOT charge online (D4): {@code statusPago} reflects the reservation's existing
+ * payment status (informative), not a per-participant charge.
+ *
+ * @param participanteId id of the created participant row
+ * @param reservaId      reservation UUID as string
+ * @param userId         id of the user who joined
+ * @param nombre         display name of the user who joined
+ * @param statusPago     informative payment status of the reservation (e.g. {@code PENDING})
+ */
+public record UnirseResponse(
+        Long participanteId,
+        String reservaId,
+        Long userId,
+        String nombre,
+        String statusPago
+) {
+}

--- a/backend/src/main/java/com/padelpro/reservas/application/service/AbandonarReservaService.java
+++ b/backend/src/main/java/com/padelpro/reservas/application/service/AbandonarReservaService.java
@@ -1,0 +1,64 @@
+package com.padelpro.reservas.application.service;
+
+import com.padelpro.reservas.domain.exception.InvalidReservaStateException;
+import com.padelpro.reservas.domain.exception.ReservaNotFoundException;
+import com.padelpro.reservas.domain.model.Participant;
+import com.padelpro.reservas.domain.model.Reservation;
+import com.padelpro.reservas.domain.port.out.ReservationCommandPort;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+/**
+ * Abandon-a-match use case (capability partidas, D3).
+ *
+ * <p>A non-owner participant may leave a reservation they joined, freeing their seat (the participant
+ * row is deleted via {@code orphanRemoval}). The owner CANNOT abandon — they must cancel the
+ * reservation through the existing cancellation flow (422). A user who is not a participant gets 422.
+ */
+public class AbandonarReservaService {
+
+    private final ReservationCommandPort reservationCommandPort;
+    private final DisponibilidadCacheInvalidator cacheInvalidator;
+
+    public AbandonarReservaService(ReservationCommandPort reservationCommandPort,
+                                   DisponibilidadCacheInvalidator cacheInvalidator) {
+        this.reservationCommandPort = reservationCommandPort;
+        this.cacheInvalidator = cacheInvalidator;
+    }
+
+    /**
+     * @param reservaId reservation to leave
+     * @param userId    authenticated user id (JWT subject)
+     */
+    @Transactional
+    public void abandonar(UUID reservaId, Long userId) {
+        Reservation reservation = reservationCommandPort.findById(reservaId)
+                .orElseThrow(() -> new ReservaNotFoundException(reservaId));
+
+        // Abandoning only makes sense while the reservation is active (D3).
+        if (!reservation.isActiveOccupant()) {
+            throw new InvalidReservaStateException(
+                    "RESERVA_NOT_JOINABLE",
+                    "La reserva no está activa; no es posible abandonarla");
+        }
+
+        Participant participant = reservation.getParticipants().stream()
+                .filter(p -> userId.equals(p.getUserId()))
+                .findFirst()
+                .orElseThrow(() -> new InvalidReservaStateException(
+                        "NOT_A_PARTICIPANT", "El usuario no participa en esta reserva"));
+
+        // The owner cannot leave: they must cancel the reservation instead (D3).
+        if (participant.isOwner()) {
+            throw new InvalidReservaStateException(
+                    "OWNER_CANNOT_ABANDON",
+                    "El titular no puede abandonar la reserva; debe cancelarla");
+        }
+
+        reservation.removeParticipant(participant);
+        reservationCommandPort.save(reservation); // orphanRemoval → DELETE the participant row
+
+        cacheInvalidator.invalidate(reservation.getReservationDate());
+    }
+}

--- a/backend/src/main/java/com/padelpro/reservas/application/service/AdminReservaService.java
+++ b/backend/src/main/java/com/padelpro/reservas/application/service/AdminReservaService.java
@@ -67,7 +67,8 @@ public class AdminReservaService {
             cacheInvalidator.invalidate(reservation.getReservationDate());
         }
 
-        return ReservaMapper.toResponse(saved, payment);
+        // ADMIN path → full PII.
+        return ReservaMapper.toResponse(saved, payment, true);
     }
 
     private ReservationStatus parseStatus(String raw) {

--- a/backend/src/main/java/com/padelpro/reservas/application/service/CrearReservaService.java
+++ b/backend/src/main/java/com/padelpro/reservas/application/service/CrearReservaService.java
@@ -105,7 +105,8 @@ public class CrearReservaService {
         // Invalidate availability cache for the affected date (D5 / data-model §7.3).
         cacheInvalidator.invalidate(reservationDate);
 
-        return ReservaMapper.toResponse(saved, payment);
+        // The creator is the owner → full PII in the returned detail.
+        return ReservaMapper.toResponse(saved, payment, true);
     }
 
     private ReservaResponse loadExisting(java.util.UUID reservationId) {
@@ -113,7 +114,8 @@ public class CrearReservaService {
                 .orElseThrow(() -> new IllegalStateException(
                         "Idempotency key references a missing reservation: " + reservationId));
         Payment payment = paymentCommandPort.findByReservationId(reservationId).orElse(null);
-        return ReservaMapper.toResponse(r, payment);
+        // Idempotency replay for the same owner → full PII.
+        return ReservaMapper.toResponse(r, payment, true);
     }
 
     private SystemConfig loadConfig() {

--- a/backend/src/main/java/com/padelpro/reservas/application/service/PartidasQueryService.java
+++ b/backend/src/main/java/com/padelpro/reservas/application/service/PartidasQueryService.java
@@ -1,0 +1,132 @@
+package com.padelpro.reservas.application.service;
+
+import com.padelpro.auth.domain.model.SystemConfig;
+import com.padelpro.auth.domain.model.User;
+import com.padelpro.auth.domain.port.out.SystemConfigRepositoryPort;
+import com.padelpro.auth.domain.port.out.UserRepositoryPort;
+import com.padelpro.reservas.application.dto.PartidaAbiertaResponse;
+import com.padelpro.reservas.application.dto.PartidaParticipanteResponse;
+import com.padelpro.reservas.domain.model.Participant;
+import com.padelpro.reservas.domain.model.Payment;
+import com.padelpro.reservas.domain.model.Reservation;
+import com.padelpro.reservas.domain.model.ReservationStatus;
+import com.padelpro.reservas.infrastructure.persistence.PaymentJpaRepository;
+import com.padelpro.reservas.infrastructure.persistence.ReservationJpaRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Read use case for the open-matches listing (capability partidas, D1).
+ *
+ * <p>An "open match" is an active reservation ({@code PENDING_CONFIRMATION}/{@code CONFIRMED}) on a
+ * given date with at least one free seat ({@code plazasLibres = max_participants − participantes ≥ 1}).
+ * Full reservations are excluded. Only display names are projected (RN-RGPD-03) — no email/phone.
+ *
+ * <p>Anti-N+1: reservations are fetched with their participants in one query; payments (for the
+ * informative total) and user display names are each batch-loaded once and joined in memory.
+ */
+public class PartidasQueryService {
+
+    /** Active occupants (RN-RES-01): CANCELLED and COMPLETED never appear as joinable matches. */
+    private static final List<ReservationStatus> ACTIVE_STATUSES =
+            List.of(ReservationStatus.PENDING_CONFIRMATION, ReservationStatus.CONFIRMED);
+
+    private final ReservationJpaRepository reservationRepository;
+    private final PaymentJpaRepository paymentRepository;
+    private final UserRepositoryPort userRepositoryPort;
+    private final SystemConfigRepositoryPort systemConfigRepositoryPort;
+
+    public PartidasQueryService(ReservationJpaRepository reservationRepository,
+                                PaymentJpaRepository paymentRepository,
+                                UserRepositoryPort userRepositoryPort,
+                                SystemConfigRepositoryPort systemConfigRepositoryPort) {
+        this.reservationRepository = reservationRepository;
+        this.paymentRepository = paymentRepository;
+        this.userRepositoryPort = userRepositoryPort;
+        this.systemConfigRepositoryPort = systemConfigRepositoryPort;
+    }
+
+    /** Open matches (reservations with free seats) for {@code fecha}, ordered by start time. */
+    @Transactional(readOnly = true)
+    public List<PartidaAbiertaResponse> listOpenByDate(LocalDate fecha) {
+        SystemConfig config = systemConfigRepositoryPort.findById(1L)
+                .orElseThrow(() -> new IllegalStateException("System configuration (id=1) not found"));
+        int maxParticipants = config.getMaxParticipantsPerPista();
+
+        List<Reservation> reservations =
+                reservationRepository.findActiveByDateWithParticipants(fecha, ACTIVE_STATUSES);
+
+        // Keep only reservations that still have at least one free seat.
+        List<Reservation> open = reservations.stream()
+                .filter(r -> maxParticipants - r.getParticipants().size() >= 1)
+                .toList();
+
+        if (open.isEmpty()) {
+            return List.of();
+        }
+
+        // Batch-load payments (informative total) for the open reservations.
+        List<UUID> ids = open.stream().map(Reservation::getId).toList();
+        Map<UUID, Payment> paymentsByReservation = paymentRepository.findByReservationIdIn(ids).stream()
+                .collect(Collectors.toMap(Payment::getReservationId, Function.identity()));
+
+        // Batch-load display names for every registered participant across the open reservations.
+        List<Long> userIds = open.stream()
+                .flatMap(r -> r.getParticipants().stream())
+                .map(Participant::getUserId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+        Map<Long, String> namesByUserId = userIds.isEmpty()
+                ? Map.of()
+                : userRepositoryPort.findAllById(userIds).stream()
+                        .collect(Collectors.toMap(User::getId, PartidasQueryService::displayName));
+
+        return open.stream()
+                .sorted(Comparator.comparing(Reservation::getStartTime))
+                .map(r -> toResponse(r, maxParticipants,
+                        paymentsByReservation.get(r.getId()), namesByUserId))
+                .toList();
+    }
+
+    private PartidaAbiertaResponse toResponse(Reservation r, int maxParticipants,
+                                              Payment payment, Map<Long, String> namesByUserId) {
+        List<PartidaParticipanteResponse> participantes = r.getParticipants().stream()
+                .sorted(Comparator.comparing(Participant::getSlotPosition))
+                .map(p -> new PartidaParticipanteResponse(
+                        participantName(p, namesByUserId), p.getSlotPosition(), p.isOwner()))
+                .toList();
+
+        BigDecimal priceTotal = payment != null ? payment.getAmount() : null;
+
+        return new PartidaAbiertaResponse(
+                r.getId().toString(),
+                r.getReservationDate(),
+                r.getStartTime(),
+                r.getDurationMinutes(),
+                maxParticipants - r.getParticipants().size(),
+                priceTotal,
+                participantes);
+    }
+
+    /** Display name for a participant: the guest name, or the registered user's full name. */
+    private static String participantName(Participant p, Map<Long, String> namesByUserId) {
+        if (p.getUserId() != null) {
+            return namesByUserId.getOrDefault(p.getUserId(), "Socio");
+        }
+        return p.getExternalName();
+    }
+
+    private static String displayName(User u) {
+        return (u.getFirstName() + " " + u.getLastName()).trim();
+    }
+}

--- a/backend/src/main/java/com/padelpro/reservas/application/service/ReservaMapper.java
+++ b/backend/src/main/java/com/padelpro/reservas/application/service/ReservaMapper.java
@@ -11,18 +11,29 @@ import java.util.List;
 
 /**
  * Maps domain {@link Reservation}/{@link Payment} aggregates to API DTOs (capability reservas).
+ *
+ * <p><b>PII minimization (RN-RGPD-03).</b> A reservation detail/list is visible not only to its owner
+ * but also to co-players who joined an open match (capability partidas, D2). Since anyone can join an
+ * open match, guest phone numbers ({@code externalPhone}) and the reservation {@code notes} must NOT
+ * be exposed to a mere co-participant. Only the owner and ADMIN see those fields; for everyone else
+ * they are nulled out. This shapes the response only — it does not change the 403 access rule.
  */
 final class ReservaMapper {
 
     private ReservaMapper() {
     }
 
-    static ReservaResponse toResponse(Reservation r, Payment payment) {
+    /**
+     * @param includePii when {@code false} (requester is a co-participant, not owner nor ADMIN),
+     *                   {@code externalPhone} of every participant and the reservation {@code notes}
+     *                   are nulled out (RN-RGPD-03).
+     */
+    static ReservaResponse toResponse(Reservation r, Payment payment, boolean includePii) {
         List<ParticipanteResponse> participants = r.getParticipants().stream()
                 .map(p -> new ParticipanteResponse(
                         p.getUserId(),
                         p.getExternalName(),
-                        p.getExternalPhone(),
+                        includePii ? p.getExternalPhone() : null,
                         p.getSlotPosition(),
                         p.isOwner()))
                 .sorted((a, b) -> Integer.compare(a.slotPosition(), b.slotPosition()))
@@ -45,7 +56,7 @@ final class ReservaMapper {
                 r.getDurationMinutes(),
                 r.getStatus() != null ? r.getStatus().name() : null,
                 r.getChannel() != null ? r.getChannel().name() : null,
-                r.getNotes(),
+                includePii ? r.getNotes() : null,
                 priceTotal,
                 participants,
                 pago,

--- a/backend/src/main/java/com/padelpro/reservas/application/service/ReservaQueryService.java
+++ b/backend/src/main/java/com/padelpro/reservas/application/service/ReservaQueryService.java
@@ -40,13 +40,14 @@ public class ReservaQueryService {
     public List<ReservaResponse> listForUser(Long userId) {
         List<Reservation> reservations =
                 reservationRepository.findVisibleToUserWithParticipants(userId);
-        return mapWithPayments(reservations);
+        // RN-RGPD-03 — a co-participant (not owner) must not see guest phones / notes.
+        return mapWithPayments(reservations, false, userId);
     }
 
     /** All reservations (ADMIN). */
     @Transactional(readOnly = true)
     public List<ReservaResponse> listAll() {
-        return mapWithPayments(reservationRepository.findAllWithParticipants());
+        return mapWithPayments(reservationRepository.findAllWithParticipants(), true, null);
     }
 
     /**
@@ -62,7 +63,9 @@ public class ReservaQueryService {
             throw new ReservaForbiddenException("No tiene acceso a esta reserva");
         }
         Payment payment = paymentRepository.findByReservationId(id).orElse(null);
-        return ReservaMapper.toResponse(reservation, payment);
+        // RN-RGPD-03 — only owner and ADMIN see guest phones / notes; a co-participant does not.
+        boolean includePii = admin || userId.equals(reservation.getOwnerId());
+        return ReservaMapper.toResponse(reservation, payment, includePii);
     }
 
     private boolean isOwnerOrParticipant(Reservation reservation, Long userId) {
@@ -74,7 +77,13 @@ public class ReservaQueryService {
                 .anyMatch(userId::equals);
     }
 
-    private List<ReservaResponse> mapWithPayments(List<Reservation> reservations) {
+    /**
+     * @param adminView   when {@code true} (ADMIN listing) every reservation exposes full PII
+     * @param requesterId requesting user id (null for ADMIN); PII is only exposed for reservations
+     *                   they own (RN-RGPD-03) — a co-participant gets guest phones / notes nulled
+     */
+    private List<ReservaResponse> mapWithPayments(List<Reservation> reservations,
+                                                  boolean adminView, Long requesterId) {
         if (reservations.isEmpty()) {
             return List.of();
         }
@@ -82,7 +91,11 @@ public class ReservaQueryService {
         Map<UUID, Payment> paymentsByReservation = paymentRepository.findByReservationIdIn(ids).stream()
                 .collect(Collectors.toMap(Payment::getReservationId, Function.identity()));
         return reservations.stream()
-                .map(r -> ReservaMapper.toResponse(r, paymentsByReservation.get(r.getId())))
+                .map(r -> {
+                    boolean includePii = adminView
+                            || (requesterId != null && requesterId.equals(r.getOwnerId()));
+                    return ReservaMapper.toResponse(r, paymentsByReservation.get(r.getId()), includePii);
+                })
                 .toList();
     }
 }

--- a/backend/src/main/java/com/padelpro/reservas/application/service/UnirseReservaService.java
+++ b/backend/src/main/java/com/padelpro/reservas/application/service/UnirseReservaService.java
@@ -1,0 +1,130 @@
+package com.padelpro.reservas.application.service;
+
+import com.padelpro.auth.domain.model.SystemConfig;
+import com.padelpro.auth.domain.model.User;
+import com.padelpro.auth.domain.port.out.SystemConfigRepositoryPort;
+import com.padelpro.auth.domain.port.out.UserRepositoryPort;
+import com.padelpro.reservas.application.dto.UnirseResponse;
+import com.padelpro.reservas.domain.exception.InvalidReservaStateException;
+import com.padelpro.reservas.domain.exception.ParticipacionDuplicadaException;
+import com.padelpro.reservas.domain.exception.ReservaNotFoundException;
+import com.padelpro.reservas.domain.model.Participant;
+import com.padelpro.reservas.domain.model.Payment;
+import com.padelpro.reservas.domain.model.PaymentStatus;
+import com.padelpro.reservas.domain.model.Reservation;
+import com.padelpro.reservas.domain.model.ReservationChannel;
+import com.padelpro.reservas.domain.port.out.ParticipantCommandPort;
+import com.padelpro.reservas.domain.port.out.PaymentCommandPort;
+import com.padelpro.reservas.domain.port.out.ReservationCommandPort;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+/**
+ * Join-a-match use case (capability partidas, D2, RN-AUTH-03 / RN-RES-02).
+ *
+ * <p>Adds the authenticated user as a non-owner participant of an existing reservation. Validation
+ * and insertion are atomic: the reservation row is loaded {@code FOR UPDATE} so two concurrent joins
+ * to the last seat serialise — exactly one succeeds (200), the other sees the reservation full (422).
+ *
+ * <p>Joining does NOT create a per-participant payment nor charge online (D4); the returned
+ * {@code statusPago} is the reservation's existing payment status, purely informative.
+ */
+public class UnirseReservaService {
+
+    private final ReservationCommandPort reservationCommandPort;
+    private final ParticipantCommandPort participantCommandPort;
+    private final PaymentCommandPort paymentCommandPort;
+    private final SystemConfigRepositoryPort systemConfigRepositoryPort;
+    private final UserRepositoryPort userRepositoryPort;
+    private final DisponibilidadCacheInvalidator cacheInvalidator;
+
+    public UnirseReservaService(ReservationCommandPort reservationCommandPort,
+                                ParticipantCommandPort participantCommandPort,
+                                PaymentCommandPort paymentCommandPort,
+                                SystemConfigRepositoryPort systemConfigRepositoryPort,
+                                UserRepositoryPort userRepositoryPort,
+                                DisponibilidadCacheInvalidator cacheInvalidator) {
+        this.reservationCommandPort = reservationCommandPort;
+        this.participantCommandPort = participantCommandPort;
+        this.paymentCommandPort = paymentCommandPort;
+        this.systemConfigRepositoryPort = systemConfigRepositoryPort;
+        this.userRepositoryPort = userRepositoryPort;
+        this.cacheInvalidator = cacheInvalidator;
+    }
+
+    /**
+     * @param reservaId reservation to join
+     * @param userId    authenticated user id (JWT subject) — becomes a non-owner participant
+     */
+    @Transactional
+    public UnirseResponse unirse(UUID reservaId, Long userId) {
+        // Lock the reservation row (SELECT ... FOR UPDATE) so the seat check + insert are atomic (D2).
+        Reservation reservation = reservationCommandPort.findByIdForUpdate(reservaId)
+                .orElseThrow(() -> new ReservaNotFoundException(reservaId));
+
+        // Only PENDING_CONFIRMATION / CONFIRMED admit new participants (CANCELLED/COMPLETED → 422).
+        if (!reservation.isActiveOccupant()) {
+            throw new InvalidReservaStateException(
+                    "RESERVA_NOT_JOINABLE",
+                    "La reserva no admite nuevos participantes en su estado actual");
+        }
+
+        // RN-AUTH-03 — a user cannot join twice (owner counts as a participant).
+        boolean alreadyParticipant = reservation.getParticipants().stream()
+                .map(Participant::getUserId)
+                .anyMatch(userId::equals);
+        if (alreadyParticipant) {
+            throw new ParticipacionDuplicadaException("El usuario ya participa en esta reserva");
+        }
+
+        // RN-RES-02 — reject when there are no free seats. Read AFTER acquiring the lock so a
+        // concurrent join that just committed is already reflected in the participant count.
+        int maxParticipants = loadMaxParticipants();
+        if (reservation.getParticipants().size() >= maxParticipants) {
+            throw new InvalidReservaStateException(
+                    "PARTICIPANTS_LIMIT_EXCEEDED",
+                    "La reserva ya ha alcanzado el máximo de " + maxParticipants + " participantes");
+        }
+
+        int slot = reservation.nextSlotPosition();
+        Participant participant = Participant.registered(userId, slot, ReservationChannel.WEB);
+        reservation.addParticipant(participant); // wires the reservation association (FK)
+        // INSERT the single participant directly so its generated id is populated (a whole-aggregate
+        // merge would leave this reference id-less). The row is inserted while the reservation is still
+        // locked FOR UPDATE, so the seat count is enforced atomically against concurrent joins.
+        Participant saved = participantCommandPort.save(participant);
+
+        // Availability cache would otherwise serve the just-taken seat as free (D6 / §7.3).
+        cacheInvalidator.invalidate(reservation.getReservationDate());
+
+        String nombre = resolveName(userId);
+        String statusPago = resolvePaymentStatus(reservaId);
+
+        return new UnirseResponse(
+                saved.getId(), reservaId.toString(), userId, nombre, statusPago);
+    }
+
+    private int loadMaxParticipants() {
+        SystemConfig config = systemConfigRepositoryPort.findById(1L)
+                .orElseThrow(() -> new IllegalStateException("System configuration (id=1) not found"));
+        return config.getMaxParticipantsPerPista();
+    }
+
+    private String resolveName(Long userId) {
+        return userRepositoryPort.findById(userId)
+                .map(this::displayName)
+                .orElse("Socio");
+    }
+
+    private String displayName(User u) {
+        return (u.getFirstName() + " " + u.getLastName()).trim();
+    }
+
+    private String resolvePaymentStatus(UUID reservaId) {
+        return paymentCommandPort.findByReservationId(reservaId)
+                .map(Payment::getStatus)
+                .map(Enum::name)
+                .orElse(PaymentStatus.PENDING.name());
+    }
+}

--- a/backend/src/main/java/com/padelpro/reservas/domain/exception/ParticipacionDuplicadaException.java
+++ b/backend/src/main/java/com/padelpro/reservas/domain/exception/ParticipacionDuplicadaException.java
@@ -1,0 +1,11 @@
+package com.padelpro.reservas.domain.exception;
+
+/**
+ * Thrown when a user tries to join a reservation they already participate in (RN-AUTH-03). Surfaces
+ * as HTTP 409 {@code CONFLICT} (error code {@code CONFLICT}); no duplicate participant row is created.
+ */
+public class ParticipacionDuplicadaException extends RuntimeException {
+    public ParticipacionDuplicadaException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/padelpro/reservas/domain/model/Reservation.java
+++ b/backend/src/main/java/com/padelpro/reservas/domain/model/Reservation.java
@@ -119,6 +119,22 @@ public class Reservation {
         this.participants.add(participant);
     }
 
+    /**
+     * Detach a participant from this reservation (capability partidas, D3 — abandon). With
+     * {@code orphanRemoval=true} the removed row is deleted on flush, freeing its seat.
+     */
+    public void removeParticipant(Participant participant) {
+        this.participants.remove(participant);
+    }
+
+    /** Next free {@code slot_position} for a new participant: {@code max(slot) + 1} (D2). */
+    public int nextSlotPosition() {
+        return participants.stream()
+                .mapToInt(Participant::getSlotPosition)
+                .max()
+                .orElse(0) + 1;
+    }
+
     @PrePersist
     protected void onCreate() {
         if (id == null) {

--- a/backend/src/main/java/com/padelpro/reservas/domain/port/out/ParticipantCommandPort.java
+++ b/backend/src/main/java/com/padelpro/reservas/domain/port/out/ParticipantCommandPort.java
@@ -1,0 +1,18 @@
+package com.padelpro.reservas.domain.port.out;
+
+import com.padelpro.reservas.domain.model.Participant;
+
+/**
+ * Outbound write port to add a single participant to an already-persisted reservation (capability
+ * partidas, D2). The create path persists a whole reservation aggregate at once; joining an existing
+ * reservation instead inserts one participant row, so its generated id is available on the returned
+ * instance (a whole-aggregate {@code merge} would otherwise leave the caller's reference id-less).
+ */
+public interface ParticipantCommandPort {
+
+    /**
+     * Persist a new participant (its {@code reservation} association must already be set). Returns the
+     * managed instance with its generated {@code id} populated.
+     */
+    Participant save(Participant participant);
+}

--- a/backend/src/main/java/com/padelpro/reservas/domain/port/out/ReservationCommandPort.java
+++ b/backend/src/main/java/com/padelpro/reservas/domain/port/out/ReservationCommandPort.java
@@ -24,6 +24,14 @@ public interface ReservationCommandPort {
     /** Look up a reservation by id (without forcing participant/payment fetch). */
     Optional<Reservation> findById(UUID id);
 
+    /**
+     * Look up a reservation acquiring a pessimistic write lock on its row ({@code SELECT ... FOR
+     * UPDATE}) so a concurrent join serialises on the same reservation (D2). Participants are loaded
+     * lazily within the caller's transaction after the lock is held, so the seat count re-read
+     * reflects the latest committed state and two joins to the last seat cannot both succeed.
+     */
+    Optional<Reservation> findByIdForUpdate(UUID id);
+
     /** Persist an idempotency record linking (user_id, key) → reservation. */
     IdempotencyKey saveIdempotencyKey(IdempotencyKey key);
 

--- a/backend/src/main/java/com/padelpro/reservas/infrastructure/config/ReservasConfig.java
+++ b/backend/src/main/java/com/padelpro/reservas/infrastructure/config/ReservasConfig.java
@@ -2,11 +2,15 @@ package com.padelpro.reservas.infrastructure.config;
 
 import com.padelpro.auth.domain.port.out.SystemConfigRepositoryPort;
 import com.padelpro.auth.domain.port.out.UserRepositoryPort;
+import com.padelpro.reservas.application.service.AbandonarReservaService;
 import com.padelpro.reservas.application.service.AdminReservaService;
 import com.padelpro.reservas.application.service.CancelarReservaService;
 import com.padelpro.reservas.application.service.CrearReservaService;
 import com.padelpro.reservas.application.service.DisponibilidadCacheInvalidator;
+import com.padelpro.reservas.application.service.PartidasQueryService;
 import com.padelpro.reservas.application.service.ReservaQueryService;
+import com.padelpro.reservas.application.service.UnirseReservaService;
+import com.padelpro.reservas.domain.port.out.ParticipantCommandPort;
 import com.padelpro.reservas.domain.port.out.PaymentCommandPort;
 import com.padelpro.reservas.domain.port.out.ReservationCommandPort;
 import com.padelpro.reservas.infrastructure.persistence.PaymentJpaRepository;
@@ -58,5 +62,34 @@ public class ReservasConfig {
             ReservationJpaRepository reservationRepository,
             PaymentJpaRepository paymentRepository) {
         return new ReservaQueryService(reservationRepository, paymentRepository);
+    }
+
+    @Bean
+    public PartidasQueryService partidasQueryService(
+            ReservationJpaRepository reservationRepository,
+            PaymentJpaRepository paymentRepository,
+            UserRepositoryPort userRepositoryPort,
+            SystemConfigRepositoryPort systemConfigRepositoryPort) {
+        return new PartidasQueryService(reservationRepository, paymentRepository,
+                userRepositoryPort, systemConfigRepositoryPort);
+    }
+
+    @Bean
+    public UnirseReservaService unirseReservaService(
+            ReservationCommandPort reservationCommandPort,
+            ParticipantCommandPort participantCommandPort,
+            PaymentCommandPort paymentCommandPort,
+            SystemConfigRepositoryPort systemConfigRepositoryPort,
+            UserRepositoryPort userRepositoryPort,
+            @Qualifier("disponibilidadCacheInvalidator") DisponibilidadCacheInvalidator cacheInvalidator) {
+        return new UnirseReservaService(reservationCommandPort, participantCommandPort,
+                paymentCommandPort, systemConfigRepositoryPort, userRepositoryPort, cacheInvalidator);
+    }
+
+    @Bean
+    public AbandonarReservaService abandonarReservaService(
+            ReservationCommandPort reservationCommandPort,
+            @Qualifier("disponibilidadCacheInvalidator") DisponibilidadCacheInvalidator cacheInvalidator) {
+        return new AbandonarReservaService(reservationCommandPort, cacheInvalidator);
     }
 }

--- a/backend/src/main/java/com/padelpro/reservas/infrastructure/persistence/ParticipantCommandAdapter.java
+++ b/backend/src/main/java/com/padelpro/reservas/infrastructure/persistence/ParticipantCommandAdapter.java
@@ -1,0 +1,25 @@
+package com.padelpro.reservas.infrastructure.persistence;
+
+import com.padelpro.reservas.domain.model.Participant;
+import com.padelpro.reservas.domain.port.out.ParticipantCommandPort;
+import org.springframework.stereotype.Component;
+
+/**
+ * Write adapter that inserts a single {@link Participant} into an existing reservation (capability
+ * partidas, D2). {@code saveAndFlush} on a new participant issues an INSERT (not a merge), so the
+ * generated identity is populated on the returned instance and surfaced in {@code UnirseResponse}.
+ */
+@Component
+public class ParticipantCommandAdapter implements ParticipantCommandPort {
+
+    private final ParticipantJpaRepository participantRepository;
+
+    public ParticipantCommandAdapter(ParticipantJpaRepository participantRepository) {
+        this.participantRepository = participantRepository;
+    }
+
+    @Override
+    public Participant save(Participant participant) {
+        return participantRepository.saveAndFlush(participant);
+    }
+}

--- a/backend/src/main/java/com/padelpro/reservas/infrastructure/persistence/ParticipantJpaRepository.java
+++ b/backend/src/main/java/com/padelpro/reservas/infrastructure/persistence/ParticipantJpaRepository.java
@@ -1,0 +1,13 @@
+package com.padelpro.reservas.infrastructure.persistence;
+
+import com.padelpro.reservas.domain.model.Participant;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Spring Data JPA repository for {@link Participant} (data-model §3.4). Used by the join path to
+ * insert a single participant into an existing reservation (capability partidas, D2).
+ */
+@Repository
+public interface ParticipantJpaRepository extends JpaRepository<Participant, Long> {
+}

--- a/backend/src/main/java/com/padelpro/reservas/infrastructure/persistence/ReservationCommandAdapter.java
+++ b/backend/src/main/java/com/padelpro/reservas/infrastructure/persistence/ReservationCommandAdapter.java
@@ -51,6 +51,11 @@ public class ReservationCommandAdapter implements ReservationCommandPort {
     }
 
     @Override
+    public Optional<Reservation> findByIdForUpdate(UUID id) {
+        return reservationRepository.findByIdForUpdate(id);
+    }
+
+    @Override
     public IdempotencyKey saveIdempotencyKey(IdempotencyKey key) {
         return idempotencyKeyRepository.saveAndFlush(key);
     }

--- a/backend/src/main/java/com/padelpro/reservas/infrastructure/persistence/ReservationJpaRepository.java
+++ b/backend/src/main/java/com/padelpro/reservas/infrastructure/persistence/ReservationJpaRepository.java
@@ -2,13 +2,16 @@ package com.padelpro.reservas.infrastructure.persistence;
 
 import com.padelpro.reservas.domain.model.Reservation;
 import com.padelpro.reservas.domain.model.ReservationStatus;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -37,6 +40,16 @@ public interface ReservationJpaRepository extends JpaRepository<Reservation, UUI
             WHERE r.id = :id
             """)
     java.util.Optional<Reservation> findByIdWithParticipants(@Param("id") UUID id);
+
+    /**
+     * Load a reservation locking its row ({@code SELECT ... FOR UPDATE}) for the atomic join (D2).
+     * The root row alone is locked — participants are NOT join-fetched here so the lock stays on the
+     * {@code reservations} row; the caller reads {@code getParticipants()} lazily inside the same
+     * transaction, after the lock is held, so the seat count reflects the latest committed state.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT r FROM Reservation r WHERE r.id = :id")
+    Optional<Reservation> findByIdForUpdate(@Param("id") UUID id);
 
     /**
      * Reservations where the user is owner OR a registered participant (RN-AUTH-01), participants

--- a/backend/src/main/java/com/padelpro/reservas/infrastructure/web/PartidasController.java
+++ b/backend/src/main/java/com/padelpro/reservas/infrastructure/web/PartidasController.java
@@ -1,0 +1,59 @@
+package com.padelpro.reservas.infrastructure.web;
+
+import com.padelpro.auth.domain.exception.ValidationException;
+import com.padelpro.reservas.application.dto.PartidaAbiertaResponse;
+import com.padelpro.reservas.application.service.PartidasQueryService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
+import java.util.List;
+
+/**
+ * REST controller for open matches — reservations with free seats a user can join (capability
+ * partidas, D1).
+ *
+ * <p>Endpoint: {@code GET /api/partidas?fecha=YYYY-MM-DD}. Requires an authenticated USER or ADMIN;
+ * anonymous/expired tokens get 401 via the security filter chain ({@code anyRequest().authenticated()}).
+ *
+ * <p>{@code fecha} is mandatory ISO {@code YYYY-MM-DD}; a missing/malformed value yields 400
+ * {@code VALIDATION_ERROR} through {@code GlobalExceptionHandler}, mirroring the availability endpoint.
+ */
+@RestController
+@RequestMapping("/api/partidas")
+public class PartidasController {
+
+    /** Strict ISO date parser: rejects out-of-range values (e.g. 2025-13-40) and non-ISO formats. */
+    private static final DateTimeFormatter FECHA_FORMAT =
+            DateTimeFormatter.ofPattern("uuuu-MM-dd").withResolverStyle(ResolverStyle.STRICT);
+
+    private final PartidasQueryService partidasQueryService;
+
+    public PartidasController(PartidasQueryService partidasQueryService) {
+        this.partidasQueryService = partidasQueryService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<PartidaAbiertaResponse>> listar(
+            @RequestParam(name = "fecha", required = false) String fecha) {
+        LocalDate parsed = parseFecha(fecha);
+        return ResponseEntity.ok(partidasQueryService.listOpenByDate(parsed));
+    }
+
+    private LocalDate parseFecha(String fecha) {
+        if (fecha == null || fecha.isBlank()) {
+            throw new ValidationException("El parámetro 'fecha' es obligatorio (formato YYYY-MM-DD)");
+        }
+        try {
+            return LocalDate.parse(fecha.trim(), FECHA_FORMAT);
+        } catch (DateTimeParseException ex) {
+            throw new ValidationException("El parámetro 'fecha' debe tener el formato YYYY-MM-DD");
+        }
+    }
+}

--- a/backend/src/main/java/com/padelpro/reservas/infrastructure/web/ReservaController.java
+++ b/backend/src/main/java/com/padelpro/reservas/infrastructure/web/ReservaController.java
@@ -2,9 +2,12 @@ package com.padelpro.reservas.infrastructure.web;
 
 import com.padelpro.reservas.application.dto.CrearReservaRequest;
 import com.padelpro.reservas.application.dto.ReservaResponse;
+import com.padelpro.reservas.application.dto.UnirseResponse;
+import com.padelpro.reservas.application.service.AbandonarReservaService;
 import com.padelpro.reservas.application.service.CancelarReservaService;
 import com.padelpro.reservas.application.service.CrearReservaService;
 import com.padelpro.reservas.application.service.ReservaQueryService;
+import com.padelpro.reservas.application.service.UnirseReservaService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -23,6 +26,8 @@ import java.util.UUID;
  *   <li>{@code GET    /api/reservas}        — list own (owner or participant, RN-AUTH-01)</li>
  *   <li>{@code GET    /api/reservas/{id}}   — detail (403 not 404 for non-owner USER, BOLA)</li>
  *   <li>{@code DELETE /api/reservas/{id}}   — cancel (owner or ADMIN, RN-AUTH-02)</li>
+ *   <li>{@code POST   /api/reservas/{id}/unirse}       — join a match (capability partidas, D2)</li>
+ *   <li>{@code DELETE /api/reservas/{id}/participacion} — leave a match (capability partidas, D3)</li>
  * </ul>
  *
  * <p>The JWT subject is the user id (Long as String); the role authority is {@code ROLE_USER}/
@@ -35,13 +40,19 @@ public class ReservaController {
     private final CrearReservaService crearReservaService;
     private final ReservaQueryService reservaQueryService;
     private final CancelarReservaService cancelarReservaService;
+    private final UnirseReservaService unirseReservaService;
+    private final AbandonarReservaService abandonarReservaService;
 
     public ReservaController(CrearReservaService crearReservaService,
                             ReservaQueryService reservaQueryService,
-                            CancelarReservaService cancelarReservaService) {
+                            CancelarReservaService cancelarReservaService,
+                            UnirseReservaService unirseReservaService,
+                            AbandonarReservaService abandonarReservaService) {
         this.crearReservaService = crearReservaService;
         this.reservaQueryService = reservaQueryService;
         this.cancelarReservaService = cancelarReservaService;
+        this.unirseReservaService = unirseReservaService;
+        this.abandonarReservaService = abandonarReservaService;
     }
 
     @PostMapping
@@ -65,6 +76,19 @@ public class ReservaController {
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> cancelar(@PathVariable("id") UUID id) {
         cancelarReservaService.cancelar(id, currentUserId(), isAdmin());
+        return ResponseEntity.noContent().build();
+    }
+
+    /** Join an open match (capability partidas, D2). No body; the user comes from the JWT. */
+    @PostMapping("/{id}/unirse")
+    public ResponseEntity<UnirseResponse> unirse(@PathVariable("id") UUID id) {
+        return ResponseEntity.ok(unirseReservaService.unirse(id, currentUserId()));
+    }
+
+    /** Leave a match a non-owner joined (capability partidas, D3). */
+    @DeleteMapping("/{id}/participacion")
+    public ResponseEntity<Void> abandonar(@PathVariable("id") UUID id) {
+        abandonarReservaService.abandonar(id, currentUserId());
         return ResponseEntity.noContent().build();
     }
 

--- a/backend/src/main/resources/db/migration/V12__unique_participant_per_reservation.sql
+++ b/backend/src/main/resources/db/migration/V12__unique_participant_per_reservation.sql
@@ -1,0 +1,15 @@
+-- Migration: unique registered-participant per reservation (capability partidas, RN-AUTH-03 backstop)
+-- Source of truth: docs/data-model.md §3.4 (participants).
+--
+-- Defense in depth. The join use case (UnirseReservaService) already rejects a duplicate join in
+-- memory while holding the reservation row FOR UPDATE, so a registered user can never occupy two
+-- seats of the same reservation. This partial unique index adds a DB-level backstop so the invariant
+-- also holds against any future write path or manual data fix. External guests (user_id IS NULL) are
+-- exempt: several guests may share the null user_id, so the index is partial on user_id IS NOT NULL.
+--
+-- Existing data is expected to contain no duplicates (the in-memory guard has always been in place);
+-- if any did exist the CREATE would fail loudly rather than silently drop rows.
+
+CREATE UNIQUE INDEX uq_part_user_reservation
+    ON participants (reservation_id, user_id)
+    WHERE user_id IS NOT NULL;

--- a/backend/src/test/java/com/padelpro/reservas/application/service/PartidasQueryServiceTest.java
+++ b/backend/src/test/java/com/padelpro/reservas/application/service/PartidasQueryServiceTest.java
@@ -1,0 +1,157 @@
+package com.padelpro.reservas.application.service;
+
+import com.padelpro.auth.domain.model.SystemConfig;
+import com.padelpro.auth.domain.model.SystemConfig.PaymentGateway;
+import com.padelpro.auth.domain.model.SystemConfig.PistaState;
+import com.padelpro.auth.domain.model.User;
+import com.padelpro.auth.domain.model.UserRole;
+import com.padelpro.auth.domain.model.UserStatus;
+import com.padelpro.auth.domain.port.out.SystemConfigRepositoryPort;
+import com.padelpro.auth.domain.port.out.UserRepositoryPort;
+import com.padelpro.reservas.application.dto.PartidaAbiertaResponse;
+import com.padelpro.reservas.domain.model.Participant;
+import com.padelpro.reservas.domain.model.Payment;
+import com.padelpro.reservas.domain.model.Reservation;
+import com.padelpro.reservas.domain.model.ReservationChannel;
+import com.padelpro.reservas.domain.model.ReservationStatus;
+import com.padelpro.reservas.infrastructure.persistence.PaymentJpaRepository;
+import com.padelpro.reservas.infrastructure.persistence.ReservationJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link PartidasQueryService} — open-matches listing (capability partidas, D1).
+ * Ports/repositories mocked; no database.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PartidasQueryService — listado de partidas abiertas")
+class PartidasQueryServiceTest {
+
+    private static final LocalDate FECHA = LocalDate.of(2025, 8, 1);
+
+    @Mock private ReservationJpaRepository reservationRepository;
+    @Mock private PaymentJpaRepository paymentRepository;
+    @Mock private UserRepositoryPort userRepositoryPort;
+    @Mock private SystemConfigRepositoryPort systemConfigRepositoryPort;
+
+    private PartidasQueryService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new PartidasQueryService(reservationRepository, paymentRepository,
+                userRepositoryPort, systemConfigRepositoryPort);
+        SystemConfig config = SystemConfig.builder()
+                .id(1L).clubName("Club").pistaState(PistaState.ACTIVA)
+                .paymentGateway(PaymentGateway.CASH).maxParticipantsPerPista(4)
+                .createdAt(OffsetDateTime.now()).updatedAt(OffsetDateTime.now()).build();
+        lenient().when(systemConfigRepositoryPort.findById(1L)).thenReturn(Optional.of(config));
+    }
+
+    private Reservation reservation(UUID id, LocalTime start, List<Participant> participants) {
+        return Reservation.builder()
+                .id(id).ownerId(1L).reservationDate(FECHA)
+                .startTime(start).endTime(start.plusMinutes(60))
+                .durationMinutes(60).status(ReservationStatus.PENDING_CONFIRMATION)
+                .channel(ReservationChannel.WEB).participants(participants).build();
+    }
+
+    private User user(long id, String first, String last) {
+        User u = new User("u" + id, "hash", first, last, "u" + id + "@example.com",
+                UserRole.USER, UserStatus.ACTIVE, OffsetDateTime.now(), OffsetDateTime.now());
+        setId(u, id);
+        return u;
+    }
+
+    private void setId(User u, long id) {
+        try {
+            var f = User.class.getDeclaredField("id");
+            f.setAccessible(true);
+            f.set(u, id);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    @DisplayName("sin reservas activas → lista vacía")
+    void should_return_empty_when_no_reservations() {
+        when(reservationRepository.findActiveByDateWithParticipants(any(), anyList()))
+                .thenReturn(List.of());
+
+        assertThat(service.listOpenByDate(FECHA)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("reserva completa (4/4) no aparece; incompleta sí, con plazasLibres y participantes")
+    void should_exclude_full_and_project_open_matches() {
+        UUID openId = UUID.randomUUID();
+        UUID fullId = UUID.randomUUID();
+
+        Reservation open = reservation(openId, LocalTime.of(18, 0), List.of(
+                Participant.owner(1L, ReservationChannel.WEB)));
+        Reservation full = reservation(fullId, LocalTime.of(19, 0), List.of(
+                Participant.owner(2L, ReservationChannel.WEB),
+                Participant.registered(3L, 2, ReservationChannel.WEB),
+                Participant.registered(4L, 3, ReservationChannel.WEB),
+                Participant.registered(5L, 4, ReservationChannel.WEB)));
+
+        when(reservationRepository.findActiveByDateWithParticipants(any(), anyList()))
+                .thenReturn(List.of(open, full));
+        when(paymentRepository.findByReservationIdIn(anyList()))
+                .thenReturn(List.of(Payment.pendingFor(openId, new BigDecimal("15.00"))));
+        when(userRepositoryPort.findAllById(anyList()))
+                .thenReturn(List.of(user(1L, "Ana", "García")));
+
+        List<PartidaAbiertaResponse> result = service.listOpenByDate(FECHA);
+
+        assertThat(result).hasSize(1);
+        PartidaAbiertaResponse p = result.get(0);
+        assertThat(p.reservaId()).isEqualTo(openId.toString());
+        assertThat(p.plazasLibres()).isEqualTo(3);
+        assertThat(p.priceTotal()).isEqualByComparingTo("15.00");
+        assertThat(p.participantes()).hasSize(1);
+        assertThat(p.participantes().get(0).nombre()).isEqualTo("Ana García");
+        assertThat(p.participantes().get(0).owner()).isTrue();
+    }
+
+    @Test
+    @DisplayName("varias partidas abiertas → ordenadas por hora de inicio")
+    void should_sort_open_matches_by_start_time() {
+        UUID a = UUID.randomUUID();
+        UUID b = UUID.randomUUID();
+        Reservation later = reservation(a, LocalTime.of(20, 0), List.of(
+                Participant.owner(1L, ReservationChannel.WEB)));
+        Reservation earlier = reservation(b, LocalTime.of(9, 0), List.of(
+                Participant.owner(2L, ReservationChannel.WEB)));
+
+        when(reservationRepository.findActiveByDateWithParticipants(any(), anyList()))
+                .thenReturn(List.of(later, earlier));
+        when(paymentRepository.findByReservationIdIn(anyList())).thenReturn(List.of());
+        when(userRepositoryPort.findAllById(anyList()))
+                .thenReturn(List.of(user(1L, "A", "A"), user(2L, "B", "B")));
+
+        List<PartidaAbiertaResponse> result = service.listOpenByDate(FECHA);
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).startTime()).isEqualTo(LocalTime.of(9, 0));
+        assertThat(result.get(1).startTime()).isEqualTo(LocalTime.of(20, 0));
+    }
+}

--- a/backend/src/test/java/com/padelpro/reservas/application/service/UnirseReservaServiceTest.java
+++ b/backend/src/test/java/com/padelpro/reservas/application/service/UnirseReservaServiceTest.java
@@ -1,0 +1,178 @@
+package com.padelpro.reservas.application.service;
+
+import com.padelpro.auth.domain.model.SystemConfig;
+import com.padelpro.auth.domain.model.SystemConfig.PaymentGateway;
+import com.padelpro.auth.domain.model.SystemConfig.PistaState;
+import com.padelpro.auth.domain.model.User;
+import com.padelpro.auth.domain.model.UserRole;
+import com.padelpro.auth.domain.model.UserStatus;
+import com.padelpro.auth.domain.port.out.SystemConfigRepositoryPort;
+import com.padelpro.auth.domain.port.out.UserRepositoryPort;
+import com.padelpro.reservas.application.dto.UnirseResponse;
+import com.padelpro.reservas.domain.exception.InvalidReservaStateException;
+import com.padelpro.reservas.domain.exception.ParticipacionDuplicadaException;
+import com.padelpro.reservas.domain.exception.ReservaNotFoundException;
+import com.padelpro.reservas.domain.model.Participant;
+import com.padelpro.reservas.domain.model.Payment;
+import com.padelpro.reservas.domain.model.Reservation;
+import com.padelpro.reservas.domain.model.ReservationChannel;
+import com.padelpro.reservas.domain.model.ReservationStatus;
+import com.padelpro.reservas.domain.port.out.ParticipantCommandPort;
+import com.padelpro.reservas.domain.port.out.PaymentCommandPort;
+import com.padelpro.reservas.domain.port.out.ReservationCommandPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link UnirseReservaService} — join validations and slot assignment (capability
+ * partidas, D2). Ports mocked; no database. The atomic last-seat race is covered by the concurrency IT.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UnirseReservaService — unirse a una partida")
+class UnirseReservaServiceTest {
+
+    private static final UUID RES_ID = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+    private static final long OWNER_ID = 1L;
+    private static final long JOINER_ID = 2L;
+
+    @Mock private ReservationCommandPort reservationCommandPort;
+    @Mock private ParticipantCommandPort participantCommandPort;
+    @Mock private PaymentCommandPort paymentCommandPort;
+    @Mock private SystemConfigRepositoryPort systemConfigRepositoryPort;
+    @Mock private UserRepositoryPort userRepositoryPort;
+    @Mock private DisponibilidadCacheInvalidator cacheInvalidator;
+
+    private UnirseReservaService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new UnirseReservaService(reservationCommandPort, participantCommandPort,
+                paymentCommandPort, systemConfigRepositoryPort, userRepositoryPort, cacheInvalidator);
+    }
+
+    private void configWithMax(int max) {
+        SystemConfig config = SystemConfig.builder()
+                .id(1L).clubName("Club").pistaState(PistaState.ACTIVA)
+                .paymentGateway(PaymentGateway.CASH).maxParticipantsPerPista(max)
+                .createdAt(OffsetDateTime.now()).updatedAt(OffsetDateTime.now()).build();
+        lenient().when(systemConfigRepositoryPort.findById(1L)).thenReturn(Optional.of(config));
+    }
+
+    private Reservation reservationWith(ReservationStatus status, Participant... participants) {
+        List<Participant> list = new ArrayList<>(List.of(participants));
+        return Reservation.builder()
+                .id(RES_ID).ownerId(OWNER_ID).reservationDate(LocalDate.now().plusDays(3))
+                .startTime(LocalTime.of(18, 0)).endTime(LocalTime.of(19, 0))
+                .durationMinutes(60).status(status).channel(ReservationChannel.WEB)
+                .participants(list).build();
+    }
+
+    @Test
+    @DisplayName("reserva inexistente → 404 ReservaNotFoundException")
+    void should_throw_not_found_when_reservation_absent() {
+        when(reservationCommandPort.findByIdForUpdate(RES_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.unirse(RES_ID, JOINER_ID))
+                .isInstanceOf(ReservaNotFoundException.class);
+        verify(participantCommandPort, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("reserva CANCELLED → 422 RESERVA_NOT_JOINABLE")
+    void should_reject_when_reservation_cancelled() {
+        Reservation r = reservationWith(ReservationStatus.CANCELLED,
+                Participant.owner(OWNER_ID, ReservationChannel.WEB));
+        when(reservationCommandPort.findByIdForUpdate(RES_ID)).thenReturn(Optional.of(r));
+
+        assertThatThrownBy(() -> service.unirse(RES_ID, JOINER_ID))
+                .isInstanceOf(InvalidReservaStateException.class)
+                .extracting(e -> ((InvalidReservaStateException) e).getCode())
+                .isEqualTo("RESERVA_NOT_JOINABLE");
+        verify(participantCommandPort, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("usuario ya participante → 409 ParticipacionDuplicadaException")
+    void should_reject_when_already_participant() {
+        Reservation r = reservationWith(ReservationStatus.PENDING_CONFIRMATION,
+                Participant.owner(OWNER_ID, ReservationChannel.WEB),
+                Participant.registered(JOINER_ID, 2, ReservationChannel.WEB));
+        when(reservationCommandPort.findByIdForUpdate(RES_ID)).thenReturn(Optional.of(r));
+
+        assertThatThrownBy(() -> service.unirse(RES_ID, JOINER_ID))
+                .isInstanceOf(ParticipacionDuplicadaException.class);
+        verify(participantCommandPort, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("reserva completa → 422 PARTICIPANTS_LIMIT_EXCEEDED")
+    void should_reject_when_full() {
+        configWithMax(2);
+        Reservation r = reservationWith(ReservationStatus.CONFIRMED,
+                Participant.owner(OWNER_ID, ReservationChannel.WEB),
+                Participant.registered(3L, 2, ReservationChannel.WEB));
+        when(reservationCommandPort.findByIdForUpdate(RES_ID)).thenReturn(Optional.of(r));
+
+        assertThatThrownBy(() -> service.unirse(RES_ID, JOINER_ID))
+                .isInstanceOf(InvalidReservaStateException.class)
+                .extracting(e -> ((InvalidReservaStateException) e).getCode())
+                .isEqualTo("PARTICIPANTS_LIMIT_EXCEEDED");
+        verify(participantCommandPort, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("unión exitosa → añade participante en el siguiente slot, invalida caché, devuelve datos")
+    void should_join_successfully_and_assign_next_slot() {
+        configWithMax(4);
+        Reservation r = reservationWith(ReservationStatus.PENDING_CONFIRMATION,
+                Participant.owner(OWNER_ID, ReservationChannel.WEB));
+        when(reservationCommandPort.findByIdForUpdate(RES_ID)).thenReturn(Optional.of(r));
+        when(participantCommandPort.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        User joiner = new User("jane", "hash", "Jane", "Smith", "jane@example.com",
+                UserRole.USER, UserStatus.ACTIVE, OffsetDateTime.now(), OffsetDateTime.now());
+        when(userRepositoryPort.findById(JOINER_ID)).thenReturn(Optional.of(joiner));
+        when(paymentCommandPort.findByReservationId(RES_ID))
+                .thenReturn(Optional.of(Payment.pendingFor(RES_ID, new BigDecimal("15.00"))));
+
+        UnirseResponse response = service.unirse(RES_ID, JOINER_ID);
+
+        assertThat(response.reservaId()).isEqualTo(RES_ID.toString());
+        assertThat(response.userId()).isEqualTo(JOINER_ID);
+        assertThat(response.nombre()).isEqualTo("Jane Smith");
+        assertThat(response.statusPago()).isEqualTo("PENDING");
+
+        // The joined participant is inserted at the next slot as a non-owner.
+        ArgumentCaptor<Participant> captor = ArgumentCaptor.forClass(Participant.class);
+        verify(participantCommandPort).save(captor.capture());
+        Participant added = captor.getValue();
+        assertThat(added.getUserId()).isEqualTo(JOINER_ID);
+        assertThat(added.getSlotPosition()).isEqualTo(2);
+        assertThat(added.isOwner()).isFalse();
+        // Both sides of the association are kept in sync so the FK is set on INSERT.
+        assertThat(r.getParticipants()).hasSize(2);
+        verify(cacheInvalidator).invalidate(r.getReservationDate());
+    }
+}

--- a/backend/src/test/java/com/padelpro/reservas/infrastructure/web/PartidasControllerIntegrationTest.java
+++ b/backend/src/test/java/com/padelpro/reservas/infrastructure/web/PartidasControllerIntegrationTest.java
@@ -1,0 +1,134 @@
+package com.padelpro.reservas.infrastructure.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.padelpro.auth.application.service.JwtService;
+import com.padelpro.auth.domain.model.User;
+import com.padelpro.auth.domain.model.UserRole;
+import com.padelpro.auth.domain.model.UserStatus;
+import com.padelpro.auth.infrastructure.persistence.UserRepository;
+import com.padelpro.reservas.application.dto.CrearReservaRequest;
+import com.padelpro.shared.PostgresIntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Integration tests for {@code GET /api/partidas} (capability partidas, D1) against a real PostgreSQL.
+ *
+ * <p>Verifies the open-matches contract: reservations with free seats appear with {@code reservaId},
+ * hora, plazas, importe informativo and participant display names only (no PII); full reservations are
+ * hidden; anonymous requests get 401.
+ */
+@DisplayName("IT — GET /api/partidas (Postgres real)")
+class PartidasControllerIntegrationTest extends PostgresIntegrationTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private UserRepository userRepository;
+    @Autowired private BCryptPasswordEncoder passwordEncoder;
+    @Autowired private JwtService jwtService;
+
+    private User owner;
+    private User p2;
+    private User p3;
+    private User p4;
+    private String ownerToken;
+
+    private final LocalDate futureDate = LocalDate.now().plusDays(7);
+
+    @BeforeEach
+    void setUp() {
+        OffsetDateTime now = OffsetDateTime.now();
+        owner = userRepository.saveAndFlush(new User("owner.user", passwordEncoder.encode("Password1"),
+                "Owner", "User", "owner@example.com", UserRole.USER, UserStatus.ACTIVE, now, now));
+        p2 = userRepository.saveAndFlush(new User("p2.user", passwordEncoder.encode("Password1"),
+                "Pepe", "Dos", "p2@example.com", UserRole.USER, UserStatus.ACTIVE, now, now));
+        p3 = userRepository.saveAndFlush(new User("p3.user", passwordEncoder.encode("Password1"),
+                "Tres", "Tres", "p3@example.com", UserRole.USER, UserStatus.ACTIVE, now, now));
+        p4 = userRepository.saveAndFlush(new User("p4.user", passwordEncoder.encode("Password1"),
+                "Cuatro", "Cuatro", "p4@example.com", UserRole.USER, UserStatus.ACTIVE, now, now));
+        ownerToken = jwtService.generateAccessToken(owner);
+    }
+
+    private void createReserva(String startTime, List<CrearReservaRequest.ParticipanteAdicional> extras)
+            throws Exception {
+        String body = objectMapper.writeValueAsString(new CrearReservaRequest(
+                futureDate.toString(), startTime, 60, "test", extras));
+        mockMvc.perform(post("/api/reservas")
+                        .header("Authorization", "Bearer " + ownerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("1.1 lista partidas abiertas con reservaId, hora, plazasLibres, importe y participantes (sin PII)")
+    void should_list_open_matches_with_identifier_and_no_pii() throws Exception {
+        createReserva("18:00", null); // owner only → 3 free seats
+
+        mockMvc.perform(get("/api/partidas").param("fecha", futureDate.toString())
+                        .header("Authorization", "Bearer " + ownerToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].reservaId").exists())
+                .andExpect(jsonPath("$[0].startTime", is("18:00:00")))
+                .andExpect(jsonPath("$[0].durationMinutes", is(60)))
+                .andExpect(jsonPath("$[0].plazasLibres", is(3)))
+                .andExpect(jsonPath("$[0].priceTotal", is(15.00)))
+                .andExpect(jsonPath("$[0].participantes", hasSize(1)))
+                .andExpect(jsonPath("$[0].participantes[0].nombre", is("Owner User")))
+                .andExpect(jsonPath("$[0].participantes[0].owner", is(true)))
+                // RGPD: no email/phone leaked in the projection
+                .andExpect(jsonPath("$[0].participantes[0].email").doesNotExist())
+                .andExpect(jsonPath("$[0].participantes[0].externalPhone").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("1.1 reserva completa (4/4) no aparece en el listado")
+    void should_hide_full_reservation() throws Exception {
+        // Full reservation at 18:00 (owner + 3 registered) and an open one at 20:00 (owner only).
+        createReserva("18:00", List.of(
+                new CrearReservaRequest.ParticipanteAdicional(p2.getId(), null, null),
+                new CrearReservaRequest.ParticipanteAdicional(p3.getId(), null, null),
+                new CrearReservaRequest.ParticipanteAdicional(p4.getId(), null, null)));
+        createReserva("20:00", null);
+
+        mockMvc.perform(get("/api/partidas").param("fecha", futureDate.toString())
+                        .header("Authorization", "Bearer " + ownerToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].startTime", is("20:00:00")))
+                .andExpect(jsonPath("$[0].plazasLibres", is(3)));
+    }
+
+    @Test
+    @DisplayName("1.1 sin JWT → 401")
+    void should_return_401_when_anonymous() throws Exception {
+        mockMvc.perform(get("/api/partidas").param("fecha", futureDate.toString()))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("1.1 fecha ausente → 400 VALIDATION_ERROR")
+    void should_return_400_when_missing_fecha() throws Exception {
+        mockMvc.perform(get("/api/partidas")
+                        .header("Authorization", "Bearer " + ownerToken))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error", is("VALIDATION_ERROR")));
+    }
+}

--- a/backend/src/test/java/com/padelpro/reservas/infrastructure/web/ReservaControllerIntegrationTest.java
+++ b/backend/src/test/java/com/padelpro/reservas/infrastructure/web/ReservaControllerIntegrationTest.java
@@ -492,4 +492,98 @@ class ReservaControllerIntegrationTest extends PostgresIntegrationTest {
         assertThat(reservationRepository.findByIdWithParticipants(reservationId).orElseThrow()
                 .getParticipants()).hasSize(2);
     }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // RN-RGPD-03 — PII minimization in the reservation detail for co-participants.
+    // A co-player who joined an open match must NOT see guest phones nor the notes;
+    // the owner and ADMIN still see everything. Access rule (403) is unchanged.
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /** Owner-created reservation with private notes and an external guest carrying a phone. */
+    private String createReservaWithGuestAndNotes(String startTime) throws Exception {
+        String body = objectMapper.writeValueAsString(new CrearReservaRequest(
+                futureDate.toString(), startTime, 60, "notas privadas del owner",
+                java.util.List.of(new CrearReservaRequest.ParticipanteAdicional(
+                        null, "Invitado Externo", "+34611223344"))));
+        MvcResult result = mockMvc.perform(post("/api/reservas")
+                        .header("Authorization", "Bearer " + ownerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return extractId(result);
+    }
+
+    /** Make {@code otherUser} join the reservation as a non-owner co-participant. */
+    private void joinAs(String id, String token) throws Exception {
+        mockMvc.perform(post("/api/reservas/{id}/unirse", id)
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("RGPD: owner ve externalPhone del invitado y notes de la reserva")
+    void should_expose_pii_to_owner() throws Exception {
+        String id = createReservaWithGuestAndNotes("18:00");
+
+        mockMvc.perform(get("/api/reservas/{id}", id)
+                        .header("Authorization", "Bearer " + ownerToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.notes", is("notas privadas del owner")))
+                .andExpect(jsonPath("$.participants[1].externalName", is("Invitado Externo")))
+                .andExpect(jsonPath("$.participants[1].externalPhone", is("+34611223344")));
+    }
+
+    @Test
+    @DisplayName("RGPD: ADMIN (no participante) ve externalPhone y notes")
+    void should_expose_pii_to_admin() throws Exception {
+        String id = createReservaWithGuestAndNotes("18:00");
+
+        mockMvc.perform(get("/api/reservas/{id}", id)
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.notes", is("notas privadas del owner")))
+                .andExpect(jsonPath("$.participants[1].externalPhone", is("+34611223344")));
+    }
+
+    @Test
+    @DisplayName("RGPD: co-participante (no owner) recibe externalPhone y notes en null")
+    void should_minimize_pii_for_co_participant() throws Exception {
+        String id = createReservaWithGuestAndNotes("18:00");
+        joinAs(id, otherToken); // otherUser becomes a non-owner co-participant (slot 3)
+
+        mockMvc.perform(get("/api/reservas/{id}", id)
+                        .header("Authorization", "Bearer " + otherToken))
+                .andExpect(status().isOk())
+                // The guest is still listed by display name, but the phone is nulled out.
+                .andExpect(jsonPath("$.participants[1].externalName", is("Invitado Externo")))
+                .andExpect(jsonPath("$.participants[1].externalPhone").doesNotExist())
+                .andExpect(jsonPath("$.notes").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("RGPD: no-participante sigue recibiendo 403 (regla de acceso intacta)")
+    void should_still_return_403_for_non_participant() throws Exception {
+        String id = createReservaWithGuestAndNotes("18:00");
+        // otherUser has NOT joined → still no access.
+        mockMvc.perform(get("/api/reservas/{id}", id)
+                        .header("Authorization", "Bearer " + otherToken))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error", is("FORBIDDEN")));
+    }
+
+    @Test
+    @DisplayName("RGPD: en el listado, el co-participante tampoco ve phone/notes de reservas ajenas")
+    void should_minimize_pii_in_list_for_co_participant() throws Exception {
+        String id = createReservaWithGuestAndNotes("18:00");
+        joinAs(id, otherToken);
+
+        // otherUser lists their reservations: this one (not owned) must come minimized.
+        mockMvc.perform(get("/api/reservas")
+                        .header("Authorization", "Bearer " + otherToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", org.hamcrest.Matchers.hasSize(1)))
+                .andExpect(jsonPath("$[0].notes").doesNotExist())
+                .andExpect(jsonPath("$[0].participants[1].externalPhone").doesNotExist());
+    }
 }

--- a/backend/src/test/java/com/padelpro/reservas/infrastructure/web/UnirseAbandonarIntegrationTest.java
+++ b/backend/src/test/java/com/padelpro/reservas/infrastructure/web/UnirseAbandonarIntegrationTest.java
@@ -185,6 +185,21 @@ class UnirseAbandonarIntegrationTest extends PostgresIntegrationTest {
     }
 
     @Test
+    @DisplayName("2.1 reserva COMPLETED → 422 RESERVA_NOT_JOINABLE")
+    void should_return_422_when_completed() throws Exception {
+        String id = createReserva("18:00", null);
+        // Move the reservation to a terminal, non-active state directly (no ADMIN endpoint here).
+        Reservation r = reservationRepository.findByIdWithParticipants(UUID.fromString(id)).orElseThrow();
+        r.changeStatus(ReservationStatus.COMPLETED);
+        reservationRepository.saveAndFlush(r);
+
+        mockMvc.perform(post("/api/reservas/{id}/unirse", id)
+                        .header("Authorization", "Bearer " + joinerToken))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.error", is("RESERVA_NOT_JOINABLE")));
+    }
+
+    @Test
     @DisplayName("2.1 sin JWT → 401")
     void should_return_401_when_anonymous_join() throws Exception {
         String id = createReserva("18:00", null);
@@ -244,5 +259,41 @@ class UnirseAbandonarIntegrationTest extends PostgresIntegrationTest {
         mockMvc.perform(delete("/api/reservas/{id}/participacion", UUID.randomUUID())
                         .header("Authorization", "Bearer " + joinerToken))
                 .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("3.1 abandonar reserva CANCELLED → 422 RESERVA_NOT_JOINABLE")
+    void should_reject_leaving_cancelled_reservation() throws Exception {
+        String id = createReserva("18:00", null);
+        // The joiner becomes a participant, then the owner cancels the reservation.
+        mockMvc.perform(post("/api/reservas/{id}/unirse", id)
+                        .header("Authorization", "Bearer " + joinerToken))
+                .andExpect(status().isOk());
+        mockMvc.perform(delete("/api/reservas/{id}", id)
+                        .header("Authorization", "Bearer " + ownerToken))
+                .andExpect(status().isNoContent());
+
+        // Abandoning a non-active reservation is rejected before the participant check.
+        mockMvc.perform(delete("/api/reservas/{id}/participacion", id)
+                        .header("Authorization", "Bearer " + joinerToken))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.error", is("RESERVA_NOT_JOINABLE")));
+    }
+
+    @Test
+    @DisplayName("3.1 abandonar reserva COMPLETED → 422 RESERVA_NOT_JOINABLE")
+    void should_reject_leaving_completed_reservation() throws Exception {
+        String id = createReserva("18:00", null);
+        mockMvc.perform(post("/api/reservas/{id}/unirse", id)
+                        .header("Authorization", "Bearer " + joinerToken))
+                .andExpect(status().isOk());
+        Reservation r = reservationRepository.findByIdWithParticipants(UUID.fromString(id)).orElseThrow();
+        r.changeStatus(ReservationStatus.COMPLETED);
+        reservationRepository.saveAndFlush(r);
+
+        mockMvc.perform(delete("/api/reservas/{id}/participacion", id)
+                        .header("Authorization", "Bearer " + joinerToken))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.error", is("RESERVA_NOT_JOINABLE")));
     }
 }

--- a/backend/src/test/java/com/padelpro/reservas/infrastructure/web/UnirseAbandonarIntegrationTest.java
+++ b/backend/src/test/java/com/padelpro/reservas/infrastructure/web/UnirseAbandonarIntegrationTest.java
@@ -1,0 +1,248 @@
+package com.padelpro.reservas.infrastructure.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.padelpro.auth.application.service.JwtService;
+import com.padelpro.auth.domain.model.User;
+import com.padelpro.auth.domain.model.UserRole;
+import com.padelpro.auth.domain.model.UserStatus;
+import com.padelpro.auth.infrastructure.persistence.UserRepository;
+import com.padelpro.reservas.application.dto.CrearReservaRequest;
+import com.padelpro.reservas.domain.model.Reservation;
+import com.padelpro.reservas.domain.model.ReservationStatus;
+import com.padelpro.reservas.infrastructure.persistence.ReservationJpaRepository;
+import com.padelpro.shared.PostgresIntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Integration tests for join/leave a match against a real PostgreSQL (capability partidas, D2/D3):
+ * {@code POST /api/reservas/{id}/unirse} and {@code DELETE /api/reservas/{id}/participacion}.
+ */
+@DisplayName("IT — unirse / abandonar partida (Postgres real)")
+class UnirseAbandonarIntegrationTest extends PostgresIntegrationTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private UserRepository userRepository;
+    @Autowired private ReservationJpaRepository reservationRepository;
+    @Autowired private BCryptPasswordEncoder passwordEncoder;
+    @Autowired private JwtService jwtService;
+
+    private User owner;
+    private User joiner;
+    private User joiner2;
+    private User joiner3;
+    private User outsider;
+    private String ownerToken;
+    private String joinerToken;
+    private String joiner2Token;
+    private String joiner3Token;
+    private String outsiderToken;
+
+    private final LocalDate futureDate = LocalDate.now().plusDays(7);
+
+    @BeforeEach
+    void setUp() {
+        OffsetDateTime now = OffsetDateTime.now();
+        owner = save("owner.user", "Owner", "User");
+        joiner = save("joiner.user", "Jane", "Smith");
+        joiner2 = save("joiner2.user", "Juan", "Dos");
+        joiner3 = save("joiner3.user", "Ken", "Tres");
+        outsider = save("outsider.user", "Out", "Sider");
+        ownerToken = jwtService.generateAccessToken(owner);
+        joinerToken = jwtService.generateAccessToken(joiner);
+        joiner2Token = jwtService.generateAccessToken(joiner2);
+        joiner3Token = jwtService.generateAccessToken(joiner3);
+        outsiderToken = jwtService.generateAccessToken(outsider);
+    }
+
+    private User save(String login, String first, String last) {
+        OffsetDateTime now = OffsetDateTime.now();
+        return userRepository.saveAndFlush(new User(login, passwordEncoder.encode("Password1"),
+                first, last, login + "@example.com", UserRole.USER, UserStatus.ACTIVE, now, now));
+    }
+
+    private String createReserva(String startTime,
+                                 List<CrearReservaRequest.ParticipanteAdicional> extras) throws Exception {
+        String body = objectMapper.writeValueAsString(new CrearReservaRequest(
+                futureDate.toString(), startTime, 60, "test", extras));
+        MvcResult result = mockMvc.perform(post("/api/reservas")
+                        .header("Authorization", "Bearer " + ownerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsString()).get("id").asText();
+    }
+
+    // ── unirse ────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("2.1 unión exitosa → 200 con datos del participante y +1 en participants")
+    void should_join_successfully() throws Exception {
+        String id = createReserva("18:00", null);
+
+        mockMvc.perform(post("/api/reservas/{id}/unirse", id)
+                        .header("Authorization", "Bearer " + joinerToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.reservaId", is(id)))
+                .andExpect(jsonPath("$.userId", is(joiner.getId().intValue())))
+                .andExpect(jsonPath("$.nombre", is("Jane Smith")))
+                .andExpect(jsonPath("$.statusPago", is("PENDING")))
+                .andExpect(jsonPath("$.participanteId").isNumber());
+
+        Reservation r = reservationRepository.findByIdWithParticipants(UUID.fromString(id)).orElseThrow();
+        assertThat(r.getParticipants()).hasSize(2);
+        assertThat(r.getParticipants()).anySatisfy(p -> {
+            assertThat(p.getUserId()).isEqualTo(joiner.getId());
+            assertThat(p.getSlotPosition()).isEqualTo(2);
+            assertThat(p.isOwner()).isFalse();
+        });
+    }
+
+    @Test
+    @DisplayName("2.1 usuario ya participante (el owner) → 409 CONFLICT")
+    void should_return_409_when_owner_tries_to_join_own_reservation() throws Exception {
+        String id = createReserva("18:00", null);
+
+        mockMvc.perform(post("/api/reservas/{id}/unirse", id)
+                        .header("Authorization", "Bearer " + ownerToken))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error", is("CONFLICT")));
+    }
+
+    @Test
+    @DisplayName("2.1 unirse dos veces → segunda vez 409 CONFLICT (sin duplicar)")
+    void should_return_409_when_joining_twice() throws Exception {
+        String id = createReserva("18:00", null);
+        mockMvc.perform(post("/api/reservas/{id}/unirse", id)
+                        .header("Authorization", "Bearer " + joinerToken))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/reservas/{id}/unirse", id)
+                        .header("Authorization", "Bearer " + joinerToken))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error", is("CONFLICT")));
+
+        Reservation r = reservationRepository.findByIdWithParticipants(UUID.fromString(id)).orElseThrow();
+        assertThat(r.getParticipants()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("2.1 reserva completa → 422 PARTICIPANTS_LIMIT_EXCEEDED")
+    void should_return_422_when_full() throws Exception {
+        // owner + 3 registered → 4/4 full
+        String id = createReserva("18:00", List.of(
+                new CrearReservaRequest.ParticipanteAdicional(joiner.getId(), null, null),
+                new CrearReservaRequest.ParticipanteAdicional(joiner2.getId(), null, null),
+                new CrearReservaRequest.ParticipanteAdicional(joiner3.getId(), null, null)));
+
+        mockMvc.perform(post("/api/reservas/{id}/unirse", id)
+                        .header("Authorization", "Bearer " + outsiderToken))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.error", is("PARTICIPANTS_LIMIT_EXCEEDED")));
+    }
+
+    @Test
+    @DisplayName("2.1 reserva inexistente → 404")
+    void should_return_404_when_reservation_absent() throws Exception {
+        mockMvc.perform(post("/api/reservas/{id}/unirse", UUID.randomUUID())
+                        .header("Authorization", "Bearer " + joinerToken))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("2.1 reserva CANCELLED → 422 RESERVA_NOT_JOINABLE")
+    void should_return_422_when_cancelled() throws Exception {
+        String id = createReserva("18:00", null);
+        // Owner cancels within deadline.
+        mockMvc.perform(delete("/api/reservas/{id}", id)
+                        .header("Authorization", "Bearer " + ownerToken))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(post("/api/reservas/{id}/unirse", id)
+                        .header("Authorization", "Bearer " + joinerToken))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.error", is("RESERVA_NOT_JOINABLE")));
+    }
+
+    @Test
+    @DisplayName("2.1 sin JWT → 401")
+    void should_return_401_when_anonymous_join() throws Exception {
+        String id = createReserva("18:00", null);
+        mockMvc.perform(post("/api/reservas/{id}/unirse", id))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ── abandonar ───────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("3.1 participante no-owner abandona → 204 y libera la plaza")
+    void should_leave_and_free_seat() throws Exception {
+        String id = createReserva("18:00", null);
+        mockMvc.perform(post("/api/reservas/{id}/unirse", id)
+                        .header("Authorization", "Bearer " + joinerToken))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(delete("/api/reservas/{id}/participacion", id)
+                        .header("Authorization", "Bearer " + joinerToken))
+                .andExpect(status().isNoContent());
+
+        Reservation r = reservationRepository.findByIdWithParticipants(UUID.fromString(id)).orElseThrow();
+        assertThat(r.getParticipants()).hasSize(1);
+        assertThat(r.getParticipants()).noneSatisfy(
+                p -> assertThat(p.getUserId()).isEqualTo(joiner.getId()));
+        assertThat(r.getStatus()).isEqualTo(ReservationStatus.PENDING_CONFIRMATION);
+    }
+
+    @Test
+    @DisplayName("3.1 el owner no puede abandonar → 422 OWNER_CANNOT_ABANDON")
+    void should_reject_owner_leaving() throws Exception {
+        String id = createReserva("18:00", null);
+
+        mockMvc.perform(delete("/api/reservas/{id}/participacion", id)
+                        .header("Authorization", "Bearer " + ownerToken))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.error", is("OWNER_CANNOT_ABANDON")));
+
+        Reservation r = reservationRepository.findByIdWithParticipants(UUID.fromString(id)).orElseThrow();
+        assertThat(r.getParticipants()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("3.1 no participante intenta abandonar → 422 NOT_A_PARTICIPANT")
+    void should_reject_non_participant_leaving() throws Exception {
+        String id = createReserva("18:00", null);
+
+        mockMvc.perform(delete("/api/reservas/{id}/participacion", id)
+                        .header("Authorization", "Bearer " + outsiderToken))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.error", is("NOT_A_PARTICIPANT")));
+    }
+
+    @Test
+    @DisplayName("3.1 abandonar reserva inexistente → 404")
+    void should_return_404_when_leaving_absent_reservation() throws Exception {
+        mockMvc.perform(delete("/api/reservas/{id}/participacion", UUID.randomUUID())
+                        .header("Authorization", "Bearer " + joinerToken))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/backend/src/test/java/com/padelpro/reservas/infrastructure/web/UnirseUltimaPlazaConcurrencyIT.java
+++ b/backend/src/test/java/com/padelpro/reservas/infrastructure/web/UnirseUltimaPlazaConcurrencyIT.java
@@ -1,0 +1,155 @@
+package com.padelpro.reservas.infrastructure.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.padelpro.auth.application.service.JwtService;
+import com.padelpro.auth.domain.model.User;
+import com.padelpro.auth.domain.model.UserRole;
+import com.padelpro.auth.domain.model.UserStatus;
+import com.padelpro.auth.infrastructure.persistence.UserRepository;
+import com.padelpro.reservas.application.dto.CrearReservaRequest;
+import com.padelpro.reservas.infrastructure.persistence.ReservationJpaRepository;
+import com.padelpro.shared.PostgresIntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Concurrency test for the atomic last-seat join (capability partidas, D2, RN-RES-02).
+ *
+ * <p>Creates a reservation with only ONE free seat (owner + 2 registered, max_participants = 4 leaves
+ * room for 1 more... so we fill to 3/4) and fires N simultaneous joins by N distinct users. Exactly
+ * one must win with 200 and the rest lose with 422 — guaranteed by loading the reservation row
+ * {@code FOR UPDATE} so the seat check + insert serialise. Real HTTP + thread pool (never MockMvc,
+ * whose transaction/security wiring is not thread-safe).
+ */
+@DisplayName("IT — unión concurrente a la última plaza (Postgres real)")
+class UnirseUltimaPlazaConcurrencyIT extends PostgresIntegrationTest {
+
+    private static final int RACERS = 8;
+
+    @LocalServerPort private int port;
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private UserRepository userRepository;
+    @Autowired private ReservationJpaRepository reservationRepository;
+    @Autowired private BCryptPasswordEncoder passwordEncoder;
+    @Autowired private JwtService jwtService;
+
+    private final LocalDate futureDate = LocalDate.now().plusDays(7);
+    private String ownerToken;
+    private String[] racerTokens;
+
+    @BeforeEach
+    void setUp() {
+        OffsetDateTime now = OffsetDateTime.now();
+        User owner = userRepository.saveAndFlush(new User("owner.race", passwordEncoder.encode("Password1"),
+                "Owner", "Race", "owner.race@example.com", UserRole.USER, UserStatus.ACTIVE, now, now));
+        ownerToken = jwtService.generateAccessToken(owner);
+        racerTokens = new String[RACERS];
+        for (int i = 0; i < RACERS; i++) {
+            User u = userRepository.saveAndFlush(new User("joinrace" + i, passwordEncoder.encode("Password1"),
+                    "Joiner", "R" + i, "joinrace" + i + "@example.com", UserRole.USER, UserStatus.ACTIVE, now, now));
+            racerTokens[i] = jwtService.generateAccessToken(u);
+        }
+    }
+
+    private String createReservaWithOneFreeSeat() throws Exception {
+        // owner + 2 registered guests → 3/4 occupied, exactly ONE seat left.
+        OffsetDateTime now = OffsetDateTime.now();
+        User g2 = userRepository.saveAndFlush(new User("guest2", passwordEncoder.encode("Password1"),
+                "Guest", "Two", "guest2@example.com", UserRole.USER, UserStatus.ACTIVE, now, now));
+        User g3 = userRepository.saveAndFlush(new User("guest3", passwordEncoder.encode("Password1"),
+                "Guest", "Three", "guest3@example.com", UserRole.USER, UserStatus.ACTIVE, now, now));
+        String body = objectMapper.writeValueAsString(new CrearReservaRequest(
+                futureDate.toString(), "18:00", 60, "race", List.of(
+                        new CrearReservaRequest.ParticipanteAdicional(g2.getId(), null, null),
+                        new CrearReservaRequest.ParticipanteAdicional(g3.getId(), null, null))));
+        MvcResult result = mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                        .post("/api/reservas")
+                        .header("Authorization", "Bearer " + ownerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsString()).get("id").asText();
+    }
+
+    @Test
+    @DisplayName("2.2 N uniones simultáneas a la última plaza → exactamente 1×200 y (N-1)×422")
+    void should_admit_exactly_one_to_the_last_seat() throws Exception {
+        String reservaId = createReservaWithOneFreeSeat();
+        String url = "http://localhost:" + port + "/api/reservas/" + reservaId + "/unirse";
+
+        HttpClient client = HttpClient.newHttpClient();
+        ExecutorService executor = Executors.newFixedThreadPool(RACERS);
+        CountDownLatch ready = new CountDownLatch(RACERS);
+        CountDownLatch start = new CountDownLatch(1);
+        AtomicInteger ok = new AtomicInteger();
+        AtomicInteger unprocessable = new AtomicInteger();
+        AtomicInteger other = new AtomicInteger();
+
+        List<Future<Integer>> futures = new ArrayList<>();
+        for (int i = 0; i < RACERS; i++) {
+            final String token = racerTokens[i];
+            futures.add(executor.submit(() -> {
+                HttpRequest request = HttpRequest.newBuilder()
+                        .uri(URI.create(url))
+                        .header("Authorization", "Bearer " + token)
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.noBody())
+                        .build();
+                ready.countDown();
+                start.await();
+                HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+                int code = response.statusCode();
+                if (code == 200) {
+                    ok.incrementAndGet();
+                } else if (code == 422) {
+                    unprocessable.incrementAndGet();
+                } else {
+                    other.incrementAndGet();
+                }
+                return code;
+            }));
+        }
+
+        ready.await(10, TimeUnit.SECONDS);
+        start.countDown();
+        for (Future<Integer> f : futures) {
+            f.get(30, TimeUnit.SECONDS);
+        }
+        executor.shutdown();
+
+        assertThat(other.get()).as("unexpected status codes (neither 200 nor 422)").isZero();
+        assertThat(ok.get()).as("exactly one 200").isEqualTo(1);
+        assertThat(unprocessable.get()).as("the rest are 422").isEqualTo(RACERS - 1);
+
+        // DB invariant: the reservation ended up with exactly max_participants (4) participants.
+        var r = reservationRepository.findByIdWithParticipants(UUID.fromString(reservaId)).orElseThrow();
+        assertThat(r.getParticipants()).hasSize(4);
+    }
+}

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2019,6 +2019,19 @@ components:
           type: string
           description: Nombre del participante (registrado o externo)
           example: "Carlos García"
+        externalName:
+          type: string
+          description: Nombre del invitado externo (null si es usuario registrado)
+          nullable: true
+          example: "Invitado Externo"
+        externalPhone:
+          type: string
+          description: >-
+            Teléfono del invitado externo. RN-RGPD-03: solo el titular (owner) y ADMIN reciben
+            este campo. A un co-participante que se unió a la partida se le devuelve `null`
+            (minimización de datos personales).
+          nullable: true
+          example: "+34611223344"
         statusPago:
           $ref: '#/components/schemas/PaymentStatus'
         isOwner:
@@ -2134,7 +2147,10 @@ components:
           example: 15.00
         notes:
           type: string
-          description: Observaciones libres del titular
+          description: >-
+            Observaciones libres del titular. RN-RGPD-03: solo el titular (owner) y ADMIN reciben
+            este campo. A un co-participante que se unió a la partida se le devuelve `null`
+            (minimización de datos personales).
           nullable: true
           example: "Reserva para partido de entrenamiento"
         participants:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -673,6 +673,41 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
 
+  /partidas:
+    get:
+      tags: [Reservas]
+      operationId: listarPartidasAbiertas
+      summary: Listar partidas abiertas (reservas con plazas libres)
+      description: |
+        Devuelve las partidas abiertas de una fecha: reservas activas
+        (PENDING_CONFIRMATION o CONFIRMED) con al menos una plaza libre, cada una identificada por
+        su `reservaId` para poder unirse. Solo se exponen nombres de display de los participantes
+        (sin email ni teléfono, RN-RGPD-03). Las reservas completas no aparecen. El importe es
+        informativo (el total de la reserva); unirse no cobra online. Requiere autenticación
+        (USER o ADMIN).
+      parameters:
+        - name: fecha
+          in: query
+          description: Fecha para la que se listan las partidas abiertas (formato YYYY-MM-DD)
+          required: true
+          schema:
+            type: string
+            format: date
+            example: "2025-06-15"
+      responses:
+        '200':
+          description: Listado de partidas abiertas devuelto correctamente
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PartidaAbierta'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
   /reservas:
     get:
       tags: [Reservas]
@@ -861,9 +896,43 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
         '409':
-          $ref: '#/components/responses/Conflict'
+          description: |
+            El usuario ya participa en la reserva (RN-AUTH-03). Error code `CONFLICT`.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
-          description: La reserva está completa o no admite nuevos participantes
+          description: |
+            La reserva está completa (`PARTICIPANTS_LIMIT_EXCEEDED`, RN-RES-02) o su estado no admite
+            unión (`RESERVA_NOT_JOINABLE`; CANCELLED/COMPLETED).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /reservas/{id}/participacion:
+    delete:
+      tags: [Reservas]
+      operationId: abandonarReserva
+      summary: Abandonar una partida (participante no-owner)
+      description: |
+        Permite a un participante no-owner abandonar una reserva a la que se unió, liberando su plaza.
+        El titular (owner) NO puede abandonar: debe cancelar la reserva mediante el flujo de
+        cancelación. Requiere ROLE_USER o ROLE_ADMIN.
+      parameters:
+        - $ref: '#/components/parameters/ReservationIdParam'
+      responses:
+        '204':
+          description: El participante ha abandonado la reserva (plaza liberada)
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          description: |
+            El titular no puede abandonar (`OWNER_CANNOT_ABANDON`), el usuario no participa en la
+            reserva (`NOT_A_PARTICIPANT`) o la reserva no está activa (`RESERVA_NOT_JOINABLE`).
           content:
             application/json:
               schema:
@@ -2205,6 +2274,75 @@ components:
           example: "Jane Smith"
         statusPago:
           $ref: '#/components/schemas/PaymentStatus'
+
+    PartidaParticipante:
+      type: object
+      description: |
+        Participante de una partida abierta. Solo datos no sensibles (RN-RGPD-03): nombre de display,
+        posición de plaza y flag de titular. Nunca email ni teléfono.
+      required:
+        - nombre
+        - slotPosition
+        - owner
+      properties:
+        nombre:
+          type: string
+          description: Nombre de display del participante
+          example: "Jane Smith"
+        slotPosition:
+          type: integer
+          description: Posición de la plaza (1..4)
+          example: 1
+        owner:
+          type: boolean
+          description: Si el participante es el titular de la reserva
+          example: true
+
+    PartidaAbierta:
+      type: object
+      description: |
+        Partida abierta: reserva activa con al menos una plaza libre, identificable por `reservaId`
+        para poder unirse. `priceTotal` es el total informativo de la reserva; unirse no cobra online.
+      required:
+        - reservaId
+        - reservationDate
+        - startTime
+        - durationMinutes
+        - plazasLibres
+        - participantes
+      properties:
+        reservaId:
+          type: string
+          format: uuid
+          description: UUID de la reserva
+          example: "550e8400-e29b-41d4-a716-446655440000"
+        reservationDate:
+          type: string
+          format: date
+          description: Fecha de la partida
+          example: "2025-06-15"
+        startTime:
+          type: string
+          description: Hora de inicio (HH:mm:ss)
+          example: "18:00:00"
+        durationMinutes:
+          type: integer
+          description: Duración en minutos
+          example: 60
+        plazasLibres:
+          type: integer
+          description: Plazas libres restantes (max_participants − participantes actuales)
+          example: 3
+        priceTotal:
+          type: number
+          format: double
+          description: Importe total informativo de la reserva
+          example: 15.00
+        participantes:
+          type: array
+          description: Participantes actuales (solo nombres de display)
+          items:
+            $ref: '#/components/schemas/PartidaParticipante'
 
     PaginatedReservasResponse:
       allOf:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,8 @@ import { DisponibilidadPage } from './pages/DisponibilidadPage';
 import { ConfirmarReservaPage } from './pages/ConfirmarReservaPage';
 import { MisReservasPage } from './pages/MisReservasPage';
 import { DetalleReservaPage } from './pages/DetalleReservaPage';
+import { PartidasAbiertasPage } from './pages/PartidasAbiertasPage';
+import { ConfirmarUnionPage } from './pages/ConfirmarUnionPage';
 import { reservasPaths } from './pages/reservasPaths';
 
 function App() {
@@ -41,6 +43,10 @@ function App() {
             <Route path={reservasPaths.confirmar} element={<ConfirmarReservaPage />} />
             <Route path={reservasPaths.mias} element={<MisReservasPage />} />
             <Route path={reservasPaths.detalle(':id')} element={<DetalleReservaPage />} />
+
+            {/* Partidas — unirse a reservas con plazas libres (partidas-unirse) */}
+            <Route path={reservasPaths.partidas} element={<PartidasAbiertasPage />} />
+            <Route path={reservasPaths.confirmarUnion(':id')} element={<ConfirmarUnionPage />} />
           </Route>
 
           {/* Rutas de administración — guard de rol ADMIN (D6) */}

--- a/frontend/src/pages/ConfirmarUnionPage.module.css
+++ b/frontend/src/pages/ConfirmarUnionPage.module.css
@@ -1,0 +1,263 @@
+/* ConfirmarUnionPage — confirmar unión a una partida (mockup 22) */
+
+.page {
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  background: var(--cream);
+  max-width: 480px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+/* ── Hero oscuro ── */
+.header {
+  background: var(--ink, #0d0d0d);
+  color: var(--white, #fff);
+  padding: 24px 24px 28px;
+  border-radius: 0 0 28px 28px;
+}
+
+.backBtn {
+  background: rgba(255, 255, 255, 0.12);
+  border: none;
+  color: var(--white, #fff);
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  font-size: 18px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.headStatus {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 18px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.headDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--lime, #dff265);
+}
+
+.headTitle {
+  font-family: var(--font-display);
+  font-size: 40px;
+  line-height: 0.95;
+  letter-spacing: -0.03em;
+  margin: 10px 0 0;
+}
+
+.headTitle em {
+  font-style: italic;
+  font-weight: 500;
+  color: var(--lime, #dff265);
+}
+
+.headTime {
+  margin-top: 14px;
+  font-size: 15px;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.headCode {
+  margin-top: 4px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+/* ── Secciones ── */
+.section {
+  padding: 22px 24px 0;
+}
+
+.sectionTitle {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin: 0 0 12px;
+}
+
+.players {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.player {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--ink);
+}
+
+.playerEmpty {
+  color: var(--muted);
+}
+
+.hostTag {
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--olive);
+  color: var(--lime, #dff265);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.avatarEmpty {
+  background: rgba(13, 13, 13, 0.06);
+  color: var(--muted);
+  border: 2px dashed rgba(13, 13, 13, 0.2);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.pill {
+  background: var(--white);
+  border: 1px solid var(--line, #e5e3d8);
+  border-radius: 14px;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.pillLab {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.pillVal {
+  font-family: var(--font-display);
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+}
+
+.infoBox {
+  margin: 18px 24px 0;
+  background: var(--bg-warm, #f3f0e6);
+  border-radius: 14px;
+  padding: 14px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--muted);
+}
+
+.infoBox b {
+  color: var(--ink);
+}
+
+.footer {
+  padding: 22px 24px 40px;
+  margin-top: auto;
+}
+
+.joinBtn {
+  width: 100%;
+}
+
+/* ── Tarjetas de resultado (éxito / aviso) ── */
+.successCard,
+.noticeCard {
+  margin: auto;
+  padding: 40px 28px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  max-width: 400px;
+}
+
+.successMark {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: var(--lime, #dff265);
+  color: var(--ink);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 32px;
+  font-weight: 700;
+}
+
+.successTitle,
+.noticeTitle {
+  font-family: var(--font-display);
+  font-size: 28px;
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+  margin: 0;
+}
+
+.successText,
+.noticeText {
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--muted);
+  margin: 0;
+}
+
+.loadingWrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex: 1;
+  padding: 48px 0;
+}
+
+.spinner {
+  width: 32px;
+  height: 32px;
+  border: 3px solid rgba(13, 13, 13, 0.15);
+  border-top-color: var(--olive);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/frontend/src/pages/ConfirmarUnionPage.tsx
+++ b/frontend/src/pages/ConfirmarUnionPage.tsx
@@ -1,0 +1,299 @@
+// partidas-unirse (Grupo 4.3/4.4) — ConfirmarUnionPage (mockup 22).
+// Confirma la unión a una partida abierta. Como el usuario aún NO participa, no
+// puede usar GET /reservas/{id} (403): re-consulta el listado de partidas de la
+// fecha (query `fecha`) y localiza la partida por `reservaId`.
+//
+// "Tu parte" = priceTotal ÷ (participantes + 1) es INFORMATIVO: la unión no crea
+// pago ni cobra online (pago presencial; el cobro compartido se difiere a
+// pagos-redsys). Unirse → POST /reservas/{id}/unirse (sin body). Se discrimina por
+// `err.status`: 409 ya participante (sin checkout), 422 completa/estado no unible,
+// 404 inexistente, 401 sesión caducada.
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Navigate, useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+import {
+  getPartidasAbiertas,
+  unirseReserva,
+  isReservaApiError,
+  PartidaAbierta,
+} from '../services/reservasApi';
+import { reservasPaths } from './reservasPaths';
+import './pages.css';
+import styles from './ConfirmarUnionPage.module.css';
+
+function formatPrecio(amount: number): string {
+  return new Intl.NumberFormat('es-ES', { style: 'currency', currency: 'EUR' }).format(amount);
+}
+
+function iniciales(nombre: string): string {
+  const parts = nombre.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return '?';
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+/** Estado de la acción de unirse (no del fetch inicial). */
+type JoinState =
+  | { kind: 'idle' }
+  | { kind: 'joining' }
+  | { kind: 'joined' }
+  | { kind: 'already' } // 409: ya es participante (sin checkout)
+  | { kind: 'full' } //    422: completa / estado no unible
+  | { kind: 'notfound' } // 404
+  | { kind: 'error'; message: string };
+
+export function ConfirmarUnionPage() {
+  const { accessToken, isAuthenticated } = useAuth();
+  const navigate = useNavigate();
+  const { id } = useParams<{ id: string }>();
+  const [params] = useSearchParams();
+  const fecha = params.get('fecha') ?? '';
+
+  const [partida, setPartida] = useState<PartidaAbierta | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<boolean>(false);
+  const [join, setJoin] = useState<JoinState>({ kind: 'idle' });
+
+  const load = useCallback(async () => {
+    if (!accessToken || !id) return;
+    setLoading(true);
+    setLoadError(false);
+    try {
+      const lista = await getPartidasAbiertas(accessToken, fecha);
+      setPartida(lista.find((p) => p.reservaId === id) ?? null);
+    } catch {
+      setPartida(null);
+      setLoadError(true);
+    } finally {
+      setLoading(false);
+    }
+  }, [accessToken, id, fecha]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  // "Tu parte" informativa: total ÷ (participantes actuales + 1 = tú).
+  const tuParte = useMemo(() => {
+    if (!partida) return 0;
+    return partida.priceTotal / (partida.participantes.length + 1);
+  }, [partida]);
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
+
+  async function handleUnirse() {
+    if (!accessToken || !id) return;
+    setJoin({ kind: 'joining' });
+    try {
+      await unirseReserva(accessToken, id);
+      setJoin({ kind: 'joined' });
+    } catch (err) {
+      if (isReservaApiError(err)) {
+        if (err.code === 'AUTH_REQUIRED') {
+          navigate('/login', { replace: true });
+          return;
+        }
+        if (err.status === 409) return setJoin({ kind: 'already' });
+        if (err.status === 422) return setJoin({ kind: 'full' });
+        if (err.status === 404) return setJoin({ kind: 'notfound' });
+      }
+      setJoin({ kind: 'error', message: 'No se pudo completar la unión. Inténtalo de nuevo.' });
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className={styles.page}>
+        <div className={styles.loadingWrapper}>
+          <div className={styles.spinner} role="status" aria-label="Cargando partida" />
+        </div>
+      </div>
+    );
+  }
+
+  // Pantalla de éxito: unión confirmada (sin pago online).
+  if (join.kind === 'joined') {
+    return (
+      <div className={styles.page}>
+        <div className={styles.successCard} role="status">
+          <div className={styles.successMark} aria-hidden="true">✓</div>
+          <h1 className={styles.successTitle}>Te has unido a la partida</h1>
+          <p className={styles.successText}>
+            ¡Listo! Ya formas parte de esta partida. El pago se realiza de forma presencial
+            en el club (sin pasarela online).
+          </p>
+          <button
+            type="button"
+            className="p-btn p-btn-dark"
+            onClick={() => navigate(reservasPaths.mias)}
+          >
+            Ver mis reservas
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // 409: ya es participante — mensaje claro, SIN checkout.
+  if (join.kind === 'already') {
+    return (
+      <div className={styles.page}>
+        <div className={styles.noticeCard} role="alert">
+          <h1 className={styles.noticeTitle}>Ya estás en esta partida</h1>
+          <p className={styles.noticeText}>
+            Ya figuras como participante de esta partida, así que no hace falta que te unas
+            de nuevo. Puedes verla en tus reservas.
+          </p>
+          <button
+            type="button"
+            className="p-btn p-btn-primary"
+            onClick={() => navigate(reservasPaths.mias)}
+          >
+            Ver mis reservas
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // 422: completa / estado no unible.
+  if (join.kind === 'full') {
+    return (
+      <div className={styles.page}>
+        <div className={styles.noticeCard} role="alert">
+          <h1 className={styles.noticeTitle}>Partida completa</h1>
+          <p className={styles.noticeText}>
+            Esta partida ya no admite nuevos jugadores: se ha completado o ya no está
+            disponible. Vuelve al listado para elegir otra.
+          </p>
+          <button
+            type="button"
+            className="p-btn p-btn-primary"
+            onClick={() => navigate(reservasPaths.partidas)}
+          >
+            Ver otras partidas
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // La partida no aparece en el listado (completada/cancelada entre pantallas), 404
+  // al unirse, o fallo de carga: aviso neutro sin exponer datos.
+  if (!partida || loadError || join.kind === 'notfound') {
+    return (
+      <div className={styles.page}>
+        <div className={styles.noticeCard} role="alert">
+          <h1 className={styles.noticeTitle}>Partida ya no disponible</h1>
+          <p className={styles.noticeText}>
+            Esta partida ya no está disponible. Puede que se haya completado o cancelado.
+            Vuelve al listado para ver las partidas abiertas.
+          </p>
+          <button
+            type="button"
+            className="p-btn p-btn-primary"
+            onClick={() => navigate(reservasPaths.partidas)}
+          >
+            Ver partidas abiertas
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.page}>
+      <header className={styles.header}>
+        <button
+          type="button"
+          className={styles.backBtn}
+          onClick={() => navigate(reservasPaths.partidas)}
+          aria-label="Volver a partidas"
+        >
+          ←
+        </button>
+        <span className={styles.headStatus}>
+          <span className={styles.headDot} aria-hidden="true" /> Partida abierta · {fecha}
+        </span>
+        <h1 className={styles.headTitle}>
+          {partida.plazasLibres === 1 ? (
+            <>Falta<br /><em>1 jugador.</em></>
+          ) : (
+            <>Faltan<br /><em>{partida.plazasLibres} jugadores.</em></>
+          )}
+        </h1>
+        <div className={styles.headTime}>
+          {partida.startTime} · {partida.durationMinutes} min
+        </div>
+        <div className={styles.headCode}>{partida.reservaId}</div>
+      </header>
+
+      <section className={styles.section}>
+        <h3 className={styles.sectionTitle}>
+          Jugadores · {partida.participantes.length} confirmados
+        </h3>
+        <ul className={styles.players}>
+          {partida.participantes.map((p) => (
+            <li key={p.slotPosition} className={styles.player}>
+              <span className={styles.avatar}>{iniciales(p.nombre)}</span>
+              {p.nombre}
+              {p.owner && <span className={styles.hostTag}> · Anfitrión</span>}
+            </li>
+          ))}
+          <li className={`${styles.player} ${styles.playerEmpty}`}>
+            <span className={`${styles.avatar} ${styles.avatarEmpty}`}>?</span>
+            Tú
+          </li>
+        </ul>
+      </section>
+
+      <section className={styles.section}>
+        <h3 className={styles.sectionTitle}>Detalles</h3>
+        <div className={styles.grid}>
+          <div className={styles.pill}>
+            <span className={styles.pillLab}>Horario</span>
+            <span className={styles.pillVal}>{partida.startTime}</span>
+          </div>
+          <div className={styles.pill}>
+            <span className={styles.pillLab}>Duración</span>
+            <span className={styles.pillVal}>{partida.durationMinutes} min</span>
+          </div>
+          <div className={styles.pill}>
+            <span className={styles.pillLab}>Tu parte</span>
+            <span className={styles.pillVal} data-testid="tu-parte">{formatPrecio(tuParte)}</span>
+          </div>
+          <div className={styles.pill}>
+            <span className={styles.pillLab}>Total partida</span>
+            <span className={styles.pillVal}>{formatPrecio(partida.priceTotal)}</span>
+          </div>
+        </div>
+      </section>
+
+      <div className={styles.infoBox}>
+        <b>Importe informativo.</b> Tu parte ({formatPrecio(tuParte)}) es orientativa: el
+        pago se realiza de forma <b>presencial</b> en el club. No se cobra online al unirte.
+      </div>
+
+      {join.kind === 'error' && (
+        <p className="p-error" role="alert">
+          {join.message}
+        </p>
+      )}
+
+      <div className={styles.footer}>
+        <button
+          type="button"
+          className={`p-btn p-btn-primary ${styles.joinBtn}`}
+          onClick={handleUnirse}
+          disabled={join.kind === 'joining'}
+        >
+          {join.kind === 'joining'
+            ? 'Uniéndote…'
+            : `Unirme · ${formatPrecio(tuParte)} →`}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/DetalleReservaPage.tsx
+++ b/frontend/src/pages/DetalleReservaPage.tsx
@@ -10,6 +10,7 @@ import { useAuth } from '../context/AuthContext';
 import {
   getReserva,
   cancelarReserva,
+  abandonarReserva,
   isReservaApiError,
   ReservaResponse,
   ReservationStatus,
@@ -41,6 +42,10 @@ export function DetalleReservaPage() {
   const [confirming, setConfirming] = useState(false);
   const [cancelling, setCancelling] = useState(false);
   const [cancelError, setCancelError] = useState<string | null>(null);
+
+  const [abandonConfirm, setAbandonConfirm] = useState(false);
+  const [abandoning, setAbandoning] = useState(false);
+  const [abandonError, setAbandonError] = useState<string | null>(null);
 
   // Asegura el id de usuario (D8) para decidir la visibilidad del botón cancelar.
   useEffect(() => {
@@ -78,6 +83,33 @@ export function DetalleReservaPage() {
   const canCancel = Boolean(
     reserva && isOwner && ESTADOS_CANCELABLES.includes(reserva.status)
   );
+
+  // Abandonar (partidas-unirse): visible solo para el participante no-owner (se unió
+  // a la partida) y estado activo. El owner no puede abandonar (debe cancelar). La
+  // barrera real la impone el backend.
+  const isParticipanteNoOwner = Boolean(
+    reserva &&
+      userId != null &&
+      !isOwner &&
+      reserva.participants.some((p) => !p.owner && p.userId === userId)
+  );
+  const canAbandon = Boolean(
+    reserva && isParticipanteNoOwner && ESTADOS_CANCELABLES.includes(reserva.status)
+  );
+
+  async function handleConfirmAbandon() {
+    if (!accessToken || !id) return;
+    setAbandoning(true);
+    setAbandonError(null);
+    try {
+      await abandonarReserva(accessToken, id);
+      navigate(reservasPaths.mias);
+    } catch {
+      setAbandonError('No se pudo abandonar la partida. Inténtalo de nuevo.');
+    } finally {
+      setAbandoning(false);
+    }
+  }
 
   async function handleConfirmCancel() {
     if (!accessToken || !id) return;
@@ -251,6 +283,55 @@ export function DetalleReservaPage() {
               disabled={cancelling}
             >
               {cancelling ? 'Cancelando…' : 'Confirmar cancelación'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {abandonError && (
+        <p className="p-error" role="alert">
+          {abandonError}
+        </p>
+      )}
+
+      {/* Abandonar: visible solo para el participante no-owner y estados activos */}
+      {canAbandon && !abandonConfirm && (
+        <button
+          type="button"
+          className={`p-btn ${styles.cancelBtn}`}
+          onClick={() => {
+            setAbandonError(null);
+            setAbandonConfirm(true);
+          }}
+        >
+          Abandonar partida
+        </button>
+      )}
+
+      {canAbandon && abandonConfirm && (
+        <div className={styles.confirmPanel} role="dialog" aria-label="Confirmar abandono">
+          <p className={styles.confirmPolicy}>
+            <b>Abandonar partida</b>
+            <br />
+            Dejarás tu plaza libre para que otro jugador pueda unirse. El pago se
+            gestiona de forma presencial en el club.
+          </p>
+          <div className={styles.confirmActions}>
+            <button
+              type="button"
+              className="p-btn p-btn-outline"
+              onClick={() => setAbandonConfirm(false)}
+              disabled={abandoning}
+            >
+              Volver
+            </button>
+            <button
+              type="button"
+              className={`p-btn ${styles.cancelBtn}`}
+              onClick={handleConfirmAbandon}
+              disabled={abandoning}
+            >
+              {abandoning ? 'Abandonando…' : 'Confirmar abandono'}
             </button>
           </div>
         </div>

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -63,6 +63,19 @@ export function HomePage() {
           <div className={styles.actionSub}>Encuentra una franja libre</div>
         </button>
 
+        <Link to={reservasPaths.partidas} className={styles.action}>
+          <div className={styles.actionIco}>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+              <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+              <circle cx="9" cy="7" r="4" />
+              <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
+              <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+            </svg>
+          </div>
+          <div className={styles.actionLabel}>Partidas abiertas</div>
+          <div className={styles.actionSub}>Únete a una partida con plazas libres</div>
+        </Link>
+
         <Link to={reservasPaths.mias} className={styles.action}>
           <div className={styles.actionIco}>
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">

--- a/frontend/src/pages/PartidasAbiertasPage.module.css
+++ b/frontend/src/pages/PartidasAbiertasPage.module.css
@@ -1,0 +1,245 @@
+/* PartidasAbiertasPage — partidas abiertas (mockup 21) */
+
+.page {
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  background: var(--cream);
+  max-width: 480px;
+  margin: 0 auto;
+  width: 100%;
+  padding: 20px 24px 48px;
+  gap: 4px;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.homeBtn {
+  background: transparent;
+  border: 1.5px solid rgba(13, 13, 13, 0.25);
+  border-radius: 999px;
+  padding: 6px 14px;
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ink);
+  cursor: pointer;
+  transition: border-color 0.15s ease;
+}
+
+.homeBtn:hover {
+  border-color: var(--ink);
+}
+
+.titleBlock {
+  padding: 24px 0 8px;
+}
+
+.eyebrow {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.titleBlock h1 {
+  font-family: var(--font-display);
+  font-size: 40px;
+  line-height: 0.95;
+  letter-spacing: -0.03em;
+  margin: 4px 0 0;
+  color: var(--ink);
+}
+
+.titleBlock em {
+  font-style: italic;
+  color: var(--olive);
+}
+
+.fieldGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 16px 0;
+}
+
+.fieldLabel {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.dateInput {
+  border: 1.5px solid rgba(13, 13, 13, 0.2);
+  border-radius: 12px;
+  padding: 12px 14px;
+  font-size: 15px;
+  font-family: var(--font-body);
+  color: var(--ink);
+  background: var(--white);
+  cursor: pointer;
+  width: 100%;
+}
+
+.dateInput:focus {
+  outline: none;
+  border-color: var(--ink);
+}
+
+.list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin-top: 8px;
+}
+
+.card {
+  background: var(--white);
+  border: 1px solid var(--line, #e5e3d8);
+  border-radius: 18px;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.cardHead {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.whenBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.hora {
+  font-family: var(--font-display);
+  font-size: 26px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+}
+
+.dur {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.plazas {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--olive);
+  background: rgba(122, 132, 79, 0.12);
+  border-radius: 999px;
+  padding: 6px 12px;
+  white-space: nowrap;
+}
+
+.players {
+  display: flex;
+  align-items: center;
+  gap: -6px;
+}
+
+.avatar {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  background: var(--olive);
+  color: var(--lime, #dff265);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  border: 2px solid var(--white);
+  margin-left: -8px;
+}
+
+.avatar:first-child {
+  margin-left: 0;
+}
+
+.avatarEmpty {
+  background: rgba(13, 13, 13, 0.06);
+  color: var(--muted);
+  border-style: dashed;
+  border-color: rgba(13, 13, 13, 0.2);
+}
+
+.cardFooter {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  border-top: 1px solid var(--line, #e5e3d8);
+  padding-top: 14px;
+}
+
+.price {
+  font-family: var(--font-display);
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--ink);
+}
+
+.price small {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.joinBtn {
+  width: auto;
+  padding: 10px 20px;
+  border-radius: 10px;
+}
+
+.empty {
+  padding: 40px 0;
+  text-align: center;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.loadingWrapper {
+  display: flex;
+  justify-content: center;
+  padding: 48px 0;
+}
+
+.spinner {
+  width: 32px;
+  height: 32px;
+  border: 3px solid rgba(13, 13, 13, 0.15);
+  border-top-color: var(--olive);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/frontend/src/pages/PartidasAbiertasPage.tsx
+++ b/frontend/src/pages/PartidasAbiertasPage.tsx
@@ -1,0 +1,170 @@
+// partidas-unirse (Grupo 4.1/4.2) — PartidasAbiertasPage (mockup 21).
+// Selector de fecha → GET /api/partidas?fecha=YYYY-MM-DD (reservas activas con
+// plazas libres). Cada tarjeta muestra hora, duración, plazas libres y los
+// participantes (nombre de display, sin PII). Seleccionar una partida navega a
+// "Confirmar unión" con su reservaId y la fecha (la confirmación re-consulta el
+// listado; no puede usar GET /reservas/{id} porque aún no es participante → 403).
+import { useCallback, useEffect, useState } from 'react';
+import { Navigate, useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+import { getPartidasAbiertas, PartidaAbierta } from '../services/reservasApi';
+import { confirmarUnionPath, reservasPaths } from './reservasPaths';
+import './pages.css';
+import styles from './PartidasAbiertasPage.module.css';
+
+/** Fecha de hoy en formato YYYY-MM-DD (input type=date). */
+function todayISO(): string {
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, '0');
+  const d = String(now.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+/** Iniciales de display a partir del nombre (para el avatar). */
+function iniciales(nombre: string): string {
+  const parts = nombre.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return '?';
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+/** Copy de plazas libres ("falta 1 jugador" / "faltan N jugadores"). */
+function plazasLabel(plazas: number): string {
+  if (plazas <= 0) return 'Completa';
+  return plazas === 1 ? 'falta 1 jugador' : `faltan ${plazas} jugadores`;
+}
+
+function formatPrecio(amount: number): string {
+  return new Intl.NumberFormat('es-ES', { style: 'currency', currency: 'EUR' }).format(amount);
+}
+
+export function PartidasAbiertasPage() {
+  const { accessToken, isAuthenticated } = useAuth();
+  const navigate = useNavigate();
+
+  const [fecha, setFecha] = useState<string>(todayISO());
+  const [partidas, setPartidas] = useState<PartidaAbierta[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!accessToken) return;
+    setLoading(true);
+    setErrorMsg(null);
+    try {
+      const data = await getPartidasAbiertas(accessToken, fecha);
+      setPartidas(data);
+    } catch {
+      setPartidas([]);
+      setErrorMsg('No se pudieron cargar las partidas. Inténtalo de nuevo.');
+    } finally {
+      setLoading(false);
+    }
+  }, [accessToken, fecha]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
+
+  function handleUnirse(reservaId: string) {
+    navigate(confirmarUnionPath(reservaId, fecha));
+  }
+
+  return (
+    <div className={styles.page}>
+      <header className={styles.header}>
+        <div className="p-logo">
+          <span className="p-dot" />
+          PadelPro
+        </div>
+        <button
+          type="button"
+          className={styles.homeBtn}
+          onClick={() => navigate(reservasPaths.home)}
+        >
+          Inicio
+        </button>
+      </header>
+
+      <div className={styles.titleBlock}>
+        <span className={styles.eyebrow}>Partidas</span>
+        <h1>
+          Partidas<br />
+          <em>abiertas.</em>
+        </h1>
+      </div>
+
+      <div className={styles.fieldGroup}>
+        <label className={styles.fieldLabel} htmlFor="partidas-fecha">
+          Fecha
+        </label>
+        <input
+          id="partidas-fecha"
+          className={styles.dateInput}
+          type="date"
+          value={fecha}
+          onChange={(e) => setFecha(e.target.value)}
+        />
+      </div>
+
+      {errorMsg && (
+        <p className="p-error" role="alert">
+          {errorMsg}
+        </p>
+      )}
+
+      {loading ? (
+        <div className={styles.loadingWrapper}>
+          <div className={styles.spinner} role="status" aria-label="Cargando partidas" />
+        </div>
+      ) : partidas.length === 0 ? (
+        <p className={styles.empty}>No hay partidas abiertas para esta fecha.</p>
+      ) : (
+        <ul className={styles.list}>
+          {partidas.map((partida) => (
+            <li key={partida.reservaId} className={styles.card} data-partida>
+              <div className={styles.cardHead}>
+                <div className={styles.whenBlock}>
+                  <span className={styles.hora}>{partida.startTime}</span>
+                  <span className={styles.dur}>{partida.durationMinutes} min</span>
+                </div>
+                <span className={styles.plazas}>{plazasLabel(partida.plazasLibres)}</span>
+              </div>
+
+              <div className={styles.players}>
+                {partida.participantes.map((p) => (
+                  <span key={`${partida.reservaId}-${p.slotPosition}`} className={styles.avatar} title={p.nombre}>
+                    {iniciales(p.nombre)}
+                  </span>
+                ))}
+                {Array.from({ length: Math.max(0, partida.plazasLibres) }).map((_, i) => (
+                  <span key={`${partida.reservaId}-empty-${i}`} className={`${styles.avatar} ${styles.avatarEmpty}`} aria-hidden="true">
+                    +1
+                  </span>
+                ))}
+              </div>
+
+              <div className={styles.cardFooter}>
+                <span className={styles.price}>
+                  {formatPrecio(partida.priceTotal)} <small>total</small>
+                </span>
+                <button
+                  type="button"
+                  className={`p-btn p-btn-primary ${styles.joinBtn}`}
+                  onClick={() => handleUnirse(partida.reservaId)}
+                >
+                  Unirme →
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/reservasPaths.ts
+++ b/frontend/src/pages/reservasPaths.ts
@@ -11,7 +11,22 @@ export const reservasPaths = {
   mias: '/reservas/mias',
   /** Detalle de una reserva concreta. */
   detalle: (id: string): string => `/reservas/detalle/${id}`,
+  /** Listado de partidas abiertas (reservas con plazas libres a las que unirse). */
+  partidas: '/reservas/partidas',
+  /** Confirmar la unión a una partida concreta (por `reservaId`). */
+  confirmarUnion: (id: string): string => `/reservas/partidas/${id}/unirse`,
 } as const;
+
+/**
+ * Construye el path de "Confirmar unión" a una partida, propagando la `fecha` en la
+ * query. La confirmación re-consulta el listado de partidas de esa fecha (no puede
+ * usar `GET /reservas/{id}`: aún no es participante → 403) y localiza la partida por
+ * `reservaId`. Llevar la fecha en la URL hace la pantalla resistente a recargas.
+ */
+export function confirmarUnionPath(reservaId: string, fecha: string): string {
+  const params = new URLSearchParams({ fecha });
+  return `${reservasPaths.confirmarUnion(reservaId)}?${params.toString()}`;
+}
 
 /**
  * Construye el path (string) de "Confirmar reserva" con el tramo elegido en la

--- a/frontend/src/services/reservasApi.ts
+++ b/frontend/src/services/reservasApi.ts
@@ -116,6 +116,38 @@ export interface CrearReservaPayload {
   notes?: string;
 }
 
+// ─── Partidas (partidas-unirse) ───────────────────────────────────────────────
+
+/** Participante de una partida abierta en la proyección del listado. Solo nombre
+ *  de display (sin PII: ni email ni teléfono, RN-RGPD-03). */
+export interface PartidaParticipante {
+  nombre: string;
+  slotPosition: number;
+  owner: boolean;
+}
+
+/** Partida abierta (reserva activa con plazas libres) del contrato
+ *  `GET /api/partidas?fecha=YYYY-MM-DD`. Identificable por `reservaId`; `priceTotal`
+ *  es informativo (el reparto "tu parte" lo calcula la UI, sin cobro online). */
+export interface PartidaAbierta {
+  reservaId: string;
+  reservationDate: string;
+  startTime: string;
+  durationMinutes: number;
+  plazasLibres: number;
+  priceTotal: number;
+  participantes: PartidaParticipante[];
+}
+
+/** Respuesta de `POST /api/reservas/{id}/unirse`. */
+export interface UnirseResponse {
+  participanteId: string | number;
+  reservaId: string;
+  userId: number;
+  nombre: string;
+  statusPago: string;
+}
+
 // ─── Errores tipados (D6) ─────────────────────────────────────────────────────
 
 export type ReservaErrorCode =
@@ -305,6 +337,52 @@ export async function getReserva(token: string, id: string): Promise<ReservaResp
 export async function cancelarReserva(token: string, id: string): Promise<void> {
   try {
     await api.delete(`/reservas/${id}`, { headers: authHeader(token) });
+  } catch (err) {
+    toReservaApiError(err);
+  }
+}
+
+// ─── Partidas: listar, unirse, abandonar (partidas-unirse) ─────────────────────
+
+/** GET /api/partidas?fecha=YYYY-MM-DD — partidas abiertas de la fecha (reservas
+ *  activas con plazas libres). El backend devuelve un ARRAY JSON plano; se normaliza
+ *  por robustez si llegara envuelto en `{ data: [...] }`. */
+export async function getPartidasAbiertas(token: string, fecha: string): Promise<PartidaAbierta[]> {
+  try {
+    const { data } = await api.get<PartidaAbierta[] | { data?: PartidaAbierta[] }>('/partidas', {
+      headers: authHeader(token),
+      params: { fecha },
+    });
+    if (Array.isArray(data)) return data;
+    return Array.isArray(data?.data) ? data.data : [];
+  } catch (err) {
+    toReservaApiError(err);
+  }
+}
+
+/** POST /api/reservas/{id}/unirse (sin body) — une al usuario como participante
+ *  no-owner. Errores del contrato: 404 (inexistente), 409 (ya participante, mapeado
+ *  a CONFLICT por status), 422 (completa o estado no unible). Las páginas
+ *  discriminan por `err.status` para no depender del código textual del cuerpo. */
+export async function unirseReserva(token: string, reservaId: string): Promise<UnirseResponse> {
+  try {
+    const { data } = await api.post<UnirseResponse>(
+      `/reservas/${reservaId}/unirse`,
+      undefined,
+      { headers: authHeader(token) }
+    );
+    return data;
+  } catch (err) {
+    toReservaApiError(err);
+  }
+}
+
+/** DELETE /api/reservas/{id}/participacion — 204. Abandona una partida en la que
+ *  el usuario participa como no-owner (libera su plaza). El owner no puede abandonar
+ *  (debe cancelar): el backend lo rechaza. */
+export async function abandonarReserva(token: string, reservaId: string): Promise<void> {
+  try {
+    await api.delete(`/reservas/${reservaId}/participacion`, { headers: authHeader(token) });
   } catch (err) {
     toReservaApiError(err);
   }

--- a/frontend/src/test/ConfirmarUnionPage.test.tsx
+++ b/frontend/src/test/ConfirmarUnionPage.test.tsx
@@ -1,0 +1,129 @@
+// partidas-unirse (Grupo 4.3/4.4) — ConfirmarUnionPage (mockup 22) — TDD.
+// Detalle de la partida (re-consultada del listado por reservaId) + "tu parte"
+// informativo (priceTotal ÷ (participantes+1)) con aviso de pago presencial (sin
+// pasarela). Unirse → POST /reservas/{id}/unirse. 200 → confirmación; 409 ya
+// participante → mensaje sin checkout; 422 completa → mensaje.
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, afterEach } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { http, HttpResponse } from 'msw';
+import { AuthContext } from '../context/AuthContext';
+import { ConfirmarUnionPage } from '../pages/ConfirmarUnionPage';
+import { server } from './mocks/server';
+
+afterEach(() => server.resetHandlers());
+
+const authValue = {
+  accessToken: 'user.jwt.token',
+  role: 'USER',
+  mustChangePassword: false,
+  userId: 42,
+  isAuthenticated: true,
+  setAccessToken: () => {},
+  setSession: () => {},
+  clearMustChangePassword: () => {},
+  loadUserId: async () => {},
+};
+
+const partida = {
+  reservaId: 'r-9',
+  reservationDate: '2026-07-10',
+  startTime: '18:30',
+  durationMinutes: 90,
+  plazasLibres: 1,
+  priceTotal: 18,
+  participantes: [
+    { nombre: 'Marcos R.', slotPosition: 1, owner: true },
+    { nombre: 'Pablo G.', slotPosition: 2, owner: false },
+    { nombre: 'Andrea S.', slotPosition: 3, owner: false },
+  ],
+};
+
+function mockPartidas(partidas: unknown[]) {
+  server.use(http.get('/api/partidas', () => HttpResponse.json(partidas)));
+}
+
+function renderPage(id = 'r-9', fecha = '2026-07-10') {
+  return render(
+    <AuthContext.Provider value={authValue}>
+      <MemoryRouter initialEntries={[`/reservas/partidas/${id}/unirse?fecha=${fecha}`]}>
+        <Routes>
+          <Route path="/reservas/partidas/:id/unirse" element={<ConfirmarUnionPage />} />
+          <Route path="/reservas/mias" element={<div>Mis reservas</div>} />
+        </Routes>
+      </MemoryRouter>
+    </AuthContext.Provider>
+  );
+}
+
+describe('ConfirmarUnionPage (Grupo 4.3/4.4)', () => {
+  it('muestra el detalle y "tu parte" = total ÷ (participantes+1), con aviso de pago presencial', async () => {
+    mockPartidas([partida]);
+    renderPage();
+
+    expect(await screen.findByText('18:30')).toBeInTheDocument();
+    // 3 participantes → tras unirte 4 → 18 / 4 = 4,50 € (pill "Tu parte").
+    expect(screen.getByTestId('tu-parte')).toHaveTextContent('4,50');
+    // Total informativo de la partida.
+    expect(screen.getByText(/18,00/)).toBeInTheDocument();
+    // Aviso de pago presencial (sin pasarela).
+    expect(screen.getByText(/presencial/i)).toBeInTheDocument();
+  });
+
+  it('unión exitosa (200) muestra confirmación', async () => {
+    mockPartidas([partida]);
+    server.use(
+      http.post('/api/reservas/r-9/unirse', () =>
+        HttpResponse.json(
+          { participanteId: 'p-1', reservaId: 'r-9', userId: 42, nombre: 'Luis', statusPago: 'PENDING' },
+          { status: 200 }
+        )
+      )
+    );
+    renderPage();
+    await screen.findByText('18:30');
+
+    await userEvent.click(screen.getByRole('button', { name: /unirme/i }));
+
+    expect(await screen.findByText(/te has unido|unión confirmada|apuntado/i)).toBeInTheDocument();
+  });
+
+  it('409 (ya participante) muestra mensaje claro sin checkout', async () => {
+    mockPartidas([partida]);
+    server.use(
+      http.post('/api/reservas/r-9/unirse', () =>
+        HttpResponse.json({ error: 'ALREADY_PARTICIPANT', message: 'ya participas' }, { status: 409 })
+      )
+    );
+    renderPage();
+    await screen.findByText('18:30');
+
+    await userEvent.click(screen.getByRole('button', { name: /unirme/i }));
+
+    expect(await screen.findByRole('heading', { name: /ya estás en esta partida/i })).toBeInTheDocument();
+    // No hay ningún flujo de pago/checkout.
+    expect(screen.queryByText(/pagar|checkout|tarjeta/i)).toBeNull();
+  });
+
+  it('422 (partida completa) muestra mensaje de completa', async () => {
+    mockPartidas([partida]);
+    server.use(
+      http.post('/api/reservas/r-9/unirse', () =>
+        HttpResponse.json({ error: 'RESERVATION_FULL', message: 'completa' }, { status: 422 })
+      )
+    );
+    renderPage();
+    await screen.findByText('18:30');
+
+    await userEvent.click(screen.getByRole('button', { name: /unirme/i }));
+
+    expect(await screen.findByRole('heading', { name: /completa|sin plazas|no quedan plazas/i })).toBeInTheDocument();
+  });
+
+  it('partida ya no disponible en el listado muestra aviso', async () => {
+    mockPartidas([]); // la partida ya no está abierta
+    renderPage();
+    expect(await screen.findByRole('heading', { name: /ya no (está|esta) disponible|no disponible|se ha completado/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/DetalleReservaPage.abandonar.test.tsx
+++ b/frontend/src/test/DetalleReservaPage.abandonar.test.tsx
@@ -1,0 +1,101 @@
+// partidas-unirse (Grupo 4.4) — abandono de partida desde el detalle.
+// Un participante no-owner que abre el detalle de una reserva en la que participa
+// ve la acción "Abandonar partida" → DELETE /api/reservas/{id}/participacion (204).
+// El owner NO ve la acción (debe cancelar). Tras abandonar, navega a mis reservas.
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, afterEach } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { http, HttpResponse } from 'msw';
+import { AuthContext } from '../context/AuthContext';
+import { DetalleReservaPage } from '../pages/DetalleReservaPage';
+import { server } from './mocks/server';
+
+afterEach(() => server.resetHandlers());
+
+function authValue(userId: number | null) {
+  return {
+    accessToken: 'user.jwt.token',
+    role: 'USER',
+    mustChangePassword: false,
+    userId,
+    isAuthenticated: true,
+    setAccessToken: () => {},
+    setSession: () => {},
+    clearMustChangePassword: () => {},
+    loadUserId: async () => {},
+  };
+}
+
+// Reserva con owner (id 7) y un participante no-owner (id 42).
+function reserva(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'r-1',
+    reservationDate: '2026-07-10',
+    startTime: '20:00',
+    endTime: '21:30',
+    durationMinutes: 90,
+    status: 'CONFIRMED',
+    channel: 'WEB',
+    ownerId: 7,
+    priceTotal: 18,
+    participants: [
+      { userId: 7, externalName: null, externalPhone: null, slotPosition: 1, owner: true },
+      { userId: 42, externalName: null, externalPhone: null, slotPosition: 2, owner: false },
+    ],
+    pago: null,
+    createdAt: '2026-07-04T10:00:00Z',
+    ...overrides,
+  };
+}
+
+function mockGetReserva(body: unknown, status = 200) {
+  server.use(http.get('/api/reservas/r-1', () => HttpResponse.json(body, { status })));
+}
+
+function renderPage(userId: number | null) {
+  return render(
+    <AuthContext.Provider value={authValue(userId)}>
+      <MemoryRouter initialEntries={['/reservas/detalle/r-1']}>
+        <Routes>
+          <Route path="/reservas/detalle/:id" element={<DetalleReservaPage />} />
+          <Route path="/reservas/mias" element={<div>Mis reservas</div>} />
+        </Routes>
+      </MemoryRouter>
+    </AuthContext.Provider>
+  );
+}
+
+describe('DetalleReservaPage — abandonar partida (Grupo 4.4)', () => {
+  it('participante no-owner ve la acción "Abandonar partida"', async () => {
+    mockGetReserva(reserva());
+    renderPage(42);
+    await screen.findByText('20:00');
+    expect(screen.getByRole('button', { name: /abandonar/i })).toBeInTheDocument();
+    // No es owner: no ve cancelar.
+    expect(screen.queryByRole('button', { name: /cancelar reserva/i })).toBeNull();
+  });
+
+  it('el owner NO ve "Abandonar" (debe cancelar)', async () => {
+    mockGetReserva(reserva());
+    renderPage(7);
+    await screen.findByText('20:00');
+    expect(screen.queryByRole('button', { name: /abandonar/i })).toBeNull();
+    expect(screen.getByRole('button', { name: /cancelar reserva/i })).toBeInTheDocument();
+  });
+
+  it('abandonar (204) navega a mis reservas', async () => {
+    mockGetReserva(reserva());
+    server.use(
+      http.delete('/api/reservas/r-1/participacion', () => new HttpResponse(null, { status: 204 }))
+    );
+    renderPage(42);
+    await screen.findByText('20:00');
+
+    await userEvent.click(screen.getByRole('button', { name: /abandonar/i }));
+    // Confirmación en dos pasos.
+    await userEvent.click(screen.getByRole('button', { name: /confirmar abandono/i }));
+
+    await waitFor(() => expect(screen.getByText('Mis reservas')).toBeInTheDocument());
+  });
+});

--- a/frontend/src/test/PartidasAbiertasPage.test.tsx
+++ b/frontend/src/test/PartidasAbiertasPage.test.tsx
@@ -1,0 +1,120 @@
+// partidas-unirse (Grupo 4.1/4.2) — PartidasAbiertasPage (mockup 21) — TDD.
+// Selector de fecha → lista de partidas abiertas desde GET /api/partidas?fecha=.
+// Cada partida muestra hora, duración y plazas libres; estado vacío y error
+// neutros. Seleccionar una partida navega a "Confirmar unión" con su reservaId y
+// la fecha (para que la confirmación re-consulte el listado).
+import { render, screen, waitFor, within, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, afterEach } from 'vitest';
+import { MemoryRouter, Route, Routes, useParams, useSearchParams } from 'react-router-dom';
+import { http, HttpResponse } from 'msw';
+import { AuthContext } from '../context/AuthContext';
+import { PartidasAbiertasPage } from '../pages/PartidasAbiertasPage';
+import { server } from './mocks/server';
+
+afterEach(() => server.resetHandlers());
+
+const authValue = {
+  accessToken: 'user.jwt.token',
+  role: 'USER',
+  mustChangePassword: false,
+  userId: 42,
+  isAuthenticated: true,
+  setAccessToken: () => {},
+  setSession: () => {},
+  clearMustChangePassword: () => {},
+  loadUserId: async () => {},
+};
+
+// Marcador de la ruta de confirmación: refleja el reservaId y la fecha recibidos.
+function ConfirmarUnionStub() {
+  const { id } = useParams<{ id: string }>();
+  const [params] = useSearchParams();
+  return (
+    <div>
+      <span data-testid="u-id">{id}</span>
+      <span data-testid="u-fecha">{params.get('fecha')}</span>
+    </div>
+  );
+}
+
+function renderPage() {
+  return render(
+    <AuthContext.Provider value={authValue}>
+      <MemoryRouter initialEntries={['/reservas/partidas']}>
+        <Routes>
+          <Route path="/reservas/partidas" element={<PartidasAbiertasPage />} />
+          <Route path="/reservas/partidas/:id/unirse" element={<ConfirmarUnionStub />} />
+        </Routes>
+      </MemoryRouter>
+    </AuthContext.Provider>
+  );
+}
+
+function mockPartidas(partidas: unknown[], status = 200) {
+  server.use(http.get('/api/partidas', () => HttpResponse.json(partidas, { status })));
+}
+
+const partidaA = {
+  reservaId: 'r-9',
+  reservationDate: '2026-07-10',
+  startTime: '18:30',
+  durationMinutes: 90,
+  plazasLibres: 1,
+  priceTotal: 18,
+  participantes: [
+    { nombre: 'Marcos R.', slotPosition: 1, owner: true },
+    { nombre: 'Pablo G.', slotPosition: 2, owner: false },
+    { nombre: 'Andrea S.', slotPosition: 3, owner: false },
+  ],
+};
+const partidaB = {
+  reservaId: 'r-10',
+  reservationDate: '2026-07-10',
+  startTime: '20:00',
+  durationMinutes: 60,
+  plazasLibres: 2,
+  priceTotal: 16,
+  participantes: [{ nombre: 'Carla L.', slotPosition: 1, owner: true }],
+};
+
+describe('PartidasAbiertasPage (Grupo 4.1/4.2)', () => {
+  it('lista las partidas abiertas con hora, duración y plazas libres', async () => {
+    mockPartidas([partidaA, partidaB]);
+    renderPage();
+
+    expect(screen.getByLabelText(/fecha/i)).toBeInTheDocument();
+    expect(await screen.findByText('18:30')).toBeInTheDocument();
+    expect(screen.getByText('20:00')).toBeInTheDocument();
+    // Plazas libres visibles (falta 1 / faltan 2).
+    expect(screen.getByText(/falta 1/i)).toBeInTheDocument();
+    expect(screen.getByText(/faltan 2/i)).toBeInTheDocument();
+  });
+
+  it('estado vacío cuando no hay partidas abiertas', async () => {
+    mockPartidas([]);
+    renderPage();
+    expect(await screen.findByText(/no hay partidas|sin partidas|no quedan/i)).toBeInTheDocument();
+  });
+
+  it('estado de error cuando el listado falla', async () => {
+    mockPartidas({ error: 'SERVER_ERROR', message: 'boom' }, 500);
+    renderPage();
+    expect(await screen.findByRole('alert')).toHaveTextContent(/no se pudo|inténtalo/i);
+  });
+
+  it('seleccionar una partida navega a confirmar unión con reservaId + fecha', async () => {
+    mockPartidas([partidaA, partidaB]);
+    renderPage();
+    const dateInput = screen.getByLabelText(/fecha/i) as HTMLInputElement;
+    fireEvent.change(dateInput, { target: { value: '2026-07-10' } });
+
+    const card = (await screen.findByText('18:30')).closest('[data-partida]') as HTMLElement;
+    await userEvent.click(within(card).getByRole('button', { name: /unirme/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('u-id')).toHaveTextContent('r-9');
+      expect(screen.getByTestId('u-fecha')).toHaveTextContent('2026-07-10');
+    });
+  });
+});

--- a/openspec/changes/partidas-unirse/.openspec.yaml
+++ b/openspec/changes/partidas-unirse/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-05

--- a/openspec/changes/partidas-unirse/design.md
+++ b/openspec/changes/partidas-unirse/design.md
@@ -1,0 +1,51 @@
+## Context
+
+`partidas` reutiliza el modelo de `reservas`: una "partida abierta" es una reserva activa (`PENDING_CONFIRMATION`/`CONFIRMED`) con `participants_count < system_config.max_participants`. La exploración confirma que las piezas de dominio existen (`Participant.registered(...)`, `Reservation.addParticipant(...)`, `Reservation.isActiveOccupant()` con los estados correctos, cálculo de plazas en `DisponibilidadService`), pero **no hay flujo de unión** ni forma de identificar la reserva joinable desde el cliente (`TramoDisponible` no lleva `reservaId`). El Requirement 3 (listar participaciones) ya lo cubre `GET /api/reservas`.
+
+Restricción de pago: los mockups muestran pago compartido ("tu parte"), pero `Payment` es 1:1 con la reserva y del owner, y `pagos-redsys` no existe. Se difiere el cobro, igual que en `reservas`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Ver las partidas abiertas (reservas joinable) identificables por `reservaId`.
+- Unirse a una reserva con plazas libres, con validaciones 404/409/422 (RN-AUTH-03, RN-RES-02) y estados correctos.
+- Abandonar una partida a la que uno se unió (liberar plaza).
+- Entregar el flujo social sin bloquear con el pago online.
+
+**Non-Goals:**
+- Cobro por participante online (Redsys) — importe solo informativo.
+- Concepto público/privado de partida — toda reserva con plazas es joinable.
+- Notificaciones / OTP de la unión.
+
+## Decisions
+
+### D1 — Endpoint dedicado `GET /api/partidas` para listar reservas joinable
+Se añade un endpoint que devuelve las reservas activas con plazas libres para una fecha (o rango), cada una con `reservaId`, fecha, hora, duración, `plazasLibres`, participantes (nombre/plaza) e importe total (informativo). *Alternativa descartada:* extender `TramoDisponible` con `reservaId` dentro de `/api/reservas/disponibles` — mezcla dos vistas (crear vs unirse), y un tramo puede mapear a varias reservas; un recurso propio de "partidas" es más claro y no toca el contrato de disponibilidad usado por el flujo de crear. Motiva RN-RES-02 (plazas) y RN-AUTH-01 (no revela datos sensibles: solo nombres de display).
+
+### D2 — `POST /api/reservas/{id}/unirse` con validación atómica de plaza
+El servicio carga la reserva (404 si no existe), valida estado activo (`isActiveOccupant`; si no → 422 `INVALID_STATE_TRANSITION`/`RESERVA_NOT_JOINABLE`), valida que el usuario no sea ya participante (409 `CONFLICT`, RN-AUTH-03), valida que queden plazas contra `max_participants` (422 `PARTICIPANTS_LIMIT_EXCEEDED`, RN-RES-02), calcula el siguiente `slot_position` (`max(slot)+1`) y persiste `Participant.registered(...)`. La comprobación de plaza + inserción debe ser **atómica** (transacción + bloqueo de la reserva, análogo al `SELECT FOR UPDATE` de creación) para evitar que dos uniones concurrentes superen `max_participants`. *Alternativa descartada:* validar plaza sin bloqueo — condición de carrera que sobrepasa el máximo (mismo patrón que el MEDIO-1 de auth). Reutiliza `Participant.registered()` y `Reservation.addParticipant()`.
+
+### D3 — Abandonar: `DELETE /api/reservas/{id}/participacion` (participante no-owner)
+Un participante no-owner puede salir de la reserva (elimina su fila de `participants`, libera plaza). El **owner no puede** abandonar (debe cancelar la reserva vía el flujo existente). *Alternativa considerada:* diferir "abandonar" — pero es barato y completa el flujo social (sin él, unirse por error es irreversible para el jugador). Se incluye en el MVP. Estados: solo con reserva activa; sin reembolso online (no hay cobro).
+
+### D4 — Importe "tu parte" informativo, sin cobro
+La UI de confirmar unión muestra `total ÷ nº participantes tras unirse` como referencia (RN-RES-03: el total lo calcula el backend), pero la unión **no** crea `Payment` por participante ni cobra. El cobro compartido llega con `pagos-redsys`. *Alternativa descartada:* crear un `Payment` por participante ahora — exige rediseño del modelo de pago (1:N, FK a participante) fuera de alcance.
+
+## Risks / Trade-offs
+
+- [Dos jugadores se unen a la vez a la última plaza] → Mitigación: validación de plaza + inserción atómica bajo transacción/bloqueo de la reserva (D2); test de concurrencia.
+- [Exponer partidas abiertas revela nombres de otros socios] → Mitigación: solo autenticados; se devuelven nombres de display (ya visibles en el detalle de reserva a participantes), sin email ni datos sensibles (RN-RGPD-03).
+- [Unirse sin cobro deja la contabilidad incompleta hasta `pagos-redsys`] → Mitigación aceptada: el club cobra presencialmente (MVP CASH), coherente con el resto de `reservas`; el importe informativo evita malentendidos.
+- [El owner intenta "abandonar"] → Mitigación: 422/403 claro indicando que debe cancelar la reserva.
+
+## Migration Plan
+
+- Sin migraciones previstas (se reutilizan `reservations`/`participants`; FK ya existe). Confirmar durante la implementación que no hace falta índice nuevo para el listado de partidas.
+- Despliegue: backend + frontend aditivos y retrocompatibles. Rollback = revertir ambos; no afecta a crear/cancelar reservas existentes.
+
+## Open Questions
+
+Resueltas en revisión (2026-07-05):
+- **D1** → endpoint dedicado `GET /api/partidas`.
+- **D3** → "abandonar" entra en el MVP.
+- **Importe** → "tu parte" informativo (sin cobro online).

--- a/openspec/changes/partidas-unirse/proposal.md
+++ b/openspec/changes/partidas-unirse/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+La capability `partidas` está definida (spec + mockups 20/21/22) pero **sin implementar**: no existe el endpoint `POST /api/reservas/{id}/unirse`, ni servicio de unión, ni pantallas. Hoy un jugador no puede ver las reservas con plazas libres ni apuntarse a una partida de otro. Es el siguiente candidato de Wave 4 (baja complejidad, reutiliza `reservas` + `disponibilidad-pistas`) y desbloquea el uso social del club (partidas abiertas).
+
+La exploración detectó dos restricciones que acotan el alcance: (1) `TramoDisponible` **no expone el `reservaId`**, así que la UI no puede identificar a qué reserva unirse — hay que exponer las reservas joinable con su id; (2) el "pago por participante" que muestran los mockups ("Tu parte 4,50€") **no está modelado** (`Payment` es 1:1 con la reserva y del owner) y depende de `pagos-redsys` (no construido) — se difiere, igual que se hizo en `reservas`.
+
+## What Changes
+
+- **[Backend] Exponer reservas joinable con su `reservaId`.** Un jugador debe poder listar las partidas abiertas (reservas activas con plazas libres) identificables por id, fecha, hora, duración, plazas libres y participantes. Se resuelve con un endpoint de listado de partidas abiertas (o exponiendo el `reservaId` en la disponibilidad; ver design D1).
+- **[Backend] `POST /api/reservas/{id}/unirse`.** Añade al usuario autenticado como participante adicional (`is_owner=false`, siguiente `slot_position`). Validaciones: 404 si la reserva no existe; 422 si su estado no admite unión (solo `PENDING_CONFIRMATION`/`CONFIRMED`; `CANCELLED`/`COMPLETED` → 422); 409 si el usuario ya es participante (RN-AUTH-03); 422 si la reserva está completa (RN-RES-02). Devuelve `UnirseResponse` (participanteId, reservaId, userId, nombre, statusPago).
+- **[Backend] Abandonar una partida.** El participante no-owner puede salir de una reserva a la que se unió (libera su plaza). (Ver design D3 — incluible en el MVP o diferible.)
+- **[Frontend] Pantallas de partidas** (mockups 21/22): "Partidas abiertas" (lista de reservas joinable) y "Confirmar unión" (detalle + unirse). El importe "tu parte" se muestra **informativo** (total ÷ participantes); la unión NO cobra online (pago presencial/diferido, como en `reservas`).
+- **[Frontend] Navegación**: acceso a "Partidas abiertas" desde Home/reservas; rutas privadas nuevas.
+- **Requirement 3 de la spec (listar reservas donde participo) YA funciona** (`GET /api/reservas` incluye participaciones no-owner) — no requiere trabajo.
+
+## Capabilities
+
+### New Capabilities
+<!-- Ninguna capability nueva: `partidas` ya existe como spec; este change la implementa. -->
+
+### Modified Capabilities
+- `partidas`: se implementan sus requirements (ver reservas joinable, unirse, abandonar) sobre el modelo de `reservas` existente.
+- `disponibilidad-pistas`: se expone el `reservaId` (y datos mínimos) de las reservas joinable para que la UI pueda unirse — cambio aditivo del contrato (o endpoint nuevo; ver design).
+
+## Impact
+
+- **Fase del producto**: fase-1 (`partidas` es fase-1).
+- **Backend** (`com.padelpro.reservas`): nuevo `UnirseReservaService` + endpoint en `ReservaController`; puerto de comando para añadir participante a reserva existente (hoy solo hay `save` de creación completa); DTO `UnirseResponse`; cálculo de siguiente `slot_position`; validaciones 404/409/422; invalidación de caché de disponibilidad; listado de partidas abiertas (endpoint o extensión de disponibilidad) exponiendo `reservaId`. Documentar en `docs/openapi.yaml` (el `/unirse` ya está documentado; alinear con lo implementado).
+- **Frontend** (`frontend/src/`): páginas `PartidasAbiertasPage`, `ConfirmarUnionPage`; rutas en `reservasPaths.ts` y `App.tsx`; funciones en `reservasApi.ts` (listar partidas, unirse, abandonar).
+- **Datos / migraciones**: previsiblemente **ninguna** (se reutilizan `reservations`/`participants`; el FK `participants.user_id → users` ya existe). Sin cambios de pago.
+- **Sin impacto** en auth ni en el cálculo de precio existente.
+
+## Fuera de alcance
+
+- **Pago por participante / "tu parte" cobrada online** (Redsys) — depende del modelo de pago compartido (hoy `Payment` es 1:1 owner) y de `pagos-redsys`. Se difiere; en este change el importe se muestra informativo y la unión no cobra online.
+- **"Crear partida pública" como concepto separado** (mockup 20) — en v1 no existe distinción pública/privada: *toda reserva con plazas libres es joinable* (per `spec.md`). Crear una partida = crear una reserva (flujo ya existente). No se añade flag público/privado.
+- **Notificar al owner cuando alguien se une** (email/Telegram) — capability `notificaciones`.
+- **Confirmación por OTP Telegram** de la unión — capability `auth-otp-telegram`.

--- a/openspec/changes/partidas-unirse/specs/partidas/spec.md
+++ b/openspec/changes/partidas-unirse/specs/partidas/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: Listado de partidas abiertas con identificador
+El sistema SHALL exponer a un usuario autenticado el listado de partidas abiertas (reservas activas en `PENDING_CONFIRMATION`/`CONFIRMED` con plazas libres) para una fecha, cada una identificable por `reservaId` y con fecha, hora, duración, plazas libres, participantes (nombre de display) e importe total (informativo). No SHALL exponer datos sensibles de los participantes (email, teléfono).
+
+#### Scenario: Ver partidas abiertas de una fecha
+- **WHEN** un usuario autenticado consulta las partidas abiertas de una fecha con reservas incompletas
+- **THEN** el sistema responde 200 con una lista de partidas, cada una con `reservaId`, hora, duración y plazas libres
+
+#### Scenario: Reserva completa no aparece
+- **WHEN** una reserva ya tiene el máximo de participantes
+- **THEN** no aparece en el listado de partidas abiertas
+
+#### Scenario: Requiere autenticación
+- **WHEN** se consulta el listado sin credenciales válidas
+- **THEN** el sistema responde 401
+
+### Requirement: Unirse a una partida con validación atómica de plaza
+El sistema SHALL añadir al usuario autenticado como participante no-owner de la reserva vía `POST /api/reservas/{id}/unirse`, asignando el siguiente `slot_position`, siempre que: la reserva exista (si no, 404), esté en estado que admite unión (si no, 422), el usuario no sea ya participante (si lo es, 409) y queden plazas (si no, 422). La comprobación de plaza y la inserción SHALL ser atómicas para que uniones concurrentes no superen `max_participants`.
+
+#### Scenario: Unión exitosa
+- **WHEN** un usuario autenticado que no participa envía `POST /api/reservas/{id}/unirse` sobre una reserva activa con plazas libres
+- **THEN** el sistema responde 200 con `{participanteId, reservaId, userId, nombre, statusPago}` y la reserva pasa a tener un participante más (`is_owner=false`)
+
+#### Scenario: Ya es participante (RN-AUTH-03)
+- **WHEN** el usuario ya figura como participante de la reserva
+- **THEN** el sistema responde 409 y no crea un registro duplicado
+
+#### Scenario: Reserva completa (RN-RES-02)
+- **WHEN** la reserva ya tiene `max_participants` participantes
+- **THEN** el sistema responde 422 indicando que está completa
+
+#### Scenario: Estado no unible
+- **WHEN** la reserva está `CANCELLED` o `COMPLETED`
+- **THEN** el sistema responde 422 indicando que no admite nuevos participantes
+
+#### Scenario: Reserva inexistente
+- **WHEN** el `id` no corresponde a ninguna reserva
+- **THEN** el sistema responde 404
+
+#### Scenario: Última plaza en concurrencia
+- **WHEN** dos usuarios se unen simultáneamente a la última plaza libre
+- **THEN** exactamente uno recibe 200 y el otro 422 (la validación atómica evita superar el máximo)
+
+### Requirement: Abandonar una partida
+El sistema SHALL permitir a un participante no-owner abandonar una reserva a la que se unió, liberando su plaza. El owner NO SHALL poder abandonar (debe cancelar la reserva mediante el flujo de cancelación existente).
+
+#### Scenario: Participante abandona
+- **WHEN** un participante no-owner abandona una reserva activa en la que participa
+- **THEN** el sistema lo elimina de `participants`, libera la plaza y responde con éxito
+
+#### Scenario: El owner no puede abandonar
+- **WHEN** el owner intenta abandonar su propia reserva
+- **THEN** el sistema lo rechaza indicando que debe cancelar la reserva
+
+### Requirement: Importe informativo al unirse (sin cobro online)
+La UI de confirmar unión SHALL mostrar el importe "tu parte" (total de la reserva ÷ nº de participantes tras la unión) como referencia informativa, pero la unión NO SHALL crear un pago por participante ni cobrar online. El cobro compartido se difiere a la capability `pagos-redsys`.
+
+#### Scenario: Mostrar tu parte sin cobrar
+- **WHEN** el usuario abre la confirmación de unión a una partida
+- **THEN** la UI muestra el importe que le correspondería, e informa de que el pago se realiza de forma presencial (sin pasarela)

--- a/openspec/changes/partidas-unirse/tasks.md
+++ b/openspec/changes/partidas-unirse/tasks.md
@@ -4,21 +4,21 @@
 
 ## 1. Backend — listado de partidas abiertas (D1)
 
-- [ ] 1.1 **[Red]** Test: listar partidas abiertas de una fecha devuelve reservas activas con plazas libres, cada una con `reservaId`, hora, duración, plazas, participantes (display), importe informativo; sin auth → 401; reserva completa no aparece
-- [ ] 1.2 **[Green]** Endpoint de listado de partidas abiertas (dedicado `GET /api/partidas` o extensión acordada) + servicio que reutiliza el cálculo de ocupación/plazas; proyección sin PII (solo nombres de display); documentar en `docs/openapi.yaml`
+- [x] 1.1 **[Red]** Test: listar partidas abiertas de una fecha devuelve reservas activas con plazas libres, cada una con `reservaId`, hora, duración, plazas, participantes (display), importe informativo; sin auth → 401; reserva completa no aparece
+- [x] 1.2 **[Green]** Endpoint de listado de partidas abiertas (dedicado `GET /api/partidas` o extensión acordada) + servicio que reutiliza el cálculo de ocupación/plazas; proyección sin PII (solo nombres de display); documentar en `docs/openapi.yaml`
 
 ## 2. Backend — unirse a una partida (D2)
 
-- [ ] 2.1 **[Red]** Tests del caso de uso `UnirseReserva`: unión exitosa (participante no-owner, siguiente slot); ya participante → 409 (RN-AUTH-03); reserva completa → 422 (RN-RES-02); estado CANCELLED/COMPLETED → 422; reserva inexistente → 404
-- [ ] 2.2 **[Red]** Test de concurrencia: dos uniones simultáneas a la última plaza → una 200, otra 422 (no supera `max_participants`)
-- [ ] 2.3 **[Green]** `UnirseReservaService`: carga reserva (404), valida estado activo (422), duplicado (409), plazas atómicamente bajo transacción/bloqueo (422), calcula siguiente `slot_position`, persiste `Participant.registered(is_owner=false)`; invalida caché de disponibilidad
-- [ ] 2.4 **[Green]** Puerto/adapter para añadir participante a reserva existente (hoy solo hay `save` de creación completa)
-- [ ] 2.5 **[Green]** `POST /api/reservas/{id}/unirse` en `ReservaController` + DTO `UnirseResponse` (participanteId, reservaId, userId, nombre, statusPago); alinear `docs/openapi.yaml` con lo implementado
+- [x] 2.1 **[Red]** Tests del caso de uso `UnirseReserva`: unión exitosa (participante no-owner, siguiente slot); ya participante → 409 (RN-AUTH-03); reserva completa → 422 (RN-RES-02); estado CANCELLED/COMPLETED → 422; reserva inexistente → 404
+- [x] 2.2 **[Red]** Test de concurrencia: dos uniones simultáneas a la última plaza → una 200, otra 422 (no supera `max_participants`)
+- [x] 2.3 **[Green]** `UnirseReservaService`: carga reserva (404), valida estado activo (422), duplicado (409), plazas atómicamente bajo transacción/bloqueo (422), calcula siguiente `slot_position`, persiste `Participant.registered(is_owner=false)`; invalida caché de disponibilidad
+- [x] 2.4 **[Green]** Puerto/adapter para añadir participante a reserva existente (hoy solo hay `save` de creación completa)
+- [x] 2.5 **[Green]** `POST /api/reservas/{id}/unirse` en `ReservaController` + DTO `UnirseResponse` (participanteId, reservaId, userId, nombre, statusPago); alinear `docs/openapi.yaml` con lo implementado
 
 ## 3. Backend — abandonar una partida (D3)
 
-- [ ] 3.1 **[Red]** Tests: participante no-owner abandona → plaza liberada; owner intenta abandonar → rechazo (debe cancelar); no participante → error
-- [ ] 3.2 **[Green]** Endpoint de abandono (`DELETE /api/reservas/{id}/participacion`) + servicio que elimina la fila de `participants` del usuario; invalida caché de disponibilidad; documentar en openapi
+- [x] 3.1 **[Red]** Tests: participante no-owner abandona → plaza liberada; owner intenta abandonar → rechazo (debe cancelar); no participante → error
+- [x] 3.2 **[Green]** Endpoint de abandono (`DELETE /api/reservas/{id}/participacion`) + servicio que elimina la fila de `participants` del usuario; invalida caché de disponibilidad; documentar en openapi
 
 ## 4. Frontend — pantallas de partidas
 

--- a/openspec/changes/partidas-unirse/tasks.md
+++ b/openspec/changes/partidas-unirse/tasks.md
@@ -1,0 +1,36 @@
+# Partidas — ver y unirse a reservas con plazas libres (fase-1)
+
+> Orden TDD (Red → Green → Refactor). Reutiliza el modelo de `reservas` (Participant.registered, Reservation.addParticipant, isActiveOccupant). Sin migraciones previstas. Pago compartido online DIFERIDO a `pagos-redsys` (aquí importe informativo).
+
+## 1. Backend — listado de partidas abiertas (D1)
+
+- [ ] 1.1 **[Red]** Test: listar partidas abiertas de una fecha devuelve reservas activas con plazas libres, cada una con `reservaId`, hora, duración, plazas, participantes (display), importe informativo; sin auth → 401; reserva completa no aparece
+- [ ] 1.2 **[Green]** Endpoint de listado de partidas abiertas (dedicado `GET /api/partidas` o extensión acordada) + servicio que reutiliza el cálculo de ocupación/plazas; proyección sin PII (solo nombres de display); documentar en `docs/openapi.yaml`
+
+## 2. Backend — unirse a una partida (D2)
+
+- [ ] 2.1 **[Red]** Tests del caso de uso `UnirseReserva`: unión exitosa (participante no-owner, siguiente slot); ya participante → 409 (RN-AUTH-03); reserva completa → 422 (RN-RES-02); estado CANCELLED/COMPLETED → 422; reserva inexistente → 404
+- [ ] 2.2 **[Red]** Test de concurrencia: dos uniones simultáneas a la última plaza → una 200, otra 422 (no supera `max_participants`)
+- [ ] 2.3 **[Green]** `UnirseReservaService`: carga reserva (404), valida estado activo (422), duplicado (409), plazas atómicamente bajo transacción/bloqueo (422), calcula siguiente `slot_position`, persiste `Participant.registered(is_owner=false)`; invalida caché de disponibilidad
+- [ ] 2.4 **[Green]** Puerto/adapter para añadir participante a reserva existente (hoy solo hay `save` de creación completa)
+- [ ] 2.5 **[Green]** `POST /api/reservas/{id}/unirse` en `ReservaController` + DTO `UnirseResponse` (participanteId, reservaId, userId, nombre, statusPago); alinear `docs/openapi.yaml` con lo implementado
+
+## 3. Backend — abandonar una partida (D3)
+
+- [ ] 3.1 **[Red]** Tests: participante no-owner abandona → plaza liberada; owner intenta abandonar → rechazo (debe cancelar); no participante → error
+- [ ] 3.2 **[Green]** Endpoint de abandono (`DELETE /api/reservas/{id}/participacion`) + servicio que elimina la fila de `participants` del usuario; invalida caché de disponibilidad; documentar en openapi
+
+## 4. Frontend — pantallas de partidas
+
+- [ ] 4.1 **[Red]** Tests (MSW): `PartidasAbiertasPage` lista partidas (reservaId, hora, plazas); estado vacío; error
+- [ ] 4.2 **[Green]** `PartidasAbiertasPage` (mockup 21) + funciones en `reservasApi.ts` (listar partidas) + ruta en `reservasPaths.ts`/`App.tsx` + acceso desde Home
+- [ ] 4.3 **[Red]** Tests: `ConfirmarUnionPage` muestra detalle + "tu parte" informativo; unirse con éxito → confirmación; 409 ya participante → mensaje claro sin checkout; 422 completa → mensaje
+- [ ] 4.4 **[Green]** `ConfirmarUnionPage` (mockup 22) + `unirseReserva` en `reservasApi.ts`; importe informativo (sin cobro online); abandono desde el detalle/mis reservas si aplica
+
+## 5. QA
+
+- [ ] 5.1 **[Refactor]** Limpieza manteniendo verde
+- [ ] 5.2 `verification-specialist`: build + tests (backend maven, frontend vitest) + lint; probes de concurrencia y validaciones
+- [ ] 5.3 `security-auditor`: acceso al listado (no PII), autorización de unirse/abandonar, no exponer datos de otros socios (RN-RGPD-03)
+- [ ] 5.4 `reality-checker`: journey end-to-end (ver partidas abiertas → unirse → aparece en mis reservas → abandonar) — live E2E puede diferirse si requiere despliegue
+- [ ] 5.5 Actualizar `docs/openapi.yaml` y verificar coherencia del contrato de `/unirse`, listado y abandono

--- a/openspec/changes/partidas-unirse/tasks.md
+++ b/openspec/changes/partidas-unirse/tasks.md
@@ -22,10 +22,10 @@
 
 ## 4. Frontend — pantallas de partidas
 
-- [ ] 4.1 **[Red]** Tests (MSW): `PartidasAbiertasPage` lista partidas (reservaId, hora, plazas); estado vacío; error
-- [ ] 4.2 **[Green]** `PartidasAbiertasPage` (mockup 21) + funciones en `reservasApi.ts` (listar partidas) + ruta en `reservasPaths.ts`/`App.tsx` + acceso desde Home
-- [ ] 4.3 **[Red]** Tests: `ConfirmarUnionPage` muestra detalle + "tu parte" informativo; unirse con éxito → confirmación; 409 ya participante → mensaje claro sin checkout; 422 completa → mensaje
-- [ ] 4.4 **[Green]** `ConfirmarUnionPage` (mockup 22) + `unirseReserva` en `reservasApi.ts`; importe informativo (sin cobro online); abandono desde el detalle/mis reservas si aplica
+- [x] 4.1 **[Red]** Tests (MSW): `PartidasAbiertasPage` lista partidas (reservaId, hora, plazas); estado vacío; error
+- [x] 4.2 **[Green]** `PartidasAbiertasPage` (mockup 21) + funciones en `reservasApi.ts` (listar partidas) + ruta en `reservasPaths.ts`/`App.tsx` + acceso desde Home
+- [x] 4.3 **[Red]** Tests: `ConfirmarUnionPage` muestra detalle + "tu parte" informativo; unirse con éxito → confirmación; 409 ya participante → mensaje claro sin checkout; 422 completa → mensaje
+- [x] 4.4 **[Green]** `ConfirmarUnionPage` (mockup 22) + `unirseReserva` en `reservasApi.ts`; importe informativo (sin cobro online); abandono desde el detalle/mis reservas si aplica
 
 ## 5. QA
 

--- a/openspec/changes/partidas-unirse/tasks.md
+++ b/openspec/changes/partidas-unirse/tasks.md
@@ -29,10 +29,9 @@
 
 ## 5. QA
 
-- [ ] 5.1 **[Refactor]** Limpieza manteniendo verde
-- [ ] 5.2 `verification-specialist`: build + tests (backend maven, frontend vitest) + lint; probes de concurrencia y validaciones
-- [x] 5.3 `security-auditor`: acceso al listado (no PII), autorización de unirse/abandonar, no exponer datos de otros socios (RN-RGPD-03)
-- [ ] 5.4 `reality-checker`: journey end-to-end (ver partidas abiertas → unirse → aparece en mis reservas → abandonar) — live E2E puede diferirse si requiere despliegue
+- [x] 5.1 **[Refactor]** Limpieza manteniendo verde — sin deuda; helpers reutilizados del módulo reservas
+- [x] 5.2 `verification-specialist`: PASS — unit backend + IT de partidas (concurrencia 8 hilos → 1×200/7×422, acaba 4/4) + regresión reservas (31 IT) verdes contra PG real; frontend 167/167; tsc/eslint limpios. security-auditor: 0 críticos/altos; MEDIO (fuga PII en detalle tras auto-unión) corregido; BAJO (índice único) añadido
+- [ ] 5.4 `reality-checker`: journey end-to-end (ver partidas abiertas → unirse → aparece en mis reservas → abandonar) — **PENDIENTE de live E2E: requiere desplegar el build; cubierto por IT backend (incl. concurrencia) + tests MSW frontend**
 - [x] 5.5 Actualizar `docs/openapi.yaml` y verificar coherencia del contrato de `/unirse`, listado y abandono
 
 ### Notas de correcciones (pasada de fixes backend, 2026-07-05)

--- a/openspec/changes/partidas-unirse/tasks.md
+++ b/openspec/changes/partidas-unirse/tasks.md
@@ -31,6 +31,24 @@
 
 - [ ] 5.1 **[Refactor]** Limpieza manteniendo verde
 - [ ] 5.2 `verification-specialist`: build + tests (backend maven, frontend vitest) + lint; probes de concurrencia y validaciones
-- [ ] 5.3 `security-auditor`: acceso al listado (no PII), autorización de unirse/abandonar, no exponer datos de otros socios (RN-RGPD-03)
+- [x] 5.3 `security-auditor`: acceso al listado (no PII), autorización de unirse/abandonar, no exponer datos de otros socios (RN-RGPD-03)
 - [ ] 5.4 `reality-checker`: journey end-to-end (ver partidas abiertas → unirse → aparece en mis reservas → abandonar) — live E2E puede diferirse si requiere despliegue
-- [ ] 5.5 Actualizar `docs/openapi.yaml` y verificar coherencia del contrato de `/unirse`, listado y abandono
+- [x] 5.5 Actualizar `docs/openapi.yaml` y verificar coherencia del contrato de `/unirse`, listado y abandono
+
+### Notas de correcciones (pasada de fixes backend, 2026-07-05)
+
+- **[MEDIO — RGPD] Minimización de PII en el detalle/listado para co-participantes (RN-RGPD-03).**
+  `ReservaMapper.toResponse` ahora recibe `includePii`; `ReservaQueryService.getForUser`/`listForUser`
+  lo calculan como `admin || solicitante==owner`. Un co-jugador que se unió a la partida recibe
+  `externalPhone` de los invitados y `notes` de la reserva en `null`; owner y ADMIN siguen viéndolo
+  todo. La regla de acceso 403 para no-participantes NO cambia. Documentado en `docs/openapi.yaml`
+  (`ReservaResponse.notes`, `ParticipanteResponse.externalPhone`).
+  Tests IT nuevos en `ReservaControllerIntegrationTest` (owner ve / ADMIN ve / co-participante null /
+  no-participante 403 / listado minimizado).
+- **[BAJO — backstop] Índice único parcial `uq_part_user_reservation (reservation_id, user_id) WHERE user_id IS NOT NULL`.**
+  Migración `V12__unique_participant_per_reservation.sql`. Defensa en profundidad de RN-AUTH-03 a
+  nivel BD (el anti-duplicado en memoria bajo el lock sigue siendo la primera línea). Flyway aplica
+  V1..V12 limpio sobre el PG de test.
+- **[Gaps de test] Estados terminales.** IT nuevos: unirse a reserva `COMPLETED` → 422
+  `RESERVA_NOT_JOINABLE`; abandonar reserva `CANCELLED` y `COMPLETED` → 422 `RESERVA_NOT_JOINABLE`.
+- Resultado: `ReservaControllerIntegrationTest` 31/31, `UnirseAbandonarIntegrationTest` 14/14 — 45 verdes contra Postgres real.


### PR DESCRIPTION
## Resumen

Implementa la capability `partidas` (MVP): un jugador puede ver reservas con plazas libres, unirse y abandonar. Reutiliza el modelo de `reservas`; sin cobro online (importe informativo — el pago compartido va en `pagos-redsys`).

- **Backend**: `GET /api/partidas` (partidas abiertas con reservaId, sin PII), `POST /api/reservas/{id}/unirse` (404/409/422, **concurrencia atómica con SELECT FOR UPDATE**), `DELETE /api/reservas/{id}/participacion` (abandonar; owner→422).
- **Frontend**: `PartidasAbiertasPage` (mockup 21), `ConfirmarUnionPage` (mockup 22, "tu parte" informativo), abandonar desde el detalle.

## Issues vinculados

- Closes #191

## Seguridad (security-auditor: 0 críticos/altos)

- **MEDIO corregido (RGPD)**: al auto-unirse, `GET /api/reservas/{id}` exponía `externalPhone`/`notes` de otros. Ahora se minimizan para co-participantes no-owner (owner/ADMIN sin cambios); regla de acceso 403 intacta.
- **BAJO**: índice único `(reservation_id, user_id)` (V12) como backstop de RN-AUTH-03.
- Sujeto siempre del JWT (no del body): no se puede unir/sacar a otro usuario. Atomicidad de última plaza verificada (8 hilos → 1×200/7×422).

## Testing

- [x] Backend: unit + IT de partidas (concurrencia real) + regresión reservas, verdes contra Postgres real.
- [x] Frontend: 167/167 (listado, confirmar unión, abandonar). tsc + eslint limpios.
- [x] verification-specialist: PASS.
- [ ] **Live E2E (reality-checker): diferido** — requiere desplegar; cubierto por IT + MSW.

## Fuera de alcance

Pago compartido online (Redsys) → `pagos-redsys`. Notificaciones y OTP de la unión → sus capabilities.

🤖 Generado con Claude Code (orchestrator agent)