### PR TITLE
feat(pagos): pago online Redsys — iniciar + webhook + efectivo (#194)

### DIFF
--- a/backend/src/main/java/com/padelpro/auth/domain/model/SystemConfig.java
+++ b/backend/src/main/java/com/padelpro/auth/domain/model/SystemConfig.java
@@ -41,6 +41,9 @@ public class SystemConfig {
     @Column(columnDefinition = "TEXT")
     private String redsysMerchantKey;
 
+    @Column(columnDefinition = "TEXT")
+    private String redsysTerminal;
+
     @Column(nullable = false)
     @Positive(message = "maxParticipantsPerPista must be greater than 0")
     private Integer maxParticipantsPerPista;
@@ -67,8 +70,8 @@ public class SystemConfig {
 
     public SystemConfig(Long id, String clubName, String clubDescription, PistaState pistaState,
                         PaymentGateway paymentGateway, String telegramBotToken, String redsysMerchantId,
-                        String redsysMerchantKey, Integer maxParticipantsPerPista, BigDecimal pricePerHour,
-                        Integer cancellationDeadlineHours, OffsetDateTime createdAt,
+                        String redsysMerchantKey, String redsysTerminal, Integer maxParticipantsPerPista,
+                        BigDecimal pricePerHour, Integer cancellationDeadlineHours, OffsetDateTime createdAt,
                         OffsetDateTime updatedAt, Long updatedByUserId) {
         this.id = id;
         this.clubName = clubName;
@@ -78,6 +81,7 @@ public class SystemConfig {
         this.telegramBotToken = telegramBotToken;
         this.redsysMerchantId = redsysMerchantId;
         this.redsysMerchantKey = redsysMerchantKey;
+        this.redsysTerminal = redsysTerminal;
         this.maxParticipantsPerPista = maxParticipantsPerPista;
         this.pricePerHour = pricePerHour;
         this.cancellationDeadlineHours = cancellationDeadlineHours;
@@ -169,6 +173,14 @@ public class SystemConfig {
         this.redsysMerchantKey = redsysMerchantKey;
     }
 
+    public String getRedsysTerminal() {
+        return redsysTerminal;
+    }
+
+    public void setRedsysTerminal(String redsysTerminal) {
+        this.redsysTerminal = redsysTerminal;
+    }
+
     public Integer getMaxParticipantsPerPista() {
         return maxParticipantsPerPista;
     }
@@ -250,6 +262,7 @@ public class SystemConfig {
         private String telegramBotToken;
         private String redsysMerchantId;
         private String redsysMerchantKey;
+        private String redsysTerminal;
         private Integer maxParticipantsPerPista;
         private BigDecimal pricePerHour;
         private Integer cancellationDeadlineHours;
@@ -297,6 +310,11 @@ public class SystemConfig {
             return this;
         }
 
+        public SystemConfigBuilder redsysTerminal(String redsysTerminal) {
+            this.redsysTerminal = redsysTerminal;
+            return this;
+        }
+
         public SystemConfigBuilder maxParticipantsPerPista(Integer maxParticipantsPerPista) {
             this.maxParticipantsPerPista = maxParticipantsPerPista;
             return this;
@@ -329,8 +347,9 @@ public class SystemConfig {
 
         public SystemConfig build() {
             return new SystemConfig(id, clubName, clubDescription, pistaState, paymentGateway,
-                    telegramBotToken, redsysMerchantId, redsysMerchantKey, maxParticipantsPerPista,
-                    pricePerHour, cancellationDeadlineHours, createdAt, updatedAt, updatedByUserId);
+                    telegramBotToken, redsysMerchantId, redsysMerchantKey, redsysTerminal,
+                    maxParticipantsPerPista, pricePerHour, cancellationDeadlineHours, createdAt,
+                    updatedAt, updatedByUserId);
         }
     }
 }

--- a/backend/src/main/java/com/padelpro/auth/infrastructure/web/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/padelpro/auth/infrastructure/web/GlobalExceptionHandler.java
@@ -9,6 +9,10 @@ import com.padelpro.auth.domain.exception.TokenExpiredException;
 import com.padelpro.auth.domain.exception.TokenInvalidException;
 import com.padelpro.auth.domain.exception.ValidationException;
 import com.padelpro.auth.infrastructure.web.dto.ErrorResponse;
+import com.padelpro.pagos.domain.exception.PagoConflictException;
+import com.padelpro.pagos.domain.exception.PagoForbiddenException;
+import com.padelpro.pagos.domain.exception.PagoNotFoundException;
+import com.padelpro.pagos.domain.exception.PagoUnprocessableException;
 import com.padelpro.reservas.domain.exception.InvalidReservaStateException;
 import com.padelpro.reservas.domain.exception.ParticipacionDuplicadaException;
 import com.padelpro.reservas.domain.exception.ReservaForbiddenException;
@@ -219,6 +223,38 @@ public class GlobalExceptionHandler {
      */
     @ExceptionHandler(InvalidReservaStateException.class)
     public ResponseEntity<ErrorResponse> handleInvalidReservaState(InvalidReservaStateException ex) {
+        return ResponseEntity
+                .status(HttpStatus.UNPROCESSABLE_ENTITY)
+                .body(new ErrorResponse(ex.getCode(), ex.getMessage()));
+    }
+
+    // -------------------------------------------------------------------------
+    // pagos-redsys-online capability
+    // -------------------------------------------------------------------------
+
+    @ExceptionHandler(PagoNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handlePagoNotFound(PagoNotFoundException ex) {
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(new ErrorResponse("PAGO_NOT_FOUND", ex.getMessage()));
+    }
+
+    @ExceptionHandler(PagoForbiddenException.class)
+    public ResponseEntity<ErrorResponse> handlePagoForbidden(PagoForbiddenException ex) {
+        return ResponseEntity
+                .status(HttpStatus.FORBIDDEN)
+                .body(new ErrorResponse("FORBIDDEN", ex.getMessage()));
+    }
+
+    @ExceptionHandler(PagoConflictException.class)
+    public ResponseEntity<ErrorResponse> handlePagoConflict(PagoConflictException ex) {
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT)
+                .body(new ErrorResponse("CONFLICT", ex.getMessage()));
+    }
+
+    @ExceptionHandler(PagoUnprocessableException.class)
+    public ResponseEntity<ErrorResponse> handlePagoUnprocessable(PagoUnprocessableException ex) {
         return ResponseEntity
                 .status(HttpStatus.UNPROCESSABLE_ENTITY)
                 .body(new ErrorResponse(ex.getCode(), ex.getMessage()));

--- a/backend/src/main/java/com/padelpro/auth/infrastructure/web/filter/RateLimitFilter.java
+++ b/backend/src/main/java/com/padelpro/auth/infrastructure/web/filter/RateLimitFilter.java
@@ -25,6 +25,9 @@ import java.util.concurrent.ConcurrentHashMap;
  *   <li>POST /api/auth/login — 5 requests / minute / IP</li>
  *   <li>POST /api/auth/register — 3 requests / minute / IP</li>
  *   <li>POST /api/auth/refresh — 5 requests / minute / IP (same public-auth budget as login)</li>
+ *   <li>POST /api/pagos/webhook — 60 requests / minute / IP (public, unauthenticated Redsys
+ *       notification; the ceiling is high enough to tolerate legitimate Redsys retries yet caps a
+ *       flood of forged notifications that would otherwise hammer signature verification, D3).</li>
  * </ul>
  *
  * <p>When a bucket is exhausted the filter returns HTTP 429 Too Many Requests
@@ -41,10 +44,12 @@ public class RateLimitFilter extends OncePerRequestFilter {
     private static final String LOGIN_PATH    = "/api/auth/login";
     private static final String REGISTER_PATH = "/api/auth/register";
     private static final String REFRESH_PATH  = "/api/auth/refresh";
+    private static final String WEBHOOK_PATH  = "/api/pagos/webhook";
 
     private static final int LOGIN_CAPACITY    = 5;
     private static final int REGISTER_CAPACITY = 3;
     private static final int REFRESH_CAPACITY  = 5;
+    private static final int WEBHOOK_CAPACITY  = 60;
     private static final Duration REFILL_PERIOD = Duration.ofMinutes(1);
 
     private final ConcurrentHashMap<String, Bucket> buckets = new ConcurrentHashMap<>();
@@ -75,6 +80,8 @@ public class RateLimitFilter extends OncePerRequestFilter {
             capacity = REGISTER_CAPACITY;
         } else if (REFRESH_PATH.equals(path)) {
             capacity = REFRESH_CAPACITY;
+        } else if (WEBHOOK_PATH.equals(path)) {
+            capacity = WEBHOOK_CAPACITY;
         }
 
         if (capacity == null) {

--- a/backend/src/main/java/com/padelpro/pagos/application/dto/EfectivoPagoResponse.java
+++ b/backend/src/main/java/com/padelpro/pagos/application/dto/EfectivoPagoResponse.java
@@ -1,0 +1,18 @@
+package com.padelpro.pagos.application.dto;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+/**
+ * Response of {@code POST /api/admin/pagos/{reservaId}/efectivo} (pagos-redsys-online, group 5).
+ */
+public record EfectivoPagoResponse(
+        String pagoId,
+        String reservaId,
+        BigDecimal amount,
+        String method,
+        String status,
+        Long registeredById,
+        OffsetDateTime paidAt
+) {
+}

--- a/backend/src/main/java/com/padelpro/pagos/application/dto/IniciarPagoRequest.java
+++ b/backend/src/main/java/com/padelpro/pagos/application/dto/IniciarPagoRequest.java
@@ -1,0 +1,12 @@
+package com.padelpro.pagos.application.dto;
+
+import java.util.UUID;
+
+/**
+ * Request body for {@code POST /api/pagos/iniciar} (pagos-redsys-online, D5).
+ *
+ * <p>Only {@code reservaId} is meaningful — any amount sent by the client is ignored; the charged
+ * amount is always the backend-frozen {@code payments.amount} (RN-RES-03).
+ */
+public record IniciarPagoRequest(UUID reservaId) {
+}

--- a/backend/src/main/java/com/padelpro/pagos/application/dto/IniciarPagoResponse.java
+++ b/backend/src/main/java/com/padelpro/pagos/application/dto/IniciarPagoResponse.java
@@ -1,0 +1,31 @@
+package com.padelpro.pagos.application.dto;
+
+import java.math.BigDecimal;
+
+/**
+ * Response of {@code POST /api/pagos/iniciar} (pagos-redsys-online, D5/D6).
+ *
+ * <p>Carries the three Redsys form fields ({@code dsSignatureVersion}, {@code dsMerchantParameters},
+ * {@code dsSignature}) plus {@code redsysUrl} (the TPV endpoint) so the frontend can build a hidden
+ * form and auto-submit it to Redsys. Card data never touches PadelPro (RN-PAY-03).
+ *
+ * @param pagoId             the payment UUID
+ * @param redsysOrderId      the generated {@code Ds_Merchant_Order} (unique, RN-PAY-02)
+ * @param redsysUrl          the TPV endpoint the form is submitted to
+ * @param amount             the charged amount in euros (backend-frozen, RN-RES-03)
+ * @param status             the payment status after initiation ({@code IN_PROGRESS})
+ * @param dsSignatureVersion always {@code HMAC_SHA256_V1}
+ * @param dsMerchantParameters Base64 of the signed parameters JSON
+ * @param dsSignature        the HMAC-SHA256 signature (Base64)
+ */
+public record IniciarPagoResponse(
+        String pagoId,
+        String redsysOrderId,
+        String redsysUrl,
+        BigDecimal amount,
+        String status,
+        String dsSignatureVersion,
+        String dsMerchantParameters,
+        String dsSignature
+) {
+}

--- a/backend/src/main/java/com/padelpro/pagos/application/dto/PagoHistorialResponse.java
+++ b/backend/src/main/java/com/padelpro/pagos/application/dto/PagoHistorialResponse.java
@@ -1,0 +1,27 @@
+package com.padelpro.pagos.application.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+
+/**
+ * Payment history row for {@code GET /api/pagos} (own) and {@code GET /api/admin/pagos} (all)
+ * (pagos-redsys-online, group 5). Never exposes card data — only {@code redsysOrderId} and
+ * {@code transactionId} (RN-PAY-03).
+ */
+public record PagoHistorialResponse(
+        String pagoId,
+        String reservaId,
+        Long ownerId,
+        BigDecimal amount,
+        String method,
+        String status,
+        String redsysOrderId,
+        String transactionId,
+        LocalDate reservationDate,
+        LocalTime startTime,
+        OffsetDateTime paidAt,
+        OffsetDateTime createdAt
+) {
+}

--- a/backend/src/main/java/com/padelpro/pagos/application/service/IniciarPagoService.java
+++ b/backend/src/main/java/com/padelpro/pagos/application/service/IniciarPagoService.java
@@ -1,0 +1,138 @@
+package com.padelpro.pagos.application.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.padelpro.pagos.application.dto.IniciarPagoResponse;
+import com.padelpro.pagos.domain.audit.PagoAuditActions;
+import com.padelpro.pagos.domain.exception.PagoConflictException;
+import com.padelpro.pagos.domain.exception.PagoForbiddenException;
+import com.padelpro.pagos.domain.exception.PagoNotFoundException;
+import com.padelpro.pagos.domain.exception.PagoUnprocessableException;
+import com.padelpro.pagos.domain.model.RedsysSignature;
+import com.padelpro.reservas.domain.model.Payment;
+import com.padelpro.reservas.domain.model.PaymentStatus;
+import com.padelpro.reservas.domain.model.Reservation;
+import com.padelpro.reservas.domain.model.ReservationStatus;
+import com.padelpro.reservas.domain.port.out.PaymentCommandPort;
+import com.padelpro.reservas.domain.port.out.ReservationCommandPort;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Start an online Redsys payment for a reservation (pagos-redsys-online, D5).
+ *
+ * <p>Guards: owner only (403), reservation exists (404), not cancelled (422), payment still PENDING
+ * (409 if IN_PROGRESS/PAID). The charged amount is always the backend-frozen {@code payments.amount}
+ * in céntimos (RN-RES-03) — any client-sent amount is ignored. On success the payment moves to
+ * IN_PROGRESS with a unique {@code redsys_order_id} and the persisted {@code payment_url}, and
+ * {@code PAYMENT_INITIATED} is audited.
+ */
+public class IniciarPagoService {
+
+    private static final String SIGNATURE_VERSION = "HMAC_SHA256_V1";
+    private static final String TRANSACTION_TYPE = "0"; // authorization
+
+    private final ReservationCommandPort reservationCommandPort;
+    private final PaymentCommandPort paymentCommandPort;
+    private final RedsysConfigService redsysConfigService;
+    private final RedsysProperties redsysProperties;
+    private final RedsysOrderIdGenerator orderIdGenerator;
+    private final PagoAuditRecorder auditRecorder;
+    private final ObjectMapper objectMapper;
+
+    public IniciarPagoService(ReservationCommandPort reservationCommandPort,
+                              PaymentCommandPort paymentCommandPort,
+                              RedsysConfigService redsysConfigService,
+                              RedsysProperties redsysProperties,
+                              RedsysOrderIdGenerator orderIdGenerator,
+                              PagoAuditRecorder auditRecorder,
+                              ObjectMapper objectMapper) {
+        this.reservationCommandPort = reservationCommandPort;
+        this.paymentCommandPort = paymentCommandPort;
+        this.redsysConfigService = redsysConfigService;
+        this.redsysProperties = redsysProperties;
+        this.orderIdGenerator = orderIdGenerator;
+        this.auditRecorder = auditRecorder;
+        this.objectMapper = objectMapper;
+    }
+
+    @Transactional
+    public IniciarPagoResponse iniciar(UUID reservaId, Long currentUserId) {
+        Reservation reservation = reservationCommandPort.findById(reservaId)
+                .orElseThrow(() -> new PagoNotFoundException("Reserva no encontrada: " + reservaId));
+
+        if (!reservation.getOwnerId().equals(currentUserId)) {
+            throw new PagoForbiddenException("Solo el titular de la reserva puede iniciar el pago");
+        }
+        if (reservation.getStatus() == ReservationStatus.CANCELLED) {
+            throw new PagoUnprocessableException("RESERVA_CANCELLED",
+                    "La reserva está cancelada y no admite pagos");
+        }
+
+        Payment payment = paymentCommandPort.findByReservationId(reservaId)
+                .orElseThrow(() -> new PagoNotFoundException(
+                        "No existe un pago para la reserva: " + reservaId));
+
+        if (payment.getStatus() != PaymentStatus.PENDING) {
+            if (payment.getStatus() == PaymentStatus.PAID) {
+                throw new PagoConflictException("La reserva ya está pagada");
+            }
+            throw new PagoConflictException("Ya hay un pago en curso para esta reserva");
+        }
+
+        RedsysCredentials credentials = redsysConfigService.loadCredentials();
+
+        // RN-RES-03 — amount is the backend-frozen euro amount; convert to céntimos for Redsys.
+        String amountCents = toCents(payment.getAmount());
+        String order = orderIdGenerator.generate();
+
+        String merchantParameters = buildMerchantParameters(order, amountCents, credentials);
+        String signature = RedsysSignature.sign(merchantParameters, order, credentials.merchantKey());
+
+        payment.markInProgress(order, redsysProperties.tpvUrl());
+        Payment saved = paymentCommandPort.save(payment);
+
+        auditRecorder.record(PagoAuditActions.PAYMENT_INITIATED, currentUserId,
+                "reservationId=" + reservaId + ", orderId=" + order);
+
+        return new IniciarPagoResponse(
+                saved.getId() != null ? saved.getId().toString() : null,
+                order,
+                redsysProperties.tpvUrl(),
+                payment.getAmount(),
+                saved.getStatus().name(),
+                SIGNATURE_VERSION,
+                merchantParameters,
+                signature);
+    }
+
+    /** Euros → céntimos string (e.g. {@code 15.00} → {@code "1500"}). */
+    private String toCents(BigDecimal euros) {
+        return euros.movePointRight(2).setScale(0, RoundingMode.HALF_UP).toBigIntegerExact().toString();
+    }
+
+    private String buildMerchantParameters(String order, String amountCents, RedsysCredentials creds) {
+        Map<String, String> params = new LinkedHashMap<>();
+        params.put("DS_MERCHANT_AMOUNT", amountCents);
+        params.put("DS_MERCHANT_ORDER", order);
+        params.put("DS_MERCHANT_MERCHANTCODE", creds.merchantCode());
+        params.put("DS_MERCHANT_CURRENCY", redsysProperties.currency());
+        params.put("DS_MERCHANT_TRANSACTIONTYPE", TRANSACTION_TYPE);
+        params.put("DS_MERCHANT_TERMINAL", creds.terminal());
+        params.put("DS_MERCHANT_MERCHANTURL", redsysProperties.merchantUrl());
+        params.put("DS_MERCHANT_URLOK", redsysProperties.urlOk());
+        params.put("DS_MERCHANT_URLKO", redsysProperties.urlKo());
+        try {
+            String json = objectMapper.writeValueAsString(params);
+            return Base64.getEncoder().encodeToString(json.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to serialize Redsys merchant parameters", e);
+        }
+    }
+}

--- a/backend/src/main/java/com/padelpro/pagos/application/service/PagoAuditRecorder.java
+++ b/backend/src/main/java/com/padelpro/pagos/application/service/PagoAuditRecorder.java
@@ -1,0 +1,36 @@
+package com.padelpro.pagos.application.service;
+
+import com.padelpro.auth.domain.model.AuditLog;
+import com.padelpro.auth.domain.model.User;
+import com.padelpro.auth.domain.port.out.AuditLogRepositoryPort;
+import com.padelpro.auth.domain.port.out.UserRepositoryPort;
+
+import java.time.OffsetDateTime;
+
+/**
+ * Writes payment audit events to {@code audit_log} (pagos-redsys-online). Resolves the optional acting
+ * user by id (null for the server-to-server webhook path). {@code details} must never contain card
+ * data or the full {@code Ds_MerchantParameters} (RN-PAY-03).
+ */
+public class PagoAuditRecorder {
+
+    private final AuditLogRepositoryPort auditLogRepositoryPort;
+    private final UserRepositoryPort userRepositoryPort;
+
+    public PagoAuditRecorder(AuditLogRepositoryPort auditLogRepositoryPort,
+                             UserRepositoryPort userRepositoryPort) {
+        this.auditLogRepositoryPort = auditLogRepositoryPort;
+        this.userRepositoryPort = userRepositoryPort;
+    }
+
+    /**
+     * @param action  audit action constant (see {@code PagoAuditActions})
+     * @param userId  the acting user id, or {@code null} (webhook has no authenticated principal)
+     * @param details safe, non-PII, non-card context (e.g. {@code "orderId=..., status=..."})
+     */
+    public void record(String action, Long userId, String details) {
+        User user = (userId == null) ? null
+                : userRepositoryPort.findById(userId).orElse(null);
+        auditLogRepositoryPort.save(new AuditLog(action, user, null, details, OffsetDateTime.now()));
+    }
+}

--- a/backend/src/main/java/com/padelpro/pagos/application/service/PagoQueryService.java
+++ b/backend/src/main/java/com/padelpro/pagos/application/service/PagoQueryService.java
@@ -1,0 +1,83 @@
+package com.padelpro.pagos.application.service;
+
+import com.padelpro.pagos.application.dto.PagoHistorialResponse;
+import com.padelpro.reservas.domain.model.Payment;
+import com.padelpro.reservas.domain.model.Reservation;
+import com.padelpro.reservas.infrastructure.persistence.PaymentJpaRepository;
+import com.padelpro.reservas.infrastructure.persistence.ReservationJpaRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Read use cases for payment history (pagos-redsys-online, group 5).
+ *
+ * <p>{@code GET /api/pagos} returns the authenticated user's own payments (reservations they own);
+ * {@code GET /api/admin/pagos} returns every payment. Anti-N+1: reservations are batch-loaded once and
+ * joined in memory. Never exposes card data — only {@code redsysOrderId}/{@code transactionId}
+ * (RN-PAY-03).
+ */
+public class PagoQueryService {
+
+    private final PaymentJpaRepository paymentRepository;
+    private final ReservationJpaRepository reservationRepository;
+
+    public PagoQueryService(PaymentJpaRepository paymentRepository,
+                            ReservationJpaRepository reservationRepository) {
+        this.paymentRepository = paymentRepository;
+        this.reservationRepository = reservationRepository;
+    }
+
+    /** Payments of reservations owned by the user, most-recent first. */
+    @Transactional(readOnly = true)
+    public List<PagoHistorialResponse> listForUser(Long userId) {
+        List<Reservation> owned = reservationRepository.findByOwnerId(userId);
+        if (owned.isEmpty()) {
+            return List.of();
+        }
+        Map<UUID, Reservation> byId = owned.stream()
+                .collect(Collectors.toMap(Reservation::getId, Function.identity()));
+        List<Payment> payments = paymentRepository.findByReservationIdIn(byId.keySet());
+        return payments.stream()
+                .map(p -> toResponse(p, byId.get(p.getReservationId())))
+                .sorted(Comparator.comparing(PagoHistorialResponse::createdAt,
+                        Comparator.nullsLast(Comparator.reverseOrder())))
+                .toList();
+    }
+
+    /** All payments (ADMIN), most-recent first. */
+    @Transactional(readOnly = true)
+    public List<PagoHistorialResponse> listAll() {
+        List<Payment> payments = paymentRepository.findAllByOrderByCreatedAtDesc();
+        if (payments.isEmpty()) {
+            return List.of();
+        }
+        List<UUID> reservationIds = payments.stream().map(Payment::getReservationId).toList();
+        Map<UUID, Reservation> byId = reservationRepository.findAllById(reservationIds).stream()
+                .collect(Collectors.toMap(Reservation::getId, Function.identity()));
+        return payments.stream()
+                .map(p -> toResponse(p, byId.get(p.getReservationId())))
+                .toList();
+    }
+
+    private PagoHistorialResponse toResponse(Payment p, Reservation r) {
+        return new PagoHistorialResponse(
+                p.getId() != null ? p.getId().toString() : null,
+                p.getReservationId() != null ? p.getReservationId().toString() : null,
+                r != null ? r.getOwnerId() : null,
+                p.getAmount(),
+                p.getMethod() != null ? p.getMethod().name() : null,
+                p.getStatus() != null ? p.getStatus().name() : null,
+                p.getRedsysOrderId(),
+                p.getTransactionId(),
+                r != null ? r.getReservationDate() : null,
+                r != null ? r.getStartTime() : null,
+                p.getPaidAt(),
+                p.getCreatedAt());
+    }
+}

--- a/backend/src/main/java/com/padelpro/pagos/application/service/ProcesarWebhookService.java
+++ b/backend/src/main/java/com/padelpro/pagos/application/service/ProcesarWebhookService.java
@@ -13,6 +13,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
 import java.util.Base64;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 /**
  * Process a Redsys notification webhook (pagos-redsys-online, D3).
@@ -31,6 +32,16 @@ import java.util.Optional;
  * <p>The caller always responds HTTP 200. The raw body and card data are never persisted or logged.
  */
 public class ProcesarWebhookService {
+
+    /** The only signature version Redsys emits for this integration (BAJO-2). */
+    private static final String SUPPORTED_SIGNATURE_VERSION = "HMAC_SHA256_V1";
+
+    /**
+     * Allowed shape of a {@code Ds_Order} (Redsys: 4–12 chars, accept up to 32 defensively). Anything
+     * outside this alphabet is treated as attacker-controlled and never written verbatim to the audit
+     * log (MEDIO-3, log-injection / stored-XSS defence).
+     */
+    private static final Pattern ORDER_PATTERN = Pattern.compile("^[0-9A-Za-z]{1,32}$");
 
     private final PaymentCommandPort paymentCommandPort;
     private final RedsysConfigService redsysConfigService;
@@ -58,45 +69,63 @@ public class ProcesarWebhookService {
         }
         String order = text(params, "Ds_Order");
 
-        // 2. Verify signature BEFORE touching anything (RN-PAY-01, constant time inside verify()).
+        // 2. Reject any unsupported signature version outright — a valid Redsys notification is always
+        //    HMAC_SHA256_V1 (BAJO-2). Anything else is audited as an invalid signature and dropped.
+        if (!SUPPORTED_SIGNATURE_VERSION.equals(signatureVersion)) {
+            auditRecorder.record(PagoAuditActions.PAYMENT_WEBHOOK_INVALID_SIGNATURE, null,
+                    "orderId=" + safeOrder(order) + ", reason=unsupported-signature-version");
+            return;
+        }
+
+        // 3. Verify signature BEFORE touching anything (RN-PAY-01, constant time inside verify()).
         String merchantKey = redsysConfigService.loadCredentials().merchantKey();
         boolean valid = order != null
                 && RedsysSignature.verify(merchantParameters, order, signature, merchantKey);
         if (!valid) {
             auditRecorder.record(PagoAuditActions.PAYMENT_WEBHOOK_INVALID_SIGNATURE, null,
-                    "orderId=" + order);
+                    "orderId=" + safeOrder(order));
             return;
         }
 
-        // 3. Locate the payment under a pessimistic write lock so concurrent notifications for the same
+        // 4. Locate the payment under a pessimistic write lock so concurrent notifications for the same
         //    order serialise (MEDIO-2): the second waits, re-reads PAID below, and skips reprocessing.
         Optional<Payment> found = paymentCommandPort.findByRedsysOrderIdForUpdate(order);
         if (found.isEmpty()) {
             auditRecorder.record(PagoAuditActions.PAYMENT_WEBHOOK_ORDER_NOT_FOUND, null,
-                    "orderId=" + order);
+                    "orderId=" + safeOrder(order));
             return;
         }
         Payment payment = found.get();
 
-        // 4. Idempotent: an already-PAID payment is never reprocessed (RN-PAY-02). Under the lock
+        // 5. Idempotent: an already-PAID payment is never reprocessed (RN-PAY-02). Under the lock
         //    above, a concurrent duplicate reaches this branch and no-ops.
         if (payment.getStatus() == PaymentStatus.PAID) {
             return;
         }
 
-        // 5. Apply outcome by Ds_Response (0000..0099 = approved).
+        // 6. Apply outcome by Ds_Response (0000..0099 = approved).
         Integer response = parseResponse(text(params, "Ds_Response"));
         if (response != null && response >= 0 && response <= 99) {
             payment.markPaid(text(params, "Ds_AuthorisationCode"), OffsetDateTime.now());
             paymentCommandPort.save(payment);
             auditRecorder.record(PagoAuditActions.PAYMENT_CONFIRMED, null,
-                    "orderId=" + order + ", reservationId=" + payment.getReservationId());
+                    "orderId=" + safeOrder(order) + ", reservationId=" + payment.getReservationId());
         } else {
             payment.markFailed();
             paymentCommandPort.save(payment);
             auditRecorder.record(PagoAuditActions.PAYMENT_REJECTED, null,
-                    "orderId=" + order + ", dsResponse=" + response);
+                    "orderId=" + safeOrder(order) + ", dsResponse=" + response);
         }
+    }
+
+    /**
+     * Sanitise a {@code Ds_Order} value before it is written to the audit log (MEDIO-3). Returns the
+     * order unchanged only when it matches the strict alphanumeric shape; any attacker-controlled
+     * payload (newlines, {@code <script>…}, over-length) collapses to {@code <invalid-format>} so it
+     * can never inject log lines or be stored/rendered verbatim.
+     */
+    private String safeOrder(String order) {
+        return (order != null && ORDER_PATTERN.matcher(order).matches()) ? order : "<invalid-format>";
     }
 
     private JsonNode decodeParameters(String merchantParameters) {

--- a/backend/src/main/java/com/padelpro/pagos/application/service/ProcesarWebhookService.java
+++ b/backend/src/main/java/com/padelpro/pagos/application/service/ProcesarWebhookService.java
@@ -68,8 +68,9 @@ public class ProcesarWebhookService {
             return;
         }
 
-        // 3. Locate the payment (idempotency anchor, RN-PAY-02).
-        Optional<Payment> found = paymentCommandPort.findByRedsysOrderId(order);
+        // 3. Locate the payment under a pessimistic write lock so concurrent notifications for the same
+        //    order serialise (MEDIO-2): the second waits, re-reads PAID below, and skips reprocessing.
+        Optional<Payment> found = paymentCommandPort.findByRedsysOrderIdForUpdate(order);
         if (found.isEmpty()) {
             auditRecorder.record(PagoAuditActions.PAYMENT_WEBHOOK_ORDER_NOT_FOUND, null,
                     "orderId=" + order);
@@ -77,7 +78,8 @@ public class ProcesarWebhookService {
         }
         Payment payment = found.get();
 
-        // 4. Idempotent: an already-PAID payment is never reprocessed (RN-PAY-02).
+        // 4. Idempotent: an already-PAID payment is never reprocessed (RN-PAY-02). Under the lock
+        //    above, a concurrent duplicate reaches this branch and no-ops.
         if (payment.getStatus() == PaymentStatus.PAID) {
             return;
         }

--- a/backend/src/main/java/com/padelpro/pagos/application/service/ProcesarWebhookService.java
+++ b/backend/src/main/java/com/padelpro/pagos/application/service/ProcesarWebhookService.java
@@ -1,0 +1,140 @@
+package com.padelpro.pagos.application.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.padelpro.pagos.domain.audit.PagoAuditActions;
+import com.padelpro.pagos.domain.model.RedsysSignature;
+import com.padelpro.reservas.domain.model.Payment;
+import com.padelpro.reservas.domain.model.PaymentStatus;
+import com.padelpro.reservas.domain.port.out.PaymentCommandPort;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
+import java.util.Base64;
+import java.util.Optional;
+
+/**
+ * Process a Redsys notification webhook (pagos-redsys-online, D3).
+ *
+ * <p>Order of operations (RN-PAY-01/02/03):
+ * <ol>
+ *   <li>Decode {@code Ds_MerchantParameters} and extract {@code Ds_Order} — no state change yet.</li>
+ *   <li>Verify the HMAC signature in constant time. Invalid → audit
+ *       {@code PAYMENT_WEBHOOK_INVALID_SIGNATURE} and stop (no payment touched).</li>
+ *   <li>Locate the payment by {@code redsys_order_id}; unknown → audit and stop.</li>
+ *   <li>Already {@code PAID} → idempotent no-op.</li>
+ *   <li>{@code Ds_Response} in {@code 0000..0099} → PAID + transaction id + {@code PAYMENT_CONFIRMED};
+ *       otherwise FAILED + {@code PAYMENT_REJECTED}.</li>
+ * </ol>
+ *
+ * <p>The caller always responds HTTP 200. The raw body and card data are never persisted or logged.
+ */
+public class ProcesarWebhookService {
+
+    private final PaymentCommandPort paymentCommandPort;
+    private final RedsysConfigService redsysConfigService;
+    private final PagoAuditRecorder auditRecorder;
+    private final ObjectMapper objectMapper;
+
+    public ProcesarWebhookService(PaymentCommandPort paymentCommandPort,
+                                  RedsysConfigService redsysConfigService,
+                                  PagoAuditRecorder auditRecorder,
+                                  ObjectMapper objectMapper) {
+        this.paymentCommandPort = paymentCommandPort;
+        this.redsysConfigService = redsysConfigService;
+        this.auditRecorder = auditRecorder;
+        this.objectMapper = objectMapper;
+    }
+
+    @Transactional
+    public void procesar(String signatureVersion, String merchantParameters, String signature) {
+        // 1. Decode parameters (no state change). A malformed body is treated as an invalid signature.
+        JsonNode params = decodeParameters(merchantParameters);
+        if (params == null) {
+            auditRecorder.record(PagoAuditActions.PAYMENT_WEBHOOK_INVALID_SIGNATURE, null,
+                    "reason=undecodable-parameters");
+            return;
+        }
+        String order = text(params, "Ds_Order");
+
+        // 2. Verify signature BEFORE touching anything (RN-PAY-01, constant time inside verify()).
+        String merchantKey = redsysConfigService.loadCredentials().merchantKey();
+        boolean valid = order != null
+                && RedsysSignature.verify(merchantParameters, order, signature, merchantKey);
+        if (!valid) {
+            auditRecorder.record(PagoAuditActions.PAYMENT_WEBHOOK_INVALID_SIGNATURE, null,
+                    "orderId=" + order);
+            return;
+        }
+
+        // 3. Locate the payment (idempotency anchor, RN-PAY-02).
+        Optional<Payment> found = paymentCommandPort.findByRedsysOrderId(order);
+        if (found.isEmpty()) {
+            auditRecorder.record(PagoAuditActions.PAYMENT_WEBHOOK_ORDER_NOT_FOUND, null,
+                    "orderId=" + order);
+            return;
+        }
+        Payment payment = found.get();
+
+        // 4. Idempotent: an already-PAID payment is never reprocessed (RN-PAY-02).
+        if (payment.getStatus() == PaymentStatus.PAID) {
+            return;
+        }
+
+        // 5. Apply outcome by Ds_Response (0000..0099 = approved).
+        Integer response = parseResponse(text(params, "Ds_Response"));
+        if (response != null && response >= 0 && response <= 99) {
+            payment.markPaid(text(params, "Ds_AuthorisationCode"), OffsetDateTime.now());
+            paymentCommandPort.save(payment);
+            auditRecorder.record(PagoAuditActions.PAYMENT_CONFIRMED, null,
+                    "orderId=" + order + ", reservationId=" + payment.getReservationId());
+        } else {
+            payment.markFailed();
+            paymentCommandPort.save(payment);
+            auditRecorder.record(PagoAuditActions.PAYMENT_REJECTED, null,
+                    "orderId=" + order + ", dsResponse=" + response);
+        }
+    }
+
+    private JsonNode decodeParameters(String merchantParameters) {
+        if (merchantParameters == null || merchantParameters.isBlank()) {
+            return null;
+        }
+        try {
+            // Redsys uses URL-safe Base64 in notifications; normalise so both variants decode.
+            String normalised = merchantParameters.replace('+', '-').replace('/', '_');
+            byte[] json = Base64.getUrlDecoder().decode(normalised);
+            return objectMapper.readTree(new String(json, StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /** Case-insensitive field read (Redsys uses {@code Ds_Order}; be lenient). */
+    private String text(JsonNode node, String field) {
+        JsonNode v = node.get(field);
+        if (v == null) {
+            java.util.Iterator<String> names = node.fieldNames();
+            while (names.hasNext()) {
+                String n = names.next();
+                if (n.equalsIgnoreCase(field)) {
+                    v = node.get(n);
+                    break;
+                }
+            }
+        }
+        return (v == null || v.isNull()) ? null : v.asText();
+    }
+
+    private Integer parseResponse(String dsResponse) {
+        if (dsResponse == null || dsResponse.isBlank()) {
+            return null;
+        }
+        try {
+            return Integer.parseInt(dsResponse.trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+}

--- a/backend/src/main/java/com/padelpro/pagos/application/service/RedsysConfigService.java
+++ b/backend/src/main/java/com/padelpro/pagos/application/service/RedsysConfigService.java
@@ -1,0 +1,73 @@
+package com.padelpro.pagos.application.service;
+
+import com.padelpro.auth.application.service.EncryptionService;
+import com.padelpro.auth.domain.model.SystemConfig;
+import com.padelpro.auth.domain.port.out.SystemConfigRepositoryPort;
+import com.padelpro.pagos.domain.exception.PagoUnprocessableException;
+
+/**
+ * Resolves and decrypts the Redsys merchant credentials from {@code system_config} (pagos-redsys-online,
+ * D4). {@code redsys_merchant_id}, {@code redsys_merchant_key} and {@code redsys_terminal} are stored
+ * AES-256-GCM encrypted and decrypted here with the existing {@link EncryptionService}.
+ *
+ * <p>The terminal defaults to {@code "1"} when unconfigured. If merchant id/key are missing the
+ * gateway cannot be used → {@link PagoUnprocessableException} {@code REDSYS_NOT_CONFIGURED} (422).
+ *
+ * <p>Never logs any secret (RN-PAY-03).
+ */
+public class RedsysConfigService {
+
+    private static final String DEFAULT_TERMINAL = "1";
+
+    private final SystemConfigRepositoryPort systemConfigRepositoryPort;
+    private final EncryptionService encryptionService;
+
+    public RedsysConfigService(SystemConfigRepositoryPort systemConfigRepositoryPort,
+                               EncryptionService encryptionService) {
+        this.systemConfigRepositoryPort = systemConfigRepositoryPort;
+        this.encryptionService = encryptionService;
+    }
+
+    /** Decrypted terminal, defaulting to {@code "1"} when the column is null/blank (D4). */
+    public String getTerminalOrDefault() {
+        SystemConfig config = loadConfig();
+        return decryptTerminal(config);
+    }
+
+    /**
+     * Full Redsys credentials for building/verifying the TPV form.
+     *
+     * @throws PagoUnprocessableException {@code REDSYS_NOT_CONFIGURED} if merchant id/key are absent
+     */
+    public RedsysCredentials loadCredentials() {
+        SystemConfig config = loadConfig();
+        String merchantId = decryptOrNull(config.getRedsysMerchantId());
+        String merchantKey = decryptOrNull(config.getRedsysMerchantKey());
+        if (isBlank(merchantId) || isBlank(merchantKey)) {
+            throw new PagoUnprocessableException("REDSYS_NOT_CONFIGURED",
+                    "El comercio Redsys no está configurado");
+        }
+        return new RedsysCredentials(merchantId, merchantKey, decryptTerminal(config));
+    }
+
+    private SystemConfig loadConfig() {
+        return systemConfigRepositoryPort.findById(1L)
+                .orElseThrow(() -> new IllegalStateException("System configuration not found"));
+    }
+
+    private String decryptTerminal(SystemConfig config) {
+        String terminal = decryptOrNull(config.getRedsysTerminal());
+        return isBlank(terminal) ? DEFAULT_TERMINAL : terminal;
+    }
+
+    private String decryptOrNull(String encrypted) {
+        if (isBlank(encrypted)) {
+            return null;
+        }
+        return encryptionService.decrypt(encrypted);
+    }
+
+    private static boolean isBlank(String s) {
+        return s == null || s.isBlank();
+    }
+}

--- a/backend/src/main/java/com/padelpro/pagos/application/service/RedsysCredentials.java
+++ b/backend/src/main/java/com/padelpro/pagos/application/service/RedsysCredentials.java
@@ -1,0 +1,11 @@
+package com.padelpro.pagos.application.service;
+
+/**
+ * Decrypted Redsys merchant credentials (pagos-redsys-online, D4). Held only in memory; never logged.
+ *
+ * @param merchantCode the merchant/commerce code (FUC)
+ * @param merchantKey  the merchant secret key (Base64) used to derive per-order signing keys
+ * @param terminal     the terminal number (defaults to {@code "1"} when unconfigured)
+ */
+public record RedsysCredentials(String merchantCode, String merchantKey, String terminal) {
+}

--- a/backend/src/main/java/com/padelpro/pagos/application/service/RedsysOrderIdGenerator.java
+++ b/backend/src/main/java/com/padelpro/pagos/application/service/RedsysOrderIdGenerator.java
@@ -1,0 +1,28 @@
+package com.padelpro.pagos.application.service;
+
+import java.security.SecureRandom;
+
+/**
+ * Generates Redsys order ids (pagos-redsys-online, D5). Redsys requires the {@code Ds_Merchant_Order}
+ * to start with 4 numeric digits followed by up to 8 alphanumeric characters (4–12 chars total).
+ *
+ * <p>Implemented as a class (not a lambda) so it can be stubbed deterministically in unit tests.
+ */
+public class RedsysOrderIdGenerator {
+
+    private static final char[] ALNUM = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ".toCharArray();
+
+    private final SecureRandom random = new SecureRandom();
+
+    /** A fresh order id: 4 leading digits + 8 uppercase alphanumeric characters (12 chars). */
+    public String generate() {
+        StringBuilder sb = new StringBuilder(12);
+        for (int i = 0; i < 4; i++) {
+            sb.append((char) ('0' + random.nextInt(10)));
+        }
+        for (int i = 0; i < 8; i++) {
+            sb.append(ALNUM[random.nextInt(ALNUM.length)]);
+        }
+        return sb.toString();
+    }
+}

--- a/backend/src/main/java/com/padelpro/pagos/application/service/RedsysProperties.java
+++ b/backend/src/main/java/com/padelpro/pagos/application/service/RedsysProperties.java
@@ -1,0 +1,20 @@
+package com.padelpro.pagos.application.service;
+
+/**
+ * Non-secret Redsys endpoint configuration (pagos-redsys-online, D5/D6). Populated from
+ * {@code app.redsys.*}. Distinct from the encrypted merchant credentials in {@code system_config}.
+ *
+ * @param tpvUrl      the Redsys TPV endpoint the signed form is submitted to (sandbox vs production)
+ * @param merchantUrl the server-to-server webhook URL sent as {@code Ds_Merchant_MerchantURL}
+ * @param urlOk       the browser return URL on success ({@code Ds_Merchant_UrlOK})
+ * @param urlKo       the browser return URL on failure ({@code Ds_Merchant_UrlKO})
+ * @param currency    ISO-4217 numeric currency code ({@code 978} = EUR)
+ */
+public record RedsysProperties(
+        String tpvUrl,
+        String merchantUrl,
+        String urlOk,
+        String urlKo,
+        String currency
+) {
+}

--- a/backend/src/main/java/com/padelpro/pagos/application/service/RegistrarPagoEfectivoService.java
+++ b/backend/src/main/java/com/padelpro/pagos/application/service/RegistrarPagoEfectivoService.java
@@ -1,0 +1,68 @@
+package com.padelpro.pagos.application.service;
+
+import com.padelpro.pagos.application.dto.EfectivoPagoResponse;
+import com.padelpro.pagos.domain.audit.PagoAuditActions;
+import com.padelpro.pagos.domain.exception.PagoNotFoundException;
+import com.padelpro.pagos.domain.exception.PagoUnprocessableException;
+import com.padelpro.reservas.domain.model.Payment;
+import com.padelpro.reservas.domain.model.PaymentStatus;
+import com.padelpro.reservas.domain.model.Reservation;
+import com.padelpro.reservas.domain.port.out.PaymentCommandPort;
+import com.padelpro.reservas.domain.port.out.ReservationCommandPort;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+/**
+ * Register a manual cash payment by an ADMIN (pagos-redsys-online, group 5).
+ *
+ * <p>The reservation must exist (404) and its payment must not already be PAID (422). On success the
+ * payment moves to PAID / CASH with the registering admin id (DB CHECK {@code chk_pay_cash_admin}) and
+ * {@code PAYMENT_CASH_REGISTERED} is audited. ADMIN authorization is enforced by the security layer
+ * ({@code /api/admin/**} + {@code @PreAuthorize}); a USER gets 403 before reaching this service.
+ */
+public class RegistrarPagoEfectivoService {
+
+    private final ReservationCommandPort reservationCommandPort;
+    private final PaymentCommandPort paymentCommandPort;
+    private final PagoAuditRecorder auditRecorder;
+
+    public RegistrarPagoEfectivoService(ReservationCommandPort reservationCommandPort,
+                                        PaymentCommandPort paymentCommandPort,
+                                        PagoAuditRecorder auditRecorder) {
+        this.reservationCommandPort = reservationCommandPort;
+        this.paymentCommandPort = paymentCommandPort;
+        this.auditRecorder = auditRecorder;
+    }
+
+    @Transactional
+    public EfectivoPagoResponse registrar(UUID reservaId, Long adminId) {
+        Reservation reservation = reservationCommandPort.findById(reservaId)
+                .orElseThrow(() -> new PagoNotFoundException("Reserva no encontrada: " + reservaId));
+
+        Payment payment = paymentCommandPort.findByReservationId(reservation.getId())
+                .orElseThrow(() -> new PagoNotFoundException(
+                        "No existe un pago para la reserva: " + reservaId));
+
+        if (payment.getStatus() == PaymentStatus.PAID) {
+            throw new PagoUnprocessableException("ALREADY_PAID",
+                    "La reserva ya está cobrada");
+        }
+
+        payment.markCashPaid(adminId, OffsetDateTime.now());
+        Payment saved = paymentCommandPort.save(payment);
+
+        auditRecorder.record(PagoAuditActions.PAYMENT_CASH_REGISTERED, adminId,
+                "reservationId=" + reservaId + ", paymentId=" + saved.getId());
+
+        return new EfectivoPagoResponse(
+                saved.getId() != null ? saved.getId().toString() : null,
+                reservaId.toString(),
+                saved.getAmount(),
+                saved.getMethod() != null ? saved.getMethod().name() : null,
+                saved.getStatus().name(),
+                saved.getRegisteredById(),
+                saved.getPaidAt());
+    }
+}

--- a/backend/src/main/java/com/padelpro/pagos/domain/audit/PagoAuditActions.java
+++ b/backend/src/main/java/com/padelpro/pagos/domain/audit/PagoAuditActions.java
@@ -1,0 +1,18 @@
+package com.padelpro.pagos.domain.audit;
+
+/**
+ * Audit action constants for the pagos-redsys-online capability. Written to {@code audit_log} with no
+ * card data (RN-PAY-03).
+ */
+public final class PagoAuditActions {
+
+    public static final String PAYMENT_INITIATED                 = "PAYMENT_INITIATED";
+    public static final String PAYMENT_CONFIRMED                 = "PAYMENT_CONFIRMED";
+    public static final String PAYMENT_REJECTED                  = "PAYMENT_REJECTED";
+    public static final String PAYMENT_WEBHOOK_INVALID_SIGNATURE = "PAYMENT_WEBHOOK_INVALID_SIGNATURE";
+    public static final String PAYMENT_WEBHOOK_ORDER_NOT_FOUND   = "PAYMENT_WEBHOOK_ORDER_NOT_FOUND";
+    public static final String PAYMENT_CASH_REGISTERED           = "PAYMENT_CASH_REGISTERED";
+
+    private PagoAuditActions() {
+    }
+}

--- a/backend/src/main/java/com/padelpro/pagos/domain/exception/PagoConflictException.java
+++ b/backend/src/main/java/com/padelpro/pagos/domain/exception/PagoConflictException.java
@@ -1,0 +1,11 @@
+package com.padelpro.pagos.domain.exception;
+
+/**
+ * A payment is already in progress or completed for this reservation (pagos-redsys-online, D5).
+ * Surfaces as HTTP 409.
+ */
+public class PagoConflictException extends RuntimeException {
+    public PagoConflictException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/padelpro/pagos/domain/exception/PagoForbiddenException.java
+++ b/backend/src/main/java/com/padelpro/pagos/domain/exception/PagoForbiddenException.java
@@ -1,0 +1,10 @@
+package com.padelpro.pagos.domain.exception;
+
+/**
+ * The caller is not the owner of the reservation and may not pay it (RN-AUTH-04). Surfaces as HTTP 403.
+ */
+public class PagoForbiddenException extends RuntimeException {
+    public PagoForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/padelpro/pagos/domain/exception/PagoNotFoundException.java
+++ b/backend/src/main/java/com/padelpro/pagos/domain/exception/PagoNotFoundException.java
@@ -1,0 +1,10 @@
+package com.padelpro.pagos.domain.exception;
+
+/**
+ * The reservation or its payment does not exist (pagos-redsys-online). Surfaces as HTTP 404.
+ */
+public class PagoNotFoundException extends RuntimeException {
+    public PagoNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/padelpro/pagos/domain/exception/PagoUnprocessableException.java
+++ b/backend/src/main/java/com/padelpro/pagos/domain/exception/PagoUnprocessableException.java
@@ -1,0 +1,20 @@
+package com.padelpro.pagos.domain.exception;
+
+/**
+ * The payment operation is not applicable in the current state (e.g. the reservation is cancelled, the
+ * payment is already collected, or Redsys is not configured). Surfaces as HTTP 422 carrying a
+ * machine-readable {@code code}.
+ */
+public class PagoUnprocessableException extends RuntimeException {
+
+    private final String code;
+
+    public PagoUnprocessableException(String code, String message) {
+        super(message);
+        this.code = code;
+    }
+
+    public String getCode() {
+        return code;
+    }
+}

--- a/backend/src/main/java/com/padelpro/pagos/domain/model/RedsysSignature.java
+++ b/backend/src/main/java/com/padelpro/pagos/domain/model/RedsysSignature.java
@@ -1,0 +1,120 @@
+package com.padelpro.pagos.domain.model;
+
+import javax.crypto.Cipher;
+import javax.crypto.Mac;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Arrays;
+import java.util.Base64;
+
+/**
+ * Redsys {@code HMAC_SHA256_V1} signature (pagos-redsys-online, D2).
+ *
+ * <p>Protocol (no third-party dependency, algorithm is short and auditable):
+ * <ol>
+ *   <li>Derive a per-order key by encrypting the {@code Ds_Merchant_Order} with <b>3DES/CBC</b> and a
+ *       zero IV, using the merchant secret key (Base64-decoded to 24 bytes) as the DESede key. The
+ *       order is zero-padded to a multiple of 8 bytes (CBC/NoPadding).</li>
+ *   <li>Compute <b>HMAC-SHA256</b> of the {@code Ds_MerchantParameters} string (the Base64 of the JSON,
+ *       exactly as transmitted) with that per-order key.</li>
+ *   <li>Base64-encode the MAC. The request uses standard Base64; the notification uses the URL-safe
+ *       alphabet ({@code -_}).</li>
+ * </ol>
+ *
+ * <p>Signature comparison on the webhook path is done in <b>constant time</b>
+ * ({@link MessageDigest#isEqual}) to avoid timing side channels (RN-PAY-01).
+ *
+ * <p><b>Security:</b> this class never logs the merchant key, the derived key, or the parameters.
+ */
+public final class RedsysSignature {
+
+    private static final byte[] ZERO_IV = new byte[8];
+
+    private RedsysSignature() {
+    }
+
+    /**
+     * Sign {@code Ds_MerchantParameters} for a <b>request</b> to the TPV (standard Base64 signature).
+     *
+     * @param base64MerchantParameters the Base64 of the parameters JSON, exactly as it will be sent
+     * @param order                    the {@code Ds_Merchant_Order} carried inside those parameters
+     * @param merchantKeyBase64        the merchant secret key (Base64)
+     * @return the Base64 (standard) {@code Ds_Signature}
+     */
+    public static String sign(String base64MerchantParameters, String order, String merchantKeyBase64) {
+        byte[] derivedKey = deriveOrderKey(order, merchantKeyBase64);
+        byte[] mac = hmacSha256(derivedKey, base64MerchantParameters);
+        return Base64.getEncoder().encodeToString(mac);
+    }
+
+    /**
+     * Verify a <b>notification</b> signature in constant time (RN-PAY-01). The received
+     * {@code Ds_MerchantParameters} and {@code Ds_Signature} may use the URL-safe Base64 alphabet;
+     * both URL-safe and standard signatures are accepted.
+     *
+     * @param receivedMerchantParameters the {@code Ds_MerchantParameters} string exactly as received
+     * @param order                      the {@code Ds_Order} decoded from those parameters
+     * @param receivedSignature          the {@code Ds_Signature} exactly as received
+     * @param merchantKeyBase64          the merchant secret key (Base64)
+     * @return {@code true} iff the signature matches
+     */
+    public static boolean verify(String receivedMerchantParameters, String order,
+                                 String receivedSignature, String merchantKeyBase64) {
+        if (receivedMerchantParameters == null || order == null || receivedSignature == null) {
+            return false;
+        }
+        byte[] derivedKey = deriveOrderKey(order, merchantKeyBase64);
+        byte[] computed = hmacSha256(derivedKey, receivedMerchantParameters);
+        byte[] provided;
+        try {
+            // Redsys emits URL-safe Base64 in notifications; normalise so both variants decode.
+            provided = Base64.getUrlDecoder().decode(toUrlSafe(receivedSignature));
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+        // Constant-time comparison (RN-PAY-01).
+        return MessageDigest.isEqual(computed, provided);
+    }
+
+    // -------------------------------------------------------------------------
+    // Internals
+    // -------------------------------------------------------------------------
+
+    private static byte[] deriveOrderKey(String order, String merchantKeyBase64) {
+        try {
+            byte[] key = Base64.getDecoder().decode(merchantKeyBase64);
+            Cipher cipher = Cipher.getInstance("DESede/CBC/NoPadding");
+            cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(key, "DESede"),
+                    new IvParameterSpec(ZERO_IV));
+            return cipher.doFinal(zeroPad(order.getBytes(StandardCharsets.UTF_8)));
+        } catch (Exception e) {
+            // Never include the key or order in the message.
+            throw new IllegalStateException("Redsys order-key derivation failed", e);
+        }
+    }
+
+    private static byte[] hmacSha256(byte[] key, String data) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(key, "HmacSHA256"));
+            return mac.doFinal(data.getBytes(StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            throw new IllegalStateException("Redsys HMAC computation failed", e);
+        }
+    }
+
+    /** Zero-pad to the next multiple of 8 bytes (3DES/CBC block size). */
+    private static byte[] zeroPad(byte[] input) {
+        int padded = ((input.length + 7) / 8) * 8;
+        if (padded == 0) {
+            padded = 8;
+        }
+        return Arrays.copyOf(input, padded);
+    }
+
+    private static String toUrlSafe(String s) {
+        return s.replace('+', '-').replace('/', '_');
+    }
+}

--- a/backend/src/main/java/com/padelpro/pagos/infrastructure/config/PagosConfig.java
+++ b/backend/src/main/java/com/padelpro/pagos/infrastructure/config/PagosConfig.java
@@ -1,0 +1,93 @@
+package com.padelpro.pagos.infrastructure.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.padelpro.auth.application.service.EncryptionService;
+import com.padelpro.auth.domain.port.out.AuditLogRepositoryPort;
+import com.padelpro.auth.domain.port.out.SystemConfigRepositoryPort;
+import com.padelpro.auth.domain.port.out.UserRepositoryPort;
+import com.padelpro.pagos.application.service.IniciarPagoService;
+import com.padelpro.pagos.application.service.PagoAuditRecorder;
+import com.padelpro.pagos.application.service.PagoQueryService;
+import com.padelpro.pagos.application.service.ProcesarWebhookService;
+import com.padelpro.pagos.application.service.RedsysConfigService;
+import com.padelpro.pagos.application.service.RedsysOrderIdGenerator;
+import com.padelpro.pagos.application.service.RedsysProperties;
+import com.padelpro.pagos.application.service.RegistrarPagoEfectivoService;
+import com.padelpro.reservas.domain.port.out.PaymentCommandPort;
+import com.padelpro.reservas.domain.port.out.ReservationCommandPort;
+import com.padelpro.reservas.infrastructure.persistence.PaymentJpaRepository;
+import com.padelpro.reservas.infrastructure.persistence.ReservationJpaRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Wiring for the pagos-redsys-online capability. Application services are plain objects instantiated
+ * here (mirroring {@code ReservasConfig}), keeping the application layer free of Spring stereotypes.
+ */
+@Configuration
+public class PagosConfig {
+
+    @Bean
+    public RedsysProperties redsysProperties(
+            @Value("${app.redsys.tpv-url:https://sis-t.redsys.es:25443/sis/realizarPago}") String tpvUrl,
+            @Value("${app.redsys.merchant-url:http://localhost:8080/api/pagos/webhook}") String merchantUrl,
+            @Value("${app.redsys.url-ok:http://localhost:5173/pago/confirmado}") String urlOk,
+            @Value("${app.redsys.url-ko:http://localhost:5173/pago/confirmado}") String urlKo,
+            @Value("${app.redsys.currency:978}") String currency) {
+        return new RedsysProperties(tpvUrl, merchantUrl, urlOk, urlKo, currency);
+    }
+
+    @Bean
+    public RedsysOrderIdGenerator redsysOrderIdGenerator() {
+        return new RedsysOrderIdGenerator();
+    }
+
+    @Bean
+    public RedsysConfigService redsysConfigService(SystemConfigRepositoryPort systemConfigRepositoryPort,
+                                                   EncryptionService encryptionService) {
+        return new RedsysConfigService(systemConfigRepositoryPort, encryptionService);
+    }
+
+    @Bean
+    public PagoAuditRecorder pagoAuditRecorder(AuditLogRepositoryPort auditLogRepositoryPort,
+                                               UserRepositoryPort userRepositoryPort) {
+        return new PagoAuditRecorder(auditLogRepositoryPort, userRepositoryPort);
+    }
+
+    @Bean
+    public IniciarPagoService iniciarPagoService(ReservationCommandPort reservationCommandPort,
+                                                 PaymentCommandPort paymentCommandPort,
+                                                 RedsysConfigService redsysConfigService,
+                                                 RedsysProperties redsysProperties,
+                                                 RedsysOrderIdGenerator redsysOrderIdGenerator,
+                                                 PagoAuditRecorder pagoAuditRecorder,
+                                                 ObjectMapper objectMapper) {
+        return new IniciarPagoService(reservationCommandPort, paymentCommandPort, redsysConfigService,
+                redsysProperties, redsysOrderIdGenerator, pagoAuditRecorder, objectMapper);
+    }
+
+    @Bean
+    public ProcesarWebhookService procesarWebhookService(PaymentCommandPort paymentCommandPort,
+                                                         RedsysConfigService redsysConfigService,
+                                                         PagoAuditRecorder pagoAuditRecorder,
+                                                         ObjectMapper objectMapper) {
+        return new ProcesarWebhookService(paymentCommandPort, redsysConfigService, pagoAuditRecorder,
+                objectMapper);
+    }
+
+    @Bean
+    public RegistrarPagoEfectivoService registrarPagoEfectivoService(
+            ReservationCommandPort reservationCommandPort,
+            PaymentCommandPort paymentCommandPort,
+            PagoAuditRecorder pagoAuditRecorder) {
+        return new RegistrarPagoEfectivoService(reservationCommandPort, paymentCommandPort,
+                pagoAuditRecorder);
+    }
+
+    @Bean
+    public PagoQueryService pagoQueryService(PaymentJpaRepository paymentRepository,
+                                             ReservationJpaRepository reservationRepository) {
+        return new PagoQueryService(paymentRepository, reservationRepository);
+    }
+}

--- a/backend/src/main/java/com/padelpro/pagos/infrastructure/web/AdminPagoController.java
+++ b/backend/src/main/java/com/padelpro/pagos/infrastructure/web/AdminPagoController.java
@@ -1,0 +1,55 @@
+package com.padelpro.pagos.infrastructure.web;
+
+import com.padelpro.pagos.application.dto.EfectivoPagoResponse;
+import com.padelpro.pagos.application.dto.PagoHistorialResponse;
+import com.padelpro.pagos.application.service.PagoQueryService;
+import com.padelpro.pagos.application.service.RegistrarPagoEfectivoService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * ADMIN payment endpoints (pagos-redsys-online, group 5).
+ *
+ * <ul>
+ *   <li>{@code POST /api/admin/pagos/{reservaId}/efectivo} — register a cash payment</li>
+ *   <li>{@code GET  /api/admin/pagos}                      — every payment in the club</li>
+ * </ul>
+ *
+ * <p>{@code /api/admin/**} is already restricted to {@code ROLE_ADMIN} by the security filter chain;
+ * {@link PreAuthorize} is added defensively (USER → 403).
+ */
+@RestController
+@RequestMapping("/api/admin/pagos")
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminPagoController {
+
+    private final RegistrarPagoEfectivoService registrarPagoEfectivoService;
+    private final PagoQueryService pagoQueryService;
+
+    public AdminPagoController(RegistrarPagoEfectivoService registrarPagoEfectivoService,
+                              PagoQueryService pagoQueryService) {
+        this.registrarPagoEfectivoService = registrarPagoEfectivoService;
+        this.pagoQueryService = pagoQueryService;
+    }
+
+    @PostMapping("/{reservaId}/efectivo")
+    public ResponseEntity<EfectivoPagoResponse> registrarEfectivo(@PathVariable("reservaId") UUID reservaId) {
+        return ResponseEntity.ok(registrarPagoEfectivoService.registrar(reservaId, currentUserId()));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<PagoHistorialResponse>> listarTodos() {
+        return ResponseEntity.ok(pagoQueryService.listAll());
+    }
+
+    private Long currentUserId() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        return Long.parseLong((String) auth.getPrincipal());
+    }
+}

--- a/backend/src/main/java/com/padelpro/pagos/infrastructure/web/PagoController.java
+++ b/backend/src/main/java/com/padelpro/pagos/infrastructure/web/PagoController.java
@@ -1,0 +1,71 @@
+package com.padelpro.pagos.infrastructure.web;
+
+import com.padelpro.pagos.application.dto.IniciarPagoRequest;
+import com.padelpro.pagos.application.dto.IniciarPagoResponse;
+import com.padelpro.pagos.application.dto.PagoHistorialResponse;
+import com.padelpro.pagos.application.service.IniciarPagoService;
+import com.padelpro.pagos.application.service.PagoQueryService;
+import com.padelpro.pagos.application.service.ProcesarWebhookService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * User-facing payment endpoints (pagos-redsys-online).
+ *
+ * <ul>
+ *   <li>{@code POST /api/pagos/iniciar} — start an online Redsys payment (owner only, D5)</li>
+ *   <li>{@code POST /api/pagos/webhook} — Redsys server-to-server notification (no JWT, D3)</li>
+ *   <li>{@code GET  /api/pagos}         — the caller's own payment history</li>
+ * </ul>
+ *
+ * <p>The webhook is public (allowlisted in {@code SecurityConfig}); its only protection is the HMAC
+ * signature validated inside the service, and it always returns 200 (D3).
+ */
+@RestController
+@RequestMapping("/api/pagos")
+public class PagoController {
+
+    private final IniciarPagoService iniciarPagoService;
+    private final ProcesarWebhookService procesarWebhookService;
+    private final PagoQueryService pagoQueryService;
+
+    public PagoController(IniciarPagoService iniciarPagoService,
+                          ProcesarWebhookService procesarWebhookService,
+                          PagoQueryService pagoQueryService) {
+        this.iniciarPagoService = iniciarPagoService;
+        this.procesarWebhookService = procesarWebhookService;
+        this.pagoQueryService = pagoQueryService;
+    }
+
+    @PostMapping("/iniciar")
+    public ResponseEntity<IniciarPagoResponse> iniciar(@RequestBody IniciarPagoRequest request) {
+        return ResponseEntity.ok(iniciarPagoService.iniciar(request.reservaId(), currentUserId()));
+    }
+
+    /**
+     * Redsys notification (application/x-www-form-urlencoded). Always 200 to avoid pointless retries
+     * (D3); the outcome is decided by the HMAC signature inside the service.
+     */
+    @PostMapping("/webhook")
+    public ResponseEntity<Void> webhook(
+            @RequestParam(name = "Ds_SignatureVersion", required = false) String signatureVersion,
+            @RequestParam(name = "Ds_MerchantParameters", required = false) String merchantParameters,
+            @RequestParam(name = "Ds_Signature", required = false) String signature) {
+        procesarWebhookService.procesar(signatureVersion, merchantParameters, signature);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping
+    public ResponseEntity<List<PagoHistorialResponse>> misPagos() {
+        return ResponseEntity.ok(pagoQueryService.listForUser(currentUserId()));
+    }
+
+    private Long currentUserId() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        return Long.parseLong((String) auth.getPrincipal());
+    }
+}

--- a/backend/src/main/java/com/padelpro/reservas/domain/model/Payment.java
+++ b/backend/src/main/java/com/padelpro/reservas/domain/model/Payment.java
@@ -115,6 +115,46 @@ public class Payment {
         this.status = PaymentStatus.REFUNDED;
     }
 
+    /**
+     * Move a PENDING payment to IN_PROGRESS when the owner starts the Redsys checkout
+     * (pagos-redsys-online, D5). Records the generated Redsys order id and the TPV URL used for the
+     * browser redirect. Card data never touches this entity (RN-PAY-03).
+     */
+    public void markInProgress(String redsysOrderId, String paymentUrl) {
+        this.status = PaymentStatus.IN_PROGRESS;
+        this.method = PaymentMethod.REDSYS;
+        this.gateway = PaymentGateway.REDSYS;
+        this.redsysOrderId = redsysOrderId;
+        this.paymentUrl = paymentUrl;
+    }
+
+    /**
+     * Confirm a Redsys payment from a valid webhook with an approved {@code Ds_Response}
+     * (pagos-redsys-online, D3). Only {@code transaction_id} (Ds_AuthorisationCode) is stored — never
+     * card data (RN-PAY-03).
+     */
+    public void markPaid(String transactionId, OffsetDateTime paidAt) {
+        this.status = PaymentStatus.PAID;
+        this.transactionId = transactionId;
+        this.paidAt = paidAt;
+    }
+
+    /** Mark a Redsys payment as FAILED from a valid webhook with a rejection {@code Ds_Response} (D3). */
+    public void markFailed() {
+        this.status = PaymentStatus.FAILED;
+    }
+
+    /**
+     * Register a manual cash payment by an ADMIN (pagos-redsys-online, group 5): PAID / CASH with the
+     * registering admin id (DB CHECK {@code chk_pay_cash_admin} requires {@code registered_by_id}).
+     */
+    public void markCashPaid(Long registeredById, OffsetDateTime paidAt) {
+        this.status = PaymentStatus.PAID;
+        this.method = PaymentMethod.CASH;
+        this.registeredById = registeredById;
+        this.paidAt = paidAt;
+    }
+
     public UUID getId() {
         return id;
     }

--- a/backend/src/main/java/com/padelpro/reservas/domain/port/out/PaymentCommandPort.java
+++ b/backend/src/main/java/com/padelpro/reservas/domain/port/out/PaymentCommandPort.java
@@ -16,4 +16,13 @@ public interface PaymentCommandPort {
 
     /** Locate a payment by its unique Redsys order id (webhook path, pagos-redsys-online). */
     Optional<Payment> findByRedsysOrderId(String redsysOrderId);
+
+    /**
+     * Locate a payment by its Redsys order id acquiring a pessimistic write lock on the row
+     * ({@code SELECT ... FOR UPDATE}). Used by the webhook to serialise concurrent notifications for
+     * the same order so idempotency holds under a race (MEDIO-2, pagos-redsys-online). Must be called
+     * inside a transaction; the second notification blocks until the first commits and then re-reads
+     * the already-{@code PAID} state.
+     */
+    Optional<Payment> findByRedsysOrderIdForUpdate(String redsysOrderId);
 }

--- a/backend/src/main/java/com/padelpro/reservas/domain/port/out/PaymentCommandPort.java
+++ b/backend/src/main/java/com/padelpro/reservas/domain/port/out/PaymentCommandPort.java
@@ -13,4 +13,7 @@ public interface PaymentCommandPort {
     Payment save(Payment payment);
 
     Optional<Payment> findByReservationId(UUID reservationId);
+
+    /** Locate a payment by its unique Redsys order id (webhook path, pagos-redsys-online). */
+    Optional<Payment> findByRedsysOrderId(String redsysOrderId);
 }

--- a/backend/src/main/java/com/padelpro/reservas/infrastructure/persistence/PaymentCommandAdapter.java
+++ b/backend/src/main/java/com/padelpro/reservas/infrastructure/persistence/PaymentCommandAdapter.java
@@ -33,4 +33,9 @@ public class PaymentCommandAdapter implements PaymentCommandPort {
     public Optional<Payment> findByRedsysOrderId(String redsysOrderId) {
         return paymentRepository.findByRedsysOrderId(redsysOrderId);
     }
+
+    @Override
+    public Optional<Payment> findByRedsysOrderIdForUpdate(String redsysOrderId) {
+        return paymentRepository.findByRedsysOrderIdForUpdate(redsysOrderId);
+    }
 }

--- a/backend/src/main/java/com/padelpro/reservas/infrastructure/persistence/PaymentCommandAdapter.java
+++ b/backend/src/main/java/com/padelpro/reservas/infrastructure/persistence/PaymentCommandAdapter.java
@@ -28,4 +28,9 @@ public class PaymentCommandAdapter implements PaymentCommandPort {
     public Optional<Payment> findByReservationId(UUID reservationId) {
         return paymentRepository.findByReservationId(reservationId);
     }
+
+    @Override
+    public Optional<Payment> findByRedsysOrderId(String redsysOrderId) {
+        return paymentRepository.findByRedsysOrderId(redsysOrderId);
+    }
 }

--- a/backend/src/main/java/com/padelpro/reservas/infrastructure/persistence/PaymentJpaRepository.java
+++ b/backend/src/main/java/com/padelpro/reservas/infrastructure/persistence/PaymentJpaRepository.java
@@ -22,4 +22,10 @@ public interface PaymentJpaRepository extends JpaRepository<Payment, UUID> {
 
     /** Batch-load payments for a set of reservations (anti-N+1 for list endpoints, §7.2). */
     List<Payment> findByReservationIdIn(Collection<UUID> reservationIds);
+
+    /** Locate a payment by its unique Redsys order id (webhook idempotency, RN-PAY-02). */
+    Optional<Payment> findByRedsysOrderId(String redsysOrderId);
+
+    /** All payments most-recent first (ADMIN history, pagos-redsys-online group 5). */
+    List<Payment> findAllByOrderByCreatedAtDesc();
 }

--- a/backend/src/main/java/com/padelpro/reservas/infrastructure/persistence/PaymentJpaRepository.java
+++ b/backend/src/main/java/com/padelpro/reservas/infrastructure/persistence/PaymentJpaRepository.java
@@ -1,7 +1,11 @@
 package com.padelpro.reservas.infrastructure.persistence;
 
 import com.padelpro.reservas.domain.model.Payment;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Collection;
@@ -25,6 +29,15 @@ public interface PaymentJpaRepository extends JpaRepository<Payment, UUID> {
 
     /** Locate a payment by its unique Redsys order id (webhook idempotency, RN-PAY-02). */
     Optional<Payment> findByRedsysOrderId(String redsysOrderId);
+
+    /**
+     * Locate a payment by Redsys order id locking its row ({@code SELECT ... FOR UPDATE}) so two
+     * concurrent webhook notifications for the same order cannot both transition IN_PROGRESS → PAID
+     * (MEDIO-2). The second waits for the first to commit, then re-reads the already-PAID state.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM Payment p WHERE p.redsysOrderId = :redsysOrderId")
+    Optional<Payment> findByRedsysOrderIdForUpdate(@Param("redsysOrderId") String redsysOrderId);
 
     /** All payments most-recent first (ADMIN history, pagos-redsys-online group 5). */
     List<Payment> findAllByOrderByCreatedAtDesc();

--- a/backend/src/main/java/com/padelpro/reservas/infrastructure/persistence/ReservationJpaRepository.java
+++ b/backend/src/main/java/com/padelpro/reservas/infrastructure/persistence/ReservationJpaRepository.java
@@ -74,4 +74,7 @@ public interface ReservationJpaRepository extends JpaRepository<Reservation, UUI
             ORDER BY r.reservationDate DESC, r.startTime DESC
             """)
     List<Reservation> findAllWithParticipants();
+
+    /** Reservations owned by a user (own-payments history, pagos-redsys-online group 5). */
+    List<Reservation> findByOwnerId(Long ownerId);
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -30,3 +30,12 @@ app:
     access-token-expiry-minutes: 15
   encryption:
     key: ${ENCRYPTION_KEY}
+  redsys:
+    # TPV endpoint (sandbox by default; set the production endpoint via env in prod).
+    tpv-url: ${REDSYS_TPV_URL:https://sis-t.redsys.es:25443/sis/realizarPago}
+    # Public server-to-server webhook URL sent as Ds_Merchant_MerchantURL (must be reachable by Redsys).
+    merchant-url: ${REDSYS_MERCHANT_URL:http://localhost:8080/api/pagos/webhook}
+    # Browser return URLs (frontend PagoConfirmadoPage).
+    url-ok: ${REDSYS_URL_OK:http://localhost:5173/pago/confirmado}
+    url-ko: ${REDSYS_URL_KO:http://localhost:5173/pago/confirmado}
+    currency: ${REDSYS_CURRENCY:978}

--- a/backend/src/main/resources/db/migration/V13__add_redsys_terminal_to_system_config.sql
+++ b/backend/src/main/resources/db/migration/V13__add_redsys_terminal_to_system_config.sql
@@ -1,0 +1,6 @@
+-- Migration: add redsys_terminal to system_config (pagos-redsys-online, D4)
+--
+-- The Redsys terminal number is a merchant-specific datum (distinct from merchant_id / merchant_key)
+-- required to build the TPV form. Stored encrypted with AES-256-GCM like the other Redsys secrets
+-- (redsys_merchant_id, redsys_merchant_key). Nullable — when absent the application defaults to "1".
+ALTER TABLE system_config ADD COLUMN IF NOT EXISTS redsys_terminal TEXT;

--- a/backend/src/test/java/com/padelpro/auth/infrastructure/web/filter/RateLimitFilterWebhookTest.java
+++ b/backend/src/test/java/com/padelpro/auth/infrastructure/web/filter/RateLimitFilterWebhookTest.java
@@ -1,0 +1,80 @@
+package com.padelpro.auth.infrastructure.web.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for the Redsys webhook rate limit (MEDIO-1, pagos-redsys-online, D3).
+ *
+ * <p>{@code POST /api/pagos/webhook} is public (no JWT); the only DoS/replay throttle is this filter.
+ * Budget: 60 requests / minute / IP — tolerant of legitimate Redsys retries, hard cap on a flood.
+ */
+@DisplayName("RateLimitFilter — webhook Redsys (MEDIO-1)")
+class RateLimitFilterWebhookTest {
+
+    private static final String WEBHOOK_PATH = "/api/pagos/webhook";
+    private static final int CAPACITY = 60;
+
+    private final RateLimitFilter filter = new RateLimitFilter(new ObjectMapper());
+
+    private MockHttpServletRequest webhookRequest(String ip) {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", WEBHOOK_PATH);
+        req.setRequestURI(WEBHOOK_PATH);
+        req.setRemoteAddr(ip);
+        return req;
+    }
+
+    @Test
+    @DisplayName("dentro del límite (≤60/min por IP) → pasa la cadena, sin 429")
+    void within_limit_passes() throws Exception {
+        String ip = "203.0.113.10";
+        for (int i = 0; i < CAPACITY; i++) {
+            MockHttpServletResponse res = new MockHttpServletResponse();
+            MockFilterChain chain = new MockFilterChain();
+            filter.doFilter(webhookRequest(ip), res, chain);
+            assertThat(res.getStatus()).isNotEqualTo(429);
+            assertThat(chain.getRequest()).isNotNull(); // chain actually invoked
+        }
+    }
+
+    @Test
+    @DisplayName("por encima del límite (petición nº 61 misma IP) → 429 RATE_LIMIT_EXCEEDED")
+    void above_limit_returns_429() throws Exception {
+        String ip = "203.0.113.20";
+        for (int i = 0; i < CAPACITY; i++) {
+            filter.doFilter(webhookRequest(ip), new MockHttpServletResponse(), new MockFilterChain());
+        }
+
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+        filter.doFilter(webhookRequest(ip), res, chain);
+
+        assertThat(res.getStatus()).isEqualTo(429);
+        assertThat(res.getContentAsString()).contains("RATE_LIMIT_EXCEEDED");
+        assertThat(res.getHeader("Retry-After")).isNotNull();
+        assertThat(chain.getRequest()).isNull(); // blocked: chain NOT invoked
+    }
+
+    @Test
+    @DisplayName("el límite es por IP: una IP distinta conserva su propio bucket")
+    void limit_is_per_ip() throws Exception {
+        String flooder = "203.0.113.30";
+        for (int i = 0; i < CAPACITY + 5; i++) {
+            filter.doFilter(webhookRequest(flooder), new MockHttpServletResponse(), new MockFilterChain());
+        }
+
+        // A fresh IP still gets through.
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+        filter.doFilter(webhookRequest("203.0.113.31"), res, chain);
+
+        assertThat(res.getStatus()).isNotEqualTo(429);
+        assertThat(chain.getRequest()).isNotNull();
+    }
+}

--- a/backend/src/test/java/com/padelpro/pagos/application/service/IniciarPagoServiceTest.java
+++ b/backend/src/test/java/com/padelpro/pagos/application/service/IniciarPagoServiceTest.java
@@ -1,0 +1,203 @@
+package com.padelpro.pagos.application.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.padelpro.pagos.application.dto.IniciarPagoResponse;
+import com.padelpro.pagos.domain.audit.PagoAuditActions;
+import com.padelpro.pagos.domain.exception.PagoConflictException;
+import com.padelpro.pagos.domain.exception.PagoForbiddenException;
+import com.padelpro.pagos.domain.exception.PagoNotFoundException;
+import com.padelpro.pagos.domain.exception.PagoUnprocessableException;
+import com.padelpro.pagos.domain.model.RedsysSignature;
+import com.padelpro.reservas.domain.model.Payment;
+import com.padelpro.reservas.domain.model.PaymentStatus;
+import com.padelpro.reservas.domain.model.Reservation;
+import com.padelpro.reservas.domain.model.ReservationChannel;
+import com.padelpro.reservas.domain.model.ReservationStatus;
+import com.padelpro.reservas.domain.port.out.PaymentCommandPort;
+import com.padelpro.reservas.domain.port.out.ReservationCommandPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Base64;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link IniciarPagoService} — guards + signed-form generation (pagos-redsys-online, D5).
+ * Ports mocked; the real {@link RedsysSignature} runs against the sandbox key.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("IniciarPagoService — iniciar pago Redsys (D5)")
+class IniciarPagoServiceTest {
+
+    private static final UUID RES_ID = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+    private static final long OWNER_ID = 1L;
+    private static final long OTHER_ID = 2L;
+    private static final String SANDBOX_KEY = "sq7HjrUOBfKmC576ILgskD5srU870gJ7";
+    private static final String FIXED_ORDER = "0001AB23CD45";
+
+    @Mock private ReservationCommandPort reservationCommandPort;
+    @Mock private PaymentCommandPort paymentCommandPort;
+    @Mock private RedsysConfigService redsysConfigService;
+    @Mock private RedsysOrderIdGenerator orderIdGenerator;
+    @Mock private PagoAuditRecorder auditRecorder;
+
+    private IniciarPagoService service;
+
+    @BeforeEach
+    void setUp() {
+        RedsysProperties props = new RedsysProperties(
+                "https://sis-t.redsys.es:25443/sis/realizarPago",
+                "https://example.test/api/pagos/webhook",
+                "https://example.test/pago/confirmado",
+                "https://example.test/pago/confirmado",
+                "978");
+        service = new IniciarPagoService(reservationCommandPort, paymentCommandPort, redsysConfigService,
+                props, orderIdGenerator, auditRecorder, new ObjectMapper());
+    }
+
+    private Reservation reservation(ReservationStatus status, long ownerId) {
+        return Reservation.builder()
+                .id(RES_ID).ownerId(ownerId).reservationDate(LocalDate.now().plusDays(3))
+                .startTime(LocalTime.of(18, 0)).endTime(LocalTime.of(19, 0))
+                .durationMinutes(60).status(status).channel(ReservationChannel.WEB).build();
+    }
+
+    private Payment payment(PaymentStatus status, String amount) {
+        Payment p = Payment.pendingFor(RES_ID, new BigDecimal(amount));
+        p.setStatus(status);
+        return p;
+    }
+
+    @Test
+    @DisplayName("owner OK → IN_PROGRESS + form firmado + PAYMENT_INITIATED")
+    void owner_initiates_ok() {
+        when(reservationCommandPort.findById(RES_ID))
+                .thenReturn(Optional.of(reservation(ReservationStatus.PENDING_CONFIRMATION, OWNER_ID)));
+        when(paymentCommandPort.findByReservationId(RES_ID))
+                .thenReturn(Optional.of(payment(PaymentStatus.PENDING, "15.00")));
+        when(redsysConfigService.loadCredentials())
+                .thenReturn(new RedsysCredentials("999008881", SANDBOX_KEY, "1"));
+        when(orderIdGenerator.generate()).thenReturn(FIXED_ORDER);
+        when(paymentCommandPort.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        IniciarPagoResponse response = service.iniciar(RES_ID, OWNER_ID);
+
+        assertThat(response.status()).isEqualTo("IN_PROGRESS");
+        assertThat(response.redsysOrderId()).isEqualTo(FIXED_ORDER);
+        assertThat(response.redsysUrl()).contains("sis-t.redsys.es");
+        assertThat(response.dsSignatureVersion()).isEqualTo("HMAC_SHA256_V1");
+        assertThat(response.amount()).isEqualByComparingTo("15.00");
+
+        // The signature verifies against the sandbox key (round-trip through the real signer).
+        assertThat(RedsysSignature.verify(
+                response.dsMerchantParameters(), FIXED_ORDER, response.dsSignature(), SANDBOX_KEY)).isTrue();
+
+        // Amount is sent to Redsys in céntimos (RN-RES-03), never from the client.
+        String json = new String(Base64.getDecoder().decode(response.dsMerchantParameters()),
+                StandardCharsets.UTF_8);
+        assertThat(json).contains("\"DS_MERCHANT_AMOUNT\":\"1500\"");
+        assertThat(json).contains("\"DS_MERCHANT_TERMINAL\":\"1\"");
+        assertThat(json).contains("\"DS_MERCHANT_MERCHANTURL\":\"https://example.test/api/pagos/webhook\"");
+
+        verify(paymentCommandPort).save(any());
+        verify(auditRecorder).record(eq(PagoAuditActions.PAYMENT_INITIATED), eq(OWNER_ID), any());
+    }
+
+    @Test
+    @DisplayName("no-owner → 403 y el pago no cambia")
+    void non_owner_forbidden() {
+        when(reservationCommandPort.findById(RES_ID))
+                .thenReturn(Optional.of(reservation(ReservationStatus.PENDING_CONFIRMATION, OWNER_ID)));
+
+        assertThatThrownBy(() -> service.iniciar(RES_ID, OTHER_ID))
+                .isInstanceOf(PagoForbiddenException.class);
+        verify(paymentCommandPort, never()).save(any());
+        verify(auditRecorder, never()).record(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("reserva inexistente → 404")
+    void reservation_not_found() {
+        when(reservationCommandPort.findById(RES_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.iniciar(RES_ID, OWNER_ID))
+                .isInstanceOf(PagoNotFoundException.class);
+        verify(paymentCommandPort, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("reserva cancelada → 422 RESERVA_CANCELLED")
+    void reservation_cancelled() {
+        when(reservationCommandPort.findById(RES_ID))
+                .thenReturn(Optional.of(reservation(ReservationStatus.CANCELLED, OWNER_ID)));
+
+        assertThatThrownBy(() -> service.iniciar(RES_ID, OWNER_ID))
+                .isInstanceOf(PagoUnprocessableException.class)
+                .extracting(e -> ((PagoUnprocessableException) e).getCode())
+                .isEqualTo("RESERVA_CANCELLED");
+        verify(paymentCommandPort, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("pago ya IN_PROGRESS → 409")
+    void payment_already_in_progress() {
+        when(reservationCommandPort.findById(RES_ID))
+                .thenReturn(Optional.of(reservation(ReservationStatus.PENDING_CONFIRMATION, OWNER_ID)));
+        when(paymentCommandPort.findByReservationId(RES_ID))
+                .thenReturn(Optional.of(payment(PaymentStatus.IN_PROGRESS, "15.00")));
+
+        assertThatThrownBy(() -> service.iniciar(RES_ID, OWNER_ID))
+                .isInstanceOf(PagoConflictException.class);
+        verify(paymentCommandPort, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("pago ya PAID → 409")
+    void payment_already_paid() {
+        when(reservationCommandPort.findById(RES_ID))
+                .thenReturn(Optional.of(reservation(ReservationStatus.CONFIRMED, OWNER_ID)));
+        when(paymentCommandPort.findByReservationId(RES_ID))
+                .thenReturn(Optional.of(payment(PaymentStatus.PAID, "15.00")));
+
+        assertThatThrownBy(() -> service.iniciar(RES_ID, OWNER_ID))
+                .isInstanceOf(PagoConflictException.class);
+        verify(paymentCommandPort, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("el importe se toma del backend en céntimos (no del cliente)")
+    void amount_is_backend_frozen_in_cents() {
+        lenient().when(reservationCommandPort.findById(RES_ID))
+                .thenReturn(Optional.of(reservation(ReservationStatus.PENDING_CONFIRMATION, OWNER_ID)));
+        when(paymentCommandPort.findByReservationId(RES_ID))
+                .thenReturn(Optional.of(payment(PaymentStatus.PENDING, "22.50")));
+        when(redsysConfigService.loadCredentials())
+                .thenReturn(new RedsysCredentials("999008881", SANDBOX_KEY, "1"));
+        when(orderIdGenerator.generate()).thenReturn(FIXED_ORDER);
+        when(paymentCommandPort.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        IniciarPagoResponse response = service.iniciar(RES_ID, OWNER_ID);
+
+        String json = new String(Base64.getDecoder().decode(response.dsMerchantParameters()),
+                StandardCharsets.UTF_8);
+        assertThat(json).contains("\"DS_MERCHANT_AMOUNT\":\"2250\"");
+    }
+}

--- a/backend/src/test/java/com/padelpro/pagos/application/service/PagoQueryServiceTest.java
+++ b/backend/src/test/java/com/padelpro/pagos/application/service/PagoQueryServiceTest.java
@@ -1,0 +1,94 @@
+package com.padelpro.pagos.application.service;
+
+import com.padelpro.pagos.application.dto.PagoHistorialResponse;
+import com.padelpro.reservas.domain.model.Payment;
+import com.padelpro.reservas.domain.model.Reservation;
+import com.padelpro.reservas.domain.model.ReservationChannel;
+import com.padelpro.reservas.domain.model.ReservationStatus;
+import com.padelpro.reservas.infrastructure.persistence.PaymentJpaRepository;
+import com.padelpro.reservas.infrastructure.persistence.ReservationJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link PagoQueryService} — own vs all payment history (pagos-redsys-online, group 5).
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PagoQueryService — historial de pagos")
+class PagoQueryServiceTest {
+
+    private static final long OWNER_ID = 1L;
+    private static final UUID RES_ID = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+
+    @Mock private PaymentJpaRepository paymentRepository;
+    @Mock private ReservationJpaRepository reservationRepository;
+
+    private PagoQueryService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new PagoQueryService(paymentRepository, reservationRepository);
+    }
+
+    private Reservation reservation() {
+        return Reservation.builder()
+                .id(RES_ID).ownerId(OWNER_ID).reservationDate(LocalDate.now().plusDays(3))
+                .startTime(LocalTime.of(18, 0)).endTime(LocalTime.of(19, 0))
+                .durationMinutes(60).status(ReservationStatus.CONFIRMED)
+                .channel(ReservationChannel.WEB).build();
+    }
+
+    private Payment payment() {
+        return Payment.pendingFor(RES_ID, new BigDecimal("15.00"));
+    }
+
+    @Test
+    @DisplayName("listForUser: pagos de reservas propias, con datos de reserva")
+    void list_for_user() {
+        when(reservationRepository.findByOwnerId(OWNER_ID)).thenReturn(List.of(reservation()));
+        when(paymentRepository.findByReservationIdIn(any())).thenReturn(List.of(payment()));
+
+        List<PagoHistorialResponse> result = service.listForUser(OWNER_ID);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).reservaId()).isEqualTo(RES_ID.toString());
+        assertThat(result.get(0).ownerId()).isEqualTo(OWNER_ID);
+        assertThat(result.get(0).amount()).isEqualByComparingTo("15.00");
+        assertThat(result.get(0).reservationDate()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("listForUser: sin reservas → lista vacía")
+    void list_for_user_empty() {
+        when(reservationRepository.findByOwnerId(OWNER_ID)).thenReturn(List.of());
+
+        assertThat(service.listForUser(OWNER_ID)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("listAll: todos los pagos (ADMIN)")
+    void list_all() {
+        when(paymentRepository.findAllByOrderByCreatedAtDesc()).thenReturn(List.of(payment()));
+        when(reservationRepository.findAllById(any())).thenReturn(List.of(reservation()));
+
+        List<PagoHistorialResponse> result = service.listAll();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).reservaId()).isEqualTo(RES_ID.toString());
+        assertThat(result.get(0).ownerId()).isEqualTo(OWNER_ID);
+    }
+}

--- a/backend/src/test/java/com/padelpro/pagos/application/service/ProcesarWebhookServiceTest.java
+++ b/backend/src/test/java/com/padelpro/pagos/application/service/ProcesarWebhookServiceTest.java
@@ -1,0 +1,174 @@
+package com.padelpro.pagos.application.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.padelpro.pagos.domain.audit.PagoAuditActions;
+import com.padelpro.pagos.domain.model.RedsysSignature;
+import com.padelpro.reservas.domain.model.Payment;
+import com.padelpro.reservas.domain.model.PaymentStatus;
+import com.padelpro.reservas.domain.port.out.PaymentCommandPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link ProcesarWebhookService} — signature-first, idempotent, always-200 processing
+ * (pagos-redsys-online, D3). The real {@link RedsysSignature} produces/validates against the sandbox key.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ProcesarWebhookService — webhook Redsys (D3)")
+class ProcesarWebhookServiceTest {
+
+    private static final String SANDBOX_KEY = "sq7HjrUOBfKmC576ILgskD5srU870gJ7";
+    private static final String ORDER = "0009AB12CD34";
+    private static final UUID RES_ID = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+
+    @Mock private PaymentCommandPort paymentCommandPort;
+    @Mock private RedsysConfigService redsysConfigService;
+    @Mock private PagoAuditRecorder auditRecorder;
+
+    private ProcesarWebhookService service;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        service = new ProcesarWebhookService(paymentCommandPort, redsysConfigService, auditRecorder,
+                objectMapper);
+    }
+
+    private void credsAvailable() {
+        when(redsysConfigService.loadCredentials())
+                .thenReturn(new RedsysCredentials("999008881", SANDBOX_KEY, "1"));
+    }
+
+    /** Build a Base64 notification parameters string for the given fields. */
+    private String params(String order, String dsResponse, String authCode) {
+        StringBuilder json = new StringBuilder("{\"Ds_Order\":\"").append(order).append("\"");
+        if (dsResponse != null) {
+            json.append(",\"Ds_Response\":\"").append(dsResponse).append("\"");
+        }
+        if (authCode != null) {
+            json.append(",\"Ds_AuthorisationCode\":\"").append(authCode).append("\"");
+        }
+        json.append(",\"Ds_Amount\":\"1500\",\"Ds_MerchantCode\":\"999008881\"}");
+        return Base64.getEncoder().encodeToString(json.toString().getBytes(StandardCharsets.UTF_8));
+    }
+
+    private String sign(String params) {
+        return RedsysSignature.sign(params, ORDER, SANDBOX_KEY);
+    }
+
+    private Payment payment(PaymentStatus status) {
+        Payment p = Payment.pendingFor(RES_ID, new BigDecimal("15.00"));
+        p.markInProgress(ORDER, "https://tpv");
+        p.setStatus(status);
+        return p;
+    }
+
+    @Test
+    @DisplayName("firma válida + aprobado (0000) → PAID + transaction_id + PAYMENT_CONFIRMED")
+    void valid_approved_marks_paid() {
+        credsAvailable();
+        String p = params(ORDER, "0000", "ABC123");
+        Payment payment = payment(PaymentStatus.IN_PROGRESS);
+        when(paymentCommandPort.findByRedsysOrderId(ORDER)).thenReturn(Optional.of(payment));
+        when(paymentCommandPort.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        service.procesar("HMAC_SHA256_V1", p, sign(p));
+
+        ArgumentCaptor<Payment> captor = ArgumentCaptor.forClass(Payment.class);
+        verify(paymentCommandPort).save(captor.capture());
+        Payment saved = captor.getValue();
+        assertThat(saved.getStatus()).isEqualTo(PaymentStatus.PAID);
+        assertThat(saved.getTransactionId()).isEqualTo("ABC123");
+        assertThat(saved.getPaidAt()).isNotNull();
+        verify(auditRecorder).record(eq(PagoAuditActions.PAYMENT_CONFIRMED), isNull(), any());
+    }
+
+    @Test
+    @DisplayName("firma válida + rechazo (0184) → FAILED + PAYMENT_REJECTED")
+    void valid_rejected_marks_failed() {
+        credsAvailable();
+        String p = params(ORDER, "0184", null);
+        Payment payment = payment(PaymentStatus.IN_PROGRESS);
+        when(paymentCommandPort.findByRedsysOrderId(ORDER)).thenReturn(Optional.of(payment));
+        when(paymentCommandPort.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        service.procesar("HMAC_SHA256_V1", p, sign(p));
+
+        ArgumentCaptor<Payment> captor = ArgumentCaptor.forClass(Payment.class);
+        verify(paymentCommandPort).save(captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo(PaymentStatus.FAILED);
+        verify(auditRecorder).record(eq(PagoAuditActions.PAYMENT_REJECTED), isNull(), any());
+    }
+
+    @Test
+    @DisplayName("firma inválida → sin cambio + PAYMENT_WEBHOOK_INVALID_SIGNATURE")
+    void invalid_signature_no_change() {
+        credsAvailable();
+        String p = params(ORDER, "0000", "ABC123");
+
+        service.procesar("HMAC_SHA256_V1", p, "not-a-valid-signature");
+
+        verify(paymentCommandPort, never()).findByRedsysOrderId(any());
+        verify(paymentCommandPort, never()).save(any());
+        verify(auditRecorder).record(eq(PagoAuditActions.PAYMENT_WEBHOOK_INVALID_SIGNATURE), isNull(), any());
+    }
+
+    @Test
+    @DisplayName("duplicado sobre pago ya PAID → sin reproceso (idempotente)")
+    void duplicate_on_paid_is_noop() {
+        credsAvailable();
+        String p = params(ORDER, "0000", "ABC123");
+        when(paymentCommandPort.findByRedsysOrderId(ORDER))
+                .thenReturn(Optional.of(payment(PaymentStatus.PAID)));
+
+        service.procesar("HMAC_SHA256_V1", p, sign(p));
+
+        verify(paymentCommandPort, never()).save(any());
+        verify(auditRecorder, never()).record(eq(PagoAuditActions.PAYMENT_CONFIRMED), any(), any());
+    }
+
+    @Test
+    @DisplayName("order_id inexistente → PAYMENT_WEBHOOK_ORDER_NOT_FOUND, sin cambios")
+    void unknown_order_audited() {
+        credsAvailable();
+        String p = params(ORDER, "0000", "ABC123");
+        when(paymentCommandPort.findByRedsysOrderId(ORDER)).thenReturn(Optional.empty());
+
+        service.procesar("HMAC_SHA256_V1", p, sign(p));
+
+        verify(paymentCommandPort, never()).save(any());
+        verify(auditRecorder).record(eq(PagoAuditActions.PAYMENT_WEBHOOK_ORDER_NOT_FOUND), isNull(), any());
+    }
+
+    @Test
+    @DisplayName("parámetros indescifrables → INVALID_SIGNATURE sin tocar el pago")
+    void undecodable_params_audited() {
+        lenient().when(redsysConfigService.loadCredentials())
+                .thenReturn(new RedsysCredentials("999008881", SANDBOX_KEY, "1"));
+
+        service.procesar("HMAC_SHA256_V1", "%%%not-base64%%%", "sig");
+
+        verify(paymentCommandPort, never()).save(any());
+        verify(auditRecorder).record(eq(PagoAuditActions.PAYMENT_WEBHOOK_INVALID_SIGNATURE), isNull(), any());
+    }
+}

--- a/backend/src/test/java/com/padelpro/pagos/application/service/ProcesarWebhookServiceTest.java
+++ b/backend/src/test/java/com/padelpro/pagos/application/service/ProcesarWebhookServiceTest.java
@@ -26,6 +26,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -89,7 +90,7 @@ class ProcesarWebhookServiceTest {
         credsAvailable();
         String p = params(ORDER, "0000", "ABC123");
         Payment payment = payment(PaymentStatus.IN_PROGRESS);
-        when(paymentCommandPort.findByRedsysOrderId(ORDER)).thenReturn(Optional.of(payment));
+        when(paymentCommandPort.findByRedsysOrderIdForUpdate(ORDER)).thenReturn(Optional.of(payment));
         when(paymentCommandPort.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
         service.procesar("HMAC_SHA256_V1", p, sign(p));
@@ -109,7 +110,7 @@ class ProcesarWebhookServiceTest {
         credsAvailable();
         String p = params(ORDER, "0184", null);
         Payment payment = payment(PaymentStatus.IN_PROGRESS);
-        when(paymentCommandPort.findByRedsysOrderId(ORDER)).thenReturn(Optional.of(payment));
+        when(paymentCommandPort.findByRedsysOrderIdForUpdate(ORDER)).thenReturn(Optional.of(payment));
         when(paymentCommandPort.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
         service.procesar("HMAC_SHA256_V1", p, sign(p));
@@ -128,7 +129,7 @@ class ProcesarWebhookServiceTest {
 
         service.procesar("HMAC_SHA256_V1", p, "not-a-valid-signature");
 
-        verify(paymentCommandPort, never()).findByRedsysOrderId(any());
+        verify(paymentCommandPort, never()).findByRedsysOrderIdForUpdate(any());
         verify(paymentCommandPort, never()).save(any());
         verify(auditRecorder).record(eq(PagoAuditActions.PAYMENT_WEBHOOK_INVALID_SIGNATURE), isNull(), any());
     }
@@ -138,7 +139,7 @@ class ProcesarWebhookServiceTest {
     void duplicate_on_paid_is_noop() {
         credsAvailable();
         String p = params(ORDER, "0000", "ABC123");
-        when(paymentCommandPort.findByRedsysOrderId(ORDER))
+        when(paymentCommandPort.findByRedsysOrderIdForUpdate(ORDER))
                 .thenReturn(Optional.of(payment(PaymentStatus.PAID)));
 
         service.procesar("HMAC_SHA256_V1", p, sign(p));
@@ -152,7 +153,7 @@ class ProcesarWebhookServiceTest {
     void unknown_order_audited() {
         credsAvailable();
         String p = params(ORDER, "0000", "ABC123");
-        when(paymentCommandPort.findByRedsysOrderId(ORDER)).thenReturn(Optional.empty());
+        when(paymentCommandPort.findByRedsysOrderIdForUpdate(ORDER)).thenReturn(Optional.empty());
 
         service.procesar("HMAC_SHA256_V1", p, sign(p));
 
@@ -170,5 +171,44 @@ class ProcesarWebhookServiceTest {
 
         verify(paymentCommandPort, never()).save(any());
         verify(auditRecorder).record(eq(PagoAuditActions.PAYMENT_WEBHOOK_INVALID_SIGNATURE), isNull(), any());
+    }
+
+    // =========================================================================
+    // MEDIO-2 — idempotencia bajo carrera: bloqueo pesimista de la fila
+    // =========================================================================
+
+    @Test
+    @DisplayName("MEDIO-2: el webhook localiza el pago con el finder que bloquea la fila (FOR UPDATE)")
+    void webhook_locates_payment_with_locking_finder() {
+        credsAvailable();
+        String p = params(ORDER, "0000", "ABC123");
+        when(paymentCommandPort.findByRedsysOrderIdForUpdate(ORDER))
+                .thenReturn(Optional.of(payment(PaymentStatus.IN_PROGRESS)));
+        when(paymentCommandPort.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        service.procesar("HMAC_SHA256_V1", p, sign(p));
+
+        // Debe usar el finder con lock pesimista, NUNCA la lectura sin lock (evita la carrera).
+        verify(paymentCommandPort).findByRedsysOrderIdForUpdate(ORDER);
+        verify(paymentCommandPort, never()).findByRedsysOrderId(any());
+    }
+
+    @Test
+    @DisplayName("MEDIO-2: dos notificaciones del mismo webhook → un solo markPaid / un solo PAYMENT_CONFIRMED")
+    void concurrent_duplicate_confirms_once() {
+        credsAvailable();
+        String p = params(ORDER, "0000", "ABC123");
+        // Bajo el lock las dos notificaciones se serializan sobre la MISMA fila: la 1ª la deja PAID,
+        // la 2ª re-lee ese estado PAID ya confirmado.
+        Payment shared = payment(PaymentStatus.IN_PROGRESS);
+        when(paymentCommandPort.findByRedsysOrderIdForUpdate(ORDER)).thenReturn(Optional.of(shared));
+        when(paymentCommandPort.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        service.procesar("HMAC_SHA256_V1", p, sign(p)); // 1ª notificación
+        service.procesar("HMAC_SHA256_V1", p, sign(p)); // 2ª notificación (duplicada)
+
+        assertThat(shared.getStatus()).isEqualTo(PaymentStatus.PAID);
+        verify(paymentCommandPort, times(1)).save(any());
+        verify(auditRecorder, times(1)).record(eq(PagoAuditActions.PAYMENT_CONFIRMED), isNull(), any());
     }
 }

--- a/backend/src/test/java/com/padelpro/pagos/application/service/ProcesarWebhookServiceTest.java
+++ b/backend/src/test/java/com/padelpro/pagos/application/service/ProcesarWebhookServiceTest.java
@@ -211,4 +211,60 @@ class ProcesarWebhookServiceTest {
         verify(paymentCommandPort, times(1)).save(any());
         verify(auditRecorder, times(1)).record(eq(PagoAuditActions.PAYMENT_CONFIRMED), isNull(), any());
     }
+
+    // =========================================================================
+    // MEDIO-3 — sanitizar Ds_Order en auditoría (log-injection / XSS)
+    // =========================================================================
+
+    @Test
+    @DisplayName("MEDIO-3: Ds_Order malicioso con firma inválida → audita <invalid-format>, no el payload")
+    void malicious_order_sanitised_in_audit() {
+        credsAvailable();
+        String malicious = "<script>alert(1)</script>";
+        String p = params(malicious, "0000", "ABC123");
+
+        service.procesar("HMAC_SHA256_V1", p, "not-a-valid-signature");
+
+        ArgumentCaptor<String> details = ArgumentCaptor.forClass(String.class);
+        verify(auditRecorder).record(eq(PagoAuditActions.PAYMENT_WEBHOOK_INVALID_SIGNATURE),
+                isNull(), details.capture());
+        assertThat(details.getValue()).contains("<invalid-format>");
+        assertThat(details.getValue()).doesNotContain("<script>");
+        assertThat(details.getValue()).doesNotContain("alert");
+        verify(paymentCommandPort, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("MEDIO-3: Ds_Order con salto de línea → audita <invalid-format> (no inyecta líneas de log)")
+    void newline_order_sanitised_in_audit() {
+        credsAvailable();
+        // Salto de línea escapado dentro del JSON de parámetros → valor real con '\n'.
+        String withNewline = "0009\\nINJECTED";
+        String p = params(withNewline, "0000", "ABC123");
+
+        service.procesar("HMAC_SHA256_V1", p, "not-a-valid-signature");
+
+        ArgumentCaptor<String> details = ArgumentCaptor.forClass(String.class);
+        verify(auditRecorder).record(eq(PagoAuditActions.PAYMENT_WEBHOOK_INVALID_SIGNATURE),
+                isNull(), details.capture());
+        assertThat(details.getValue()).contains("<invalid-format>");
+        assertThat(details.getValue()).doesNotContain("INJECTED");
+    }
+
+    // =========================================================================
+    // BAJO-2 — validar Ds_SignatureVersion
+    // =========================================================================
+
+    @Test
+    @DisplayName("BAJO-2: signatureVersion != HMAC_SHA256_V1 → INVALID_SIGNATURE, sin tocar el pago")
+    void unsupported_signature_version_rejected() {
+        String p = params(ORDER, "0000", "ABC123");
+
+        // Firma correcta pero versión no soportada: se rechaza igualmente.
+        service.procesar("HMAC_SHA1_V1", p, sign(p));
+
+        verify(paymentCommandPort, never()).findByRedsysOrderIdForUpdate(any());
+        verify(paymentCommandPort, never()).save(any());
+        verify(auditRecorder).record(eq(PagoAuditActions.PAYMENT_WEBHOOK_INVALID_SIGNATURE), isNull(), any());
+    }
 }

--- a/backend/src/test/java/com/padelpro/pagos/application/service/RedsysConfigServiceTest.java
+++ b/backend/src/test/java/com/padelpro/pagos/application/service/RedsysConfigServiceTest.java
@@ -1,0 +1,109 @@
+package com.padelpro.pagos.application.service;
+
+import com.padelpro.auth.application.service.EncryptionService;
+import com.padelpro.auth.domain.model.SystemConfig;
+import com.padelpro.auth.domain.model.SystemConfig.PaymentGateway;
+import com.padelpro.auth.domain.model.SystemConfig.PistaState;
+import com.padelpro.auth.domain.port.out.SystemConfigRepositoryPort;
+import com.padelpro.pagos.domain.exception.PagoUnprocessableException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link RedsysConfigService} — decrypting Redsys credentials from {@code system_config}
+ * with the real {@link EncryptionService} (round-trip), and the terminal default (D4).
+ */
+@DisplayName("RedsysConfigService — credenciales Redsys descifradas (D4)")
+class RedsysConfigServiceTest {
+
+    private EncryptionService encryptionService;
+    private StubConfigRepo repo;
+    private RedsysConfigService service;
+
+    @BeforeEach
+    void setUp() {
+        encryptionService = new EncryptionService("test-encryption-key-padelpro-256-bits-minimum-length");
+        repo = new StubConfigRepo();
+        service = new RedsysConfigService(repo, encryptionService);
+    }
+
+    private SystemConfig.SystemConfigBuilder baseConfig() {
+        return SystemConfig.builder()
+                .id(1L).clubName("Club").pistaState(PistaState.ACTIVA)
+                .paymentGateway(PaymentGateway.REDSYS).maxParticipantsPerPista(4)
+                .createdAt(OffsetDateTime.now()).updatedAt(OffsetDateTime.now());
+    }
+
+    @Test
+    @DisplayName("terminal descifrado cuando está configurado")
+    void decrypts_terminal_when_present() {
+        repo.config = baseConfig()
+                .redsysMerchantId(encryptionService.encrypt("999008881"))
+                .redsysMerchantKey(encryptionService.encrypt("sq7HjrUOBfKmC576ILgskD5srU870gJ7"))
+                .redsysTerminal(encryptionService.encrypt("3"))
+                .build();
+
+        assertThat(service.getTerminalOrDefault()).isEqualTo("3");
+        assertThat(service.loadCredentials().terminal()).isEqualTo("3");
+    }
+
+    @Test
+    @DisplayName("terminal por defecto \"1\" cuando la columna es null")
+    void defaults_terminal_to_1_when_absent() {
+        repo.config = baseConfig()
+                .redsysMerchantId(encryptionService.encrypt("999008881"))
+                .redsysMerchantKey(encryptionService.encrypt("sq7HjrUOBfKmC576ILgskD5srU870gJ7"))
+                .redsysTerminal(null)
+                .build();
+
+        assertThat(service.getTerminalOrDefault()).isEqualTo("1");
+        assertThat(service.loadCredentials().terminal()).isEqualTo("1");
+    }
+
+    @Test
+    @DisplayName("loadCredentials descifra merchant id/key")
+    void decrypts_merchant_credentials() {
+        repo.config = baseConfig()
+                .redsysMerchantId(encryptionService.encrypt("999008881"))
+                .redsysMerchantKey(encryptionService.encrypt("sq7HjrUOBfKmC576ILgskD5srU870gJ7"))
+                .build();
+
+        RedsysCredentials creds = service.loadCredentials();
+        assertThat(creds.merchantCode()).isEqualTo("999008881");
+        assertThat(creds.merchantKey()).isEqualTo("sq7HjrUOBfKmC576ILgskD5srU870gJ7");
+    }
+
+    @Test
+    @DisplayName("credenciales ausentes → 422 REDSYS_NOT_CONFIGURED")
+    void throws_when_not_configured() {
+        repo.config = baseConfig().build();
+
+        assertThatThrownBy(() -> service.loadCredentials())
+                .isInstanceOf(PagoUnprocessableException.class)
+                .extracting(e -> ((PagoUnprocessableException) e).getCode())
+                .isEqualTo("REDSYS_NOT_CONFIGURED");
+    }
+
+    /** Minimal in-memory stub of the config port. */
+    private static class StubConfigRepo implements SystemConfigRepositoryPort {
+        SystemConfig config;
+
+        @Override
+        public Optional<SystemConfig> findById(Long id) {
+            return Optional.ofNullable(config);
+        }
+
+        @Override
+        public SystemConfig save(SystemConfig config) {
+            this.config = config;
+            return config;
+        }
+    }
+}

--- a/backend/src/test/java/com/padelpro/pagos/application/service/RegistrarPagoEfectivoServiceTest.java
+++ b/backend/src/test/java/com/padelpro/pagos/application/service/RegistrarPagoEfectivoServiceTest.java
@@ -1,0 +1,121 @@
+package com.padelpro.pagos.application.service;
+
+import com.padelpro.pagos.application.dto.EfectivoPagoResponse;
+import com.padelpro.pagos.domain.audit.PagoAuditActions;
+import com.padelpro.pagos.domain.exception.PagoNotFoundException;
+import com.padelpro.pagos.domain.exception.PagoUnprocessableException;
+import com.padelpro.reservas.domain.model.Payment;
+import com.padelpro.reservas.domain.model.PaymentMethod;
+import com.padelpro.reservas.domain.model.PaymentStatus;
+import com.padelpro.reservas.domain.model.Reservation;
+import com.padelpro.reservas.domain.model.ReservationChannel;
+import com.padelpro.reservas.domain.model.ReservationStatus;
+import com.padelpro.reservas.domain.port.out.PaymentCommandPort;
+import com.padelpro.reservas.domain.port.out.ReservationCommandPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link RegistrarPagoEfectivoService} — ADMIN cash registration (pagos-redsys-online,
+ * group 5). USER → 403 is enforced by the security layer and covered at the controller/IT level.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RegistrarPagoEfectivoService — efectivo ADMIN")
+class RegistrarPagoEfectivoServiceTest {
+
+    private static final UUID RES_ID = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+    private static final long ADMIN_ID = 99L;
+
+    @Mock private ReservationCommandPort reservationCommandPort;
+    @Mock private PaymentCommandPort paymentCommandPort;
+    @Mock private PagoAuditRecorder auditRecorder;
+
+    private RegistrarPagoEfectivoService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new RegistrarPagoEfectivoService(reservationCommandPort, paymentCommandPort,
+                auditRecorder);
+    }
+
+    private Reservation reservation() {
+        return Reservation.builder()
+                .id(RES_ID).ownerId(1L).reservationDate(LocalDate.now().plusDays(3))
+                .startTime(LocalTime.of(18, 0)).endTime(LocalTime.of(19, 0))
+                .durationMinutes(60).status(ReservationStatus.CONFIRMED)
+                .channel(ReservationChannel.WEB).build();
+    }
+
+    private Payment payment(PaymentStatus status) {
+        Payment p = Payment.pendingFor(RES_ID, new BigDecimal("15.00"));
+        p.setStatus(status);
+        return p;
+    }
+
+    @Test
+    @DisplayName("ADMIN registra efectivo → PAID/CASH/registered_by + PAYMENT_CASH_REGISTERED")
+    void admin_registers_cash() {
+        when(reservationCommandPort.findById(RES_ID)).thenReturn(Optional.of(reservation()));
+        when(paymentCommandPort.findByReservationId(RES_ID))
+                .thenReturn(Optional.of(payment(PaymentStatus.PENDING)));
+        when(paymentCommandPort.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        EfectivoPagoResponse response = service.registrar(RES_ID, ADMIN_ID);
+
+        assertThat(response.status()).isEqualTo("PAID");
+        assertThat(response.method()).isEqualTo("CASH");
+        assertThat(response.registeredById()).isEqualTo(ADMIN_ID);
+
+        ArgumentCaptor<Payment> captor = ArgumentCaptor.forClass(Payment.class);
+        verify(paymentCommandPort).save(captor.capture());
+        Payment saved = captor.getValue();
+        assertThat(saved.getStatus()).isEqualTo(PaymentStatus.PAID);
+        assertThat(saved.getMethod()).isEqualTo(PaymentMethod.CASH);
+        assertThat(saved.getRegisteredById()).isEqualTo(ADMIN_ID);
+        assertThat(saved.getPaidAt()).isNotNull();
+        verify(auditRecorder).record(eq(PagoAuditActions.PAYMENT_CASH_REGISTERED), eq(ADMIN_ID), any());
+    }
+
+    @Test
+    @DisplayName("reserva inexistente → 404")
+    void reservation_not_found() {
+        when(reservationCommandPort.findById(RES_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.registrar(RES_ID, ADMIN_ID))
+                .isInstanceOf(PagoNotFoundException.class);
+        verify(paymentCommandPort, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("reserva ya PAID → 422 ALREADY_PAID")
+    void already_paid() {
+        when(reservationCommandPort.findById(RES_ID)).thenReturn(Optional.of(reservation()));
+        when(paymentCommandPort.findByReservationId(RES_ID))
+                .thenReturn(Optional.of(payment(PaymentStatus.PAID)));
+
+        assertThatThrownBy(() -> service.registrar(RES_ID, ADMIN_ID))
+                .isInstanceOf(PagoUnprocessableException.class)
+                .extracting(e -> ((PagoUnprocessableException) e).getCode())
+                .isEqualTo("ALREADY_PAID");
+        verify(paymentCommandPort, never()).save(any());
+    }
+}

--- a/backend/src/test/java/com/padelpro/pagos/domain/model/RedsysSignatureTest.java
+++ b/backend/src/test/java/com/padelpro/pagos/domain/model/RedsysSignatureTest.java
@@ -1,0 +1,117 @@
+package com.padelpro.pagos.domain.model;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link RedsysSignature} against the Redsys <b>sandbox</b> (test-environment) merchant.
+ *
+ * <p>Merchant code {@code 999008881}, terminal {@code 1}, sandbox secret key (Base64)
+ * {@code sq7HjrUOBfKmC576ILgskD5srU870gJ7}. The key is public documentation for the test environment,
+ * so it is safe to embed here — production keys live encrypted in {@code system_config}.
+ */
+@DisplayName("RedsysSignature — HMAC_SHA256_V1 (sandbox)")
+class RedsysSignatureTest {
+
+    private static final String SANDBOX_KEY = "sq7HjrUOBfKmC576ILgskD5srU870gJ7";
+    private static final String MERCHANT_CODE = "999008881";
+    private static final String TERMINAL = "1";
+
+    /** Build a realistic Ds_MerchantParameters (Base64 of a request JSON) for a given order. */
+    private String buildParams(String order) {
+        String json = "{"
+                + "\"DS_MERCHANT_AMOUNT\":\"1500\","
+                + "\"DS_MERCHANT_ORDER\":\"" + order + "\","
+                + "\"DS_MERCHANT_MERCHANTCODE\":\"" + MERCHANT_CODE + "\","
+                + "\"DS_MERCHANT_CURRENCY\":\"978\","
+                + "\"DS_MERCHANT_TRANSACTIONTYPE\":\"0\","
+                + "\"DS_MERCHANT_TERMINAL\":\"" + TERMINAL + "\","
+                + "\"DS_MERCHANT_MERCHANTURL\":\"https://example.test/api/pagos/webhook\","
+                + "\"DS_MERCHANT_URLOK\":\"https://example.test/pago/confirmado\","
+                + "\"DS_MERCHANT_URLKO\":\"https://example.test/pago/confirmado\""
+                + "}";
+        return Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    @DisplayName("firma determinista: el mismo input produce siempre la misma firma")
+    void sign_is_deterministic() {
+        String params = buildParams("0001abcd1234");
+
+        String sig1 = RedsysSignature.sign(params, "0001abcd1234", SANDBOX_KEY);
+        String sig2 = RedsysSignature.sign(params, "0001abcd1234", SANDBOX_KEY);
+
+        assertThat(sig1).isNotBlank();
+        assertThat(sig1).isEqualTo(sig2);
+        // The signature is the Base64 of a 32-byte HMAC-SHA256 digest.
+        assertThat(Base64.getDecoder().decode(sig1)).hasSize(32);
+    }
+
+    @Test
+    @DisplayName("round-trip: firmar (request) → verificar (webhook) con la misma clave sandbox")
+    void round_trip_sign_then_verify() {
+        String order = "0002ffee5678";
+        String params = buildParams(order);
+
+        String signature = RedsysSignature.sign(params, order, SANDBOX_KEY);
+
+        assertThat(RedsysSignature.verify(params, order, signature, SANDBOX_KEY)).isTrue();
+    }
+
+    @Test
+    @DisplayName("round-trip con firma URL-safe (como la envía Redsys en la notificación)")
+    void verify_accepts_url_safe_signature() {
+        String order = "0003aa11bb22";
+        String params = buildParams(order);
+        String standard = RedsysSignature.sign(params, order, SANDBOX_KEY);
+        // Redsys notifications carry the signature in URL-safe Base64.
+        String urlSafe = standard.replace('+', '-').replace('/', '_');
+
+        assertThat(RedsysSignature.verify(params, order, urlSafe, SANDBOX_KEY)).isTrue();
+    }
+
+    @Test
+    @DisplayName("firma inválida (manipulada) → verify=false")
+    void verify_rejects_tampered_signature() {
+        String order = "0004cc33dd44";
+        String params = buildParams(order);
+        String signature = RedsysSignature.sign(params, order, SANDBOX_KEY);
+
+        // Flip the first character of the (Base64) signature.
+        char first = signature.charAt(0);
+        String tampered = (first == 'A' ? 'B' : 'A') + signature.substring(1);
+
+        assertThat(RedsysSignature.verify(params, order, tampered, SANDBOX_KEY)).isFalse();
+    }
+
+    @Test
+    @DisplayName("parámetros manipulados con la firma original → verify=false")
+    void verify_rejects_tampered_parameters() {
+        String order = "0005ee55ff66";
+        String params = buildParams(order);
+        String signature = RedsysSignature.sign(params, order, SANDBOX_KEY);
+
+        String tamperedParams = buildParams(order) // rebuild identical then mutate a byte
+                .substring(0, buildParams(order).length() - 4) + "AAAA";
+
+        assertThat(RedsysSignature.verify(tamperedParams, order, signature, SANDBOX_KEY)).isFalse();
+    }
+
+    @Test
+    @DisplayName("clave de comercio distinta → verify=false")
+    void verify_rejects_wrong_key() {
+        String order = "0006112233ab";
+        String params = buildParams(order);
+        String signature = RedsysSignature.sign(params, order, SANDBOX_KEY);
+
+        String otherKey = Base64.getEncoder()
+                .encodeToString("0123456789abcdef01234567".getBytes(StandardCharsets.UTF_8));
+
+        assertThat(RedsysSignature.verify(params, order, signature, otherKey)).isFalse();
+    }
+}

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1023,19 +1023,19 @@ paths:
       operationId: listarMisPagos
       summary: Listar pagos del usuario autenticado
       description: |
-        Lista los pagos vinculados al usuario autenticado con paginación.
-        Solo se devuelven pagos del propio usuario.
+        Lista los pagos de las reservas de las que el usuario autenticado es titular,
+        ordenados del más reciente al más antiguo. Devuelve un array plano (sin paginación).
+        Nunca expone datos de tarjeta: solo `redsysOrderId` y `transactionId` (RN-PAY-03).
         Requiere ROLE_USER o ROLE_ADMIN.
-      parameters:
-        - $ref: '#/components/parameters/PageParam'
-        - $ref: '#/components/parameters/PageSizeParam'
       responses:
         '200':
           description: Lista de pagos devuelta correctamente
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedPagosResponse'
+                type: array
+                items:
+                  $ref: '#/components/schemas/PagoHistorialResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
 
@@ -1077,6 +1077,43 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+
+  /pagos/webhook:
+    post:
+      tags: [Pagos]
+      operationId: webhookRedsys
+      summary: Notificación server-to-server de Redsys
+      description: |
+        Endpoint público (sin JWT) que recibe la notificación de Redsys tras el pago. Está
+        allowlisted en `SecurityConfig` y protegido por rate limiting; su única validación de
+        autenticidad es la **firma HMAC SHA-256**, verificada en tiempo constante (RN-PAY-01) ANTES
+        de modificar nada.
+
+        Comportamiento (D3): firma inválida → 200 sin cambios + auditoría
+        `PAYMENT_WEBHOOK_INVALID_SIGNATURE`; firma válida + `Ds_Response` 0000–0099 → pago a `PAID` con
+        `transaction_id` + `PAYMENT_CONFIRMED`; rechazo → `FAILED` + `PAYMENT_REJECTED`; pago ya `PAID`
+        → idempotente sin reproceso (RN-PAY-02). **Siempre responde 200.** Nunca persiste ni registra
+        el cuerpo crudo ni datos de tarjeta (RN-PAY-03).
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                Ds_SignatureVersion:
+                  type: string
+                  example: HMAC_SHA256_V1
+                Ds_MerchantParameters:
+                  type: string
+                  description: Base64 (URL-safe) del JSON de parámetros de la notificación
+                Ds_Signature:
+                  type: string
+                  description: Firma HMAC-SHA256 (Base64 URL-safe)
+      responses:
+        '200':
+          description: Notificación procesada (siempre 200, incluso ante firma inválida)
 
   /admin/pagos/{reservaId}/efectivo:
     post:
@@ -1121,23 +1158,18 @@ paths:
       tags: [Pagos]
       operationId: listarTodosPagos
       summary: Listar todos los pagos (ADMIN)
-      description: Lista todos los pagos del sistema con filtros y paginación. Requiere ROLE_ADMIN.
-      parameters:
-        - $ref: '#/components/parameters/PageParam'
-        - $ref: '#/components/parameters/PageSizeParam'
-        - name: status
-          in: query
-          description: Filtrar por estado del pago
-          required: false
-          schema:
-            $ref: '#/components/schemas/PaymentStatus'
+      description: |
+        Lista todos los pagos del sistema, ordenados del más reciente al más antiguo. Devuelve un
+        array plano (sin paginación). Requiere ROLE_ADMIN.
       responses:
         '200':
           description: Lista de pagos devuelta correctamente
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedPagosResponse'
+                type: array
+                items:
+                  $ref: '#/components/schemas/PagoHistorialResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -2448,80 +2480,172 @@ components:
 
     IniciarPagoRequest:
       type: object
-      description: Datos para iniciar un pago online vía Redsys
+      description: |
+        Datos para iniciar un pago online vía Redsys. Solo `reservaId` es relevante; cualquier importe
+        enviado por el cliente se ignora — el importe cobrado es siempre el congelado en backend
+        (RN-RES-03). Solo el titular de la reserva puede iniciar el pago (RN-AUTH-04).
       required:
         - reservaId
-        - participanteId
       properties:
         reservaId:
           type: string
           format: uuid
           description: UUID de la reserva a pagar
           example: "550e8400-e29b-41d4-a716-446655440000"
-        participanteId:
-          type: integer
-          format: int64
-          description: ID del participante que realiza el pago (debe corresponder al usuario autenticado)
-          example: 3
 
     IniciarPagoResponse:
       type: object
-      description: Datos para redirigir al usuario al TPV virtual de Redsys
+      description: |
+        Datos para que el frontend construya un formulario oculto y lo auto-envíe al TPV de Redsys
+        (D6). Los datos de tarjeta nunca pasan por PadelPro (RN-PAY-03).
       required:
         - pagoId
         - redsysOrderId
         - redsysUrl
         - amount
         - status
+        - dsSignatureVersion
+        - dsMerchantParameters
+        - dsSignature
       properties:
         pagoId:
           type: string
           format: uuid
-          description: UUID del registro de pago creado
+          description: UUID del registro de pago
           example: "7c9e6679-7425-40de-944b-e07fc1f90ae7"
         redsysOrderId:
           type: string
-          description: Referencia de orden generada para Redsys
-          example: "ORDER-20250615-001"
+          description: Referencia de orden generada para Redsys (Ds_Merchant_Order)
+          example: "0001AB23CD45"
         redsysUrl:
           type: string
           format: uri
-          description: URL del TPV virtual Redsys al que redirigir al usuario
+          description: URL del TPV de Redsys a la que se envía el formulario
           example: "https://sis-t.redsys.es:25443/sis/realizarPago"
         amount:
           type: number
           format: double
-          description: Importe del pago en EUR
+          description: Importe del pago en EUR (congelado en backend)
           example: 15.00
         status:
           type: string
           enum:
             - IN_PROGRESS
-          description: Estado inicial del pago tras iniciar el proceso
+          description: Estado del pago tras iniciar el proceso
           example: IN_PROGRESS
+        dsSignatureVersion:
+          type: string
+          description: Versión de firma Redsys
+          example: HMAC_SHA256_V1
+        dsMerchantParameters:
+          type: string
+          description: Base64 del JSON de parámetros firmados (campo de formulario Ds_MerchantParameters)
+        dsSignature:
+          type: string
+          description: Firma HMAC-SHA256 (Base64) del campo Ds_Signature
 
     EfectivoPagoResponse:
       type: object
-      description: Confirmación del registro de pago en efectivo
+      description: Confirmación del registro de pago en efectivo por un ADMIN
       required:
+        - pagoId
         - reservaId
-        - pagosActualizados
-        - totalCobrado
+        - amount
+        - status
       properties:
+        pagoId:
+          type: string
+          format: uuid
+          description: UUID del registro de pago
+          example: "7c9e6679-7425-40de-944b-e07fc1f90ae7"
         reservaId:
           type: string
           format: uuid
           description: UUID de la reserva
           example: "550e8400-e29b-41d4-a716-446655440000"
-        pagosActualizados:
-          type: integer
-          description: Número de registros de pago actualizados
-          example: 1
-        totalCobrado:
+        amount:
           type: number
           format: double
-          description: Importe total cobrado en efectivo
+          description: Importe cobrado en EUR
           example: 15.00
+        method:
+          $ref: '#/components/schemas/PaymentMethod'
+        status:
+          $ref: '#/components/schemas/PaymentStatus'
+        registeredById:
+          type: integer
+          format: int64
+          description: ID del ADMIN que registró el pago en efectivo
+          nullable: true
+          example: 99
+        paidAt:
+          type: string
+          format: date-time
+          description: Instante del cobro
+          nullable: true
+          example: "2026-07-05T10:30:00Z"
+
+    PagoHistorialResponse:
+      type: object
+      description: |
+        Fila del historial de pagos. Nunca expone datos de tarjeta: solo `redsysOrderId` y
+        `transactionId` (RN-PAY-03).
+      required:
+        - pagoId
+        - reservaId
+        - amount
+        - status
+      properties:
+        pagoId:
+          type: string
+          format: uuid
+          example: "7c9e6679-7425-40de-944b-e07fc1f90ae7"
+        reservaId:
+          type: string
+          format: uuid
+          example: "550e8400-e29b-41d4-a716-446655440000"
+        ownerId:
+          type: integer
+          format: int64
+          nullable: true
+          example: 3
+        amount:
+          type: number
+          format: double
+          example: 15.00
+        method:
+          allOf:
+            - $ref: '#/components/schemas/PaymentMethod'
+          nullable: true
+        status:
+          $ref: '#/components/schemas/PaymentStatus'
+        redsysOrderId:
+          type: string
+          nullable: true
+          example: "0001AB23CD45"
+        transactionId:
+          type: string
+          nullable: true
+          example: "123456"
+        reservationDate:
+          type: string
+          format: date
+          nullable: true
+          example: "2026-07-12"
+        startTime:
+          type: string
+          nullable: true
+          example: "18:00"
+        paidAt:
+          type: string
+          format: date-time
+          nullable: true
+          example: "2026-07-05T10:30:00Z"
+        createdAt:
+          type: string
+          format: date-time
+          nullable: true
+          example: "2026-07-05T09:00:00Z"
 
     PaginatedPagosResponse:
       allOf:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,8 @@ import { MisReservasPage } from './pages/MisReservasPage';
 import { DetalleReservaPage } from './pages/DetalleReservaPage';
 import { PartidasAbiertasPage } from './pages/PartidasAbiertasPage';
 import { ConfirmarUnionPage } from './pages/ConfirmarUnionPage';
+import { CheckoutRedsysPage } from './pages/CheckoutRedsysPage';
+import { PagoConfirmadoPage } from './pages/PagoConfirmadoPage';
 import { reservasPaths } from './pages/reservasPaths';
 
 function App() {
@@ -30,6 +32,13 @@ function App() {
           <Route path="/login" element={<LoginPage />} />
           <Route path="/register" element={<RegisterPage />} />
           <Route path="/forgot-password" element={<ForgotPasswordPage />} />
+
+          {/* Retorno del TPV Redsys (pagos-redsys-online). Público: al volver del TPV
+              el access token en memoria puede haberse perdido (recarga completa,
+              RN-AUTH-09); la página consulta el estado real al backend (webhook =
+              fuente de verdad) y el interceptor del httpClient restaura la sesión. */}
+          <Route path={reservasPaths.pagoOk} element={<PagoConfirmadoPage />} />
+          <Route path={reservasPaths.pagoKo} element={<PagoConfirmadoPage />} />
 
           {/* Rutas privadas */}
           <Route element={<PrivateRoute />}>
@@ -47,6 +56,10 @@ function App() {
             {/* Partidas — unirse a reservas con plazas libres (partidas-unirse) */}
             <Route path={reservasPaths.partidas} element={<PartidasAbiertasPage />} />
             <Route path={reservasPaths.confirmarUnion(':id')} element={<ConfirmarUnionPage />} />
+
+            {/* Checkout Redsys (pagos-redsys-online): se inicia desde la app con el
+                response de iniciar pago en el state de navegación. */}
+            <Route path={reservasPaths.checkout} element={<CheckoutRedsysPage />} />
           </Route>
 
           {/* Rutas de administración — guard de rol ADMIN (D6) */}

--- a/frontend/src/pages/CheckoutRedsysPage.module.css
+++ b/frontend/src/pages/CheckoutRedsysPage.module.css
@@ -1,0 +1,143 @@
+/* CheckoutRedsysPage — checkout Redsys (mockup 11) */
+
+.page {
+  min-height: 100dvh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--cream);
+  padding: 24px;
+}
+
+.card {
+  width: 100%;
+  max-width: 400px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 18px;
+  background: var(--white);
+  border: 1px solid var(--line, #e5e3d8);
+  border-radius: 20px;
+  padding: 28px 24px 24px;
+  text-align: center;
+}
+
+.title {
+  font-family: var(--font-display);
+  font-size: 26px;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+}
+
+.merch {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--line, #e5e3d8);
+}
+
+.merchLogo {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 9px;
+  background: var(--ink);
+  color: var(--cream);
+  font-family: var(--font-display);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.merchInfo {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1px;
+  flex: 1;
+}
+
+.merchName {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.merchUrl {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.secure {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--olive);
+  white-space: nowrap;
+}
+
+.amountBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.amountLab {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.amount {
+  font-family: var(--font-display);
+  font-size: 44px;
+  line-height: 1;
+  letter-spacing: -0.03em;
+  color: var(--ink);
+}
+
+.orderRef {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.notice {
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--muted);
+}
+
+.footerTech {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  color: var(--muted-light, #a8a49a);
+}
+
+.spinner {
+  width: 32px;
+  height: 32px;
+  border: 3px solid rgba(13, 13, 13, 0.15);
+  border-top-color: var(--olive);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+.card form {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/frontend/src/pages/CheckoutRedsysPage.tsx
+++ b/frontend/src/pages/CheckoutRedsysPage.tsx
@@ -1,0 +1,93 @@
+// pagos-redsys-online (Grupo 6, D6) — CheckoutRedsysPage (mockup 11).
+// Recibe el response de `iniciarPago` en el `state` de navegación y construye un
+// formulario oculto con los tres campos firmados (Ds_SignatureVersion /
+// Ds_MerchantParameters / Ds_Signature) que auto-envía (POST) al `redsysUrl` del
+// TPV de Redsys. Los datos de tarjeta NUNCA pasan por PadelPro (RN-PAY-03): el
+// navegador se redirige al entorno seguro de Redsys y allí introduce la tarjeta.
+import { useEffect, useRef } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import { type IniciarPagoResponse } from '../services/pagosApi';
+import { reservasPaths } from './reservasPaths';
+import './pages.css';
+import styles from './CheckoutRedsysPage.module.css';
+
+interface CheckoutLocationState {
+  pago?: IniciarPagoResponse;
+}
+
+/** Formatea el importe como euros. El resto de la app trata `amount`/`priceTotal`
+ *  en euros; el importe autoritativo en céntimos viaja dentro de Ds_MerchantParameters. */
+function formatPrecio(amount: number): string {
+  return new Intl.NumberFormat('es-ES', { style: 'currency', currency: 'EUR' }).format(amount);
+}
+
+export function CheckoutRedsysPage() {
+  const location = useLocation();
+  const pago = (location.state as CheckoutLocationState | null)?.pago;
+  const formRef = useRef<HTMLFormElement>(null);
+
+  // Auto-submit al TPV en cuanto el form está montado con los parámetros firmados.
+  useEffect(() => {
+    if (pago && formRef.current) {
+      formRef.current.submit();
+    }
+  }, [pago]);
+
+  // Sin datos de pago (p. ej. recarga directa de la URL): no hay nada que enviar.
+  if (!pago) {
+    return (
+      <div className={styles.page}>
+        <div className={styles.card}>
+          <h1 className={styles.title}>Pago no disponible</h1>
+          <p className={styles.notice}>
+            No se ha podido iniciar el pago. Vuelve a tus reservas e inténtalo de nuevo.
+          </p>
+          <Link to={reservasPaths.mias} className="p-btn p-btn-primary">
+            Volver a mis reservas
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.page}>
+      <div className={styles.card}>
+        <div className={styles.merch}>
+          <span className={styles.merchLogo}>PP</span>
+          <div className={styles.merchInfo}>
+            <span className={styles.merchName}>PadelPro</span>
+            <span className={styles.merchUrl}>checkout.redsys.es</span>
+          </div>
+          <span className={styles.secure} aria-hidden="true">
+            🔒 3DSv2
+          </span>
+        </div>
+
+        <div className={styles.amountBlock}>
+          <span className={styles.amountLab}>Importe</span>
+          <span className={styles.amount}>{formatPrecio(pago.amount)}</span>
+          <span className={styles.orderRef}>Pedido {pago.redsysOrderId}</span>
+        </div>
+
+        <div className={styles.spinner} role="status" aria-label="Redirigiendo a Redsys" />
+        <p className={styles.notice}>
+          Te estamos redirigiendo a la pasarela de pago segura de Redsys. Introduce los
+          datos de tu tarjeta allí; nunca se almacenan en PadelPro.
+        </p>
+
+        {/* Form firmado que se auto-envía al TPV. Sin datos de tarjeta (RN-PAY-03). */}
+        <form ref={formRef} method="POST" action={pago.redsysUrl} data-testid="redsys-form">
+          <input type="hidden" name="Ds_SignatureVersion" value={pago.dsSignatureVersion} />
+          <input type="hidden" name="Ds_MerchantParameters" value={pago.dsMerchantParameters} />
+          <input type="hidden" name="Ds_Signature" value={pago.dsSignature} />
+          <button type="submit" className="p-btn p-btn-primary">
+            Continuar al pago →
+          </button>
+        </form>
+
+        <p className={styles.footerTech}>Procesado por Redsys · HMAC SHA-256 · PCI-DSS L1</p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/MisReservasPage.module.css
+++ b/frontend/src/pages/MisReservasPage.module.css
@@ -196,6 +196,30 @@
   cursor: not-allowed;
 }
 
+.pagarBtn {
+  flex: 1;
+  min-width: 130px;
+  padding: 10px 12px;
+  border: 1.5px solid var(--ink);
+  border-radius: 10px;
+  background: var(--ink);
+  color: var(--cream);
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.15s ease;
+}
+
+.pagarBtn:hover:not(:disabled) {
+  opacity: 0.85;
+}
+
+.pagarBtn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 .pagoInfo {
   font-size: 13px;
   line-height: 1.4;

--- a/frontend/src/pages/MisReservasPage.tsx
+++ b/frontend/src/pages/MisReservasPage.tsx
@@ -16,6 +16,7 @@ import {
   ReservaResponse,
   ReservationStatus,
 } from '../services/reservasApi';
+import { iniciarPago } from '../services/pagosApi';
 import { EstadoBadge } from '../components/EstadoBadge';
 import { reservasPaths } from './reservasPaths';
 import './pages.css';
@@ -38,6 +39,8 @@ export function MisReservasPage() {
   const [cancellingId, setCancellingId] = useState<string | null>(null);
   const [cancelError, setCancelError] = useState<{ id: string; msg: string } | null>(null);
   const [diferidoId, setDiferidoId] = useState<string | null>(null);
+  const [pagandoId, setPagandoId] = useState<string | null>(null);
+  const [pagoError, setPagoError] = useState<{ id: string; msg: string } | null>(null);
 
   // Id del usuario (D8) para decidir la propiedad de cada reserva (botón cancelar).
   useEffect(() => {
@@ -65,6 +68,25 @@ export function MisReservasPage() {
 
   if (!isAuthenticated) {
     return <Navigate to="/login" replace />;
+  }
+
+  // "Pagar ahora" (pagos-redsys-online, D6): inicia el pago online y navega al
+  // checkout Redsys con el form firmado en el state. Solo owner con pago PENDING.
+  async function handlePagar(id: string) {
+    if (!accessToken) return;
+    setPagandoId(id);
+    setPagoError(null);
+    try {
+      const pago = await iniciarPago(accessToken, id);
+      navigate(reservasPaths.checkout, { state: { pago } });
+    } catch (err) {
+      const msg =
+        isReservaApiError(err) && err.code === 'CONFLICT'
+          ? 'Este pago ya está en curso o completado.'
+          : 'No se pudo iniciar el pago. Inténtalo de nuevo.';
+      setPagoError({ id, msg });
+      setPagandoId(null);
+    }
   }
 
   async function handleCancel(id: string) {
@@ -134,6 +156,8 @@ export function MisReservasPage() {
             const pagoPendiente =
               r.pago != null && (r.pago.status === 'PENDING' || r.pago.status === 'IN_PROGRESS');
             const mostrarPago = pagoPendiente && r.status !== 'CANCELLED';
+            // "Pagar ahora": solo el owner y solo con pago PENDING (RN-AUTH-04).
+            const puedePagar = isOwner && r.pago?.status === 'PENDING' && r.status !== 'CANCELLED';
 
             return (
               <li key={r.id} className={styles.card}>
@@ -169,19 +193,26 @@ export function MisReservasPage() {
                           >
                             Pago en diferido
                           </button>
-                          <button
-                            type="button"
-                            className={styles.pagoBtnDisabled}
-                            disabled
-                            title="El pago online estará disponible próximamente"
-                          >
-                            Pagar ahora (disponible próximamente)
-                          </button>
+                          {puedePagar && (
+                            <button
+                              type="button"
+                              className={styles.pagarBtn}
+                              onClick={() => handlePagar(r.id)}
+                              disabled={pagandoId === r.id}
+                            >
+                              {pagandoId === r.id ? 'Iniciando…' : 'Pagar ahora'}
+                            </button>
+                          )}
                         </div>
                         {diferidoId === r.id && (
                           <p className={styles.pagoInfo} role="status">
                             El cobro se realizará de forma presencial en el club. No es necesario
                             pagar ahora.
+                          </p>
+                        )}
+                        {pagoError?.id === r.id && (
+                          <p className="p-error" role="alert">
+                            {pagoError.msg}
                           </p>
                         )}
                       </div>

--- a/frontend/src/pages/PagoConfirmadoPage.module.css
+++ b/frontend/src/pages/PagoConfirmadoPage.module.css
@@ -1,0 +1,162 @@
+/* PagoConfirmadoPage — retorno del TPV (mockup 12) */
+
+.page {
+  min-height: 100dvh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--cream);
+  padding: 24px;
+}
+
+.pageOk {
+  background: var(--ink);
+}
+
+.card {
+  width: 100%;
+  max-width: 400px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  background: var(--white);
+  border: 1px solid var(--line, #e5e3d8);
+  border-radius: 20px;
+  padding: 32px 24px;
+  text-align: center;
+}
+
+.successCard {
+  width: 100%;
+  max-width: 400px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  text-align: center;
+  color: var(--cream);
+}
+
+.successIco {
+  display: grid;
+  place-items: center;
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: var(--lime, #c8f560);
+  color: var(--ink);
+  font-size: 32px;
+  font-weight: 700;
+  box-shadow: 0 0 48px rgba(200, 245, 96, 0.35);
+}
+
+.failIco {
+  display: grid;
+  place-items: center;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: rgba(200, 60, 60, 0.12);
+  color: var(--error, #c83c3c);
+  font-size: 26px;
+  font-weight: 700;
+}
+
+.title {
+  font-family: var(--font-display);
+  font-size: 26px;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+}
+
+.successTitle {
+  font-family: var(--font-display);
+  font-size: 34px;
+  letter-spacing: -0.03em;
+  color: var(--cream);
+}
+
+.successTitle em {
+  font-style: italic;
+  color: var(--lime, #c8f560);
+}
+
+.sub {
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--muted);
+}
+
+.successSub {
+  font-size: 14px;
+  line-height: 1.5;
+  color: rgba(245, 243, 235, 0.7);
+}
+
+.detailCard {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  background: rgba(245, 243, 235, 0.06);
+  border: 1px solid rgba(245, 243, 235, 0.12);
+  border-radius: 14px;
+  padding: 8px 16px;
+  margin: 4px 0;
+}
+
+.detailRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 0;
+  border-bottom: 1px solid rgba(245, 243, 235, 0.08);
+}
+
+.detailRow:last-child {
+  border-bottom: none;
+}
+
+.detailRow dt {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(245, 243, 235, 0.55);
+}
+
+.detailRow dd {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--cream);
+  text-align: right;
+  word-break: break-all;
+}
+
+.confirmed {
+  color: var(--lime, #c8f560) !important;
+}
+
+.actions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+}
+
+.spinner {
+  width: 36px;
+  height: 36px;
+  border: 3px solid rgba(13, 13, 13, 0.15);
+  border-top-color: var(--olive);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/frontend/src/pages/PagoConfirmadoPage.tsx
+++ b/frontend/src/pages/PagoConfirmadoPage.tsx
@@ -1,0 +1,181 @@
+// pagos-redsys-online (Grupo 6, D6) — PagoConfirmadoPage (mockup 12).
+// Página de retorno del TPV (Redsys UrlOK/UrlKO). NO confía en los parámetros de
+// resultado de la URL de Redsys: el estado real del pago lo fija el webhook
+// (server-to-server, fuente de verdad). Aquí se consulta `GET /api/pagos` y se
+// localiza el pago de la reserva (por `reservaId`/`pagoId` de la query) para
+// mostrar el estado real: PAID / FAILED / "procesando" (si el webhook aún no ha
+// llegado, con opción de refrescar).
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+import { getPagos, type PagoHistorial } from '../services/pagosApi';
+import { reservasPaths } from './reservasPaths';
+import './pages.css';
+import styles from './PagoConfirmadoPage.module.css';
+
+function formatPrecio(amount: number): string {
+  return new Intl.NumberFormat('es-ES', { style: 'currency', currency: 'EUR' }).format(amount);
+}
+
+/** Referencia Redsys a mostrar: transactionId (Ds_AuthorisationCode) o el order id;
+ *  fallback al id del pago si el backend no envía ninguna. */
+function referenciaRedsys(pago: PagoHistorial): string {
+  return pago.transactionId ?? pago.redsysOrderId ?? pago.id;
+}
+
+export function PagoConfirmadoPage() {
+  const { accessToken } = useAuth();
+  const [searchParams] = useSearchParams();
+  const reservaId = searchParams.get('reservaId');
+  const pagoId = searchParams.get('pagoId');
+
+  const [pagos, setPagos] = useState<PagoHistorial[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setLoadError(false);
+    try {
+      const lista = await getPagos(accessToken);
+      setPagos(lista);
+    } catch {
+      setLoadError(true);
+    } finally {
+      setLoading(false);
+    }
+  }, [accessToken]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const pago = useMemo(() => {
+    if (pagoId) return pagos.find((p) => p.id === pagoId) ?? null;
+    if (reservaId) return pagos.find((p) => p.reservaId === reservaId) ?? null;
+    return null;
+  }, [pagos, pagoId, reservaId]);
+
+  if (loading) {
+    return (
+      <div className={styles.page}>
+        <div className={styles.spinner} role="status" aria-label="Consultando el estado del pago" />
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div className={styles.page}>
+        <div className={styles.card}>
+          <h1 className={styles.title}>No se pudo comprobar el pago</h1>
+          <p className={styles.sub}>
+            No hemos podido consultar el estado de tu pago. Inténtalo de nuevo en unos
+            instantes.
+          </p>
+          <div className={styles.actions}>
+            <button type="button" className="p-btn p-btn-primary" onClick={load}>
+              Reintentar
+            </button>
+            <Link to={reservasPaths.mias} className="p-btn p-btn-outline">
+              Ver mis reservas →
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // No se encuentra el pago (webhook aún no ha creado/actualizado, o falta el id).
+  const status = pago?.status;
+  const esPagado = status === 'PAID';
+  const esFallido = status === 'FAILED' || status === 'CANCELLED';
+
+  if (esPagado && pago) {
+    return (
+      <div className={`${styles.page} ${styles.pageOk}`}>
+        <div className={styles.successCard}>
+          <div className={styles.successIco} aria-hidden="true">
+            ✓
+          </div>
+          <h1 className={styles.successTitle}>
+            ¡Pista <em>reservada!</em>
+          </h1>
+          <p className={styles.successSub}>Tu pago se ha confirmado correctamente.</p>
+
+          <dl className={styles.detailCard}>
+            <div className={styles.detailRow}>
+              <dt>Reserva</dt>
+              <dd>{pago.reservaId}</dd>
+            </div>
+            <div className={styles.detailRow}>
+              <dt>Referencia Redsys</dt>
+              <dd>{referenciaRedsys(pago)}</dd>
+            </div>
+            <div className={styles.detailRow}>
+              <dt>Importe</dt>
+              <dd>{formatPrecio(pago.amount)}</dd>
+            </div>
+            <div className={styles.detailRow}>
+              <dt>Pago</dt>
+              <dd className={styles.confirmed}>✓ Confirmado</dd>
+            </div>
+          </dl>
+
+          <div className={styles.actions}>
+            <Link to={reservasPaths.detalle(pago.reservaId)} className="p-btn p-btn-primary">
+              Ver reserva →
+            </Link>
+            <Link to={reservasPaths.mias} className="p-btn p-btn-outline">
+              Mis reservas
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (esFallido && pago) {
+    return (
+      <div className={styles.page}>
+        <div className={styles.card}>
+          <div className={styles.failIco} aria-hidden="true">
+            ✕
+          </div>
+          <h1 className={styles.title}>El pago no se ha completado</h1>
+          <p className={styles.sub}>
+            No se ha realizado ningún cargo. Puedes volver a intentar el pago desde tus
+            reservas.
+          </p>
+          <div className={styles.actions}>
+            <Link to={reservasPaths.mias} className="p-btn p-btn-primary">
+              Volver a mis reservas
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // enProceso — el webhook puede tardar unos segundos en confirmar.
+  return (
+    <div className={styles.page}>
+      <div className={styles.card}>
+        <div className={styles.spinner} role="status" aria-label="Procesando el pago" />
+        <h1 className={styles.title}>Estamos procesando tu pago</h1>
+        <p className={styles.sub}>
+          La confirmación puede tardar unos segundos. Si has completado el pago, pulsa
+          «Actualizar» para comprobar el estado.
+        </p>
+        <div className={styles.actions}>
+          <button type="button" className="p-btn p-btn-primary" onClick={load}>
+            Actualizar
+          </button>
+          <Link to={reservasPaths.mias} className="p-btn p-btn-outline">
+            Ver mis reservas →
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/reservasPaths.ts
+++ b/frontend/src/pages/reservasPaths.ts
@@ -15,7 +15,25 @@ export const reservasPaths = {
   partidas: '/reservas/partidas',
   /** Confirmar la unión a una partida concreta (por `reservaId`). */
   confirmarUnion: (id: string): string => `/reservas/partidas/${id}/unirse`,
+  /** Checkout Redsys (pagos-redsys-online): auto-envía el form firmado al TPV.
+   *  Se llega con el response de iniciar pago en el `state` de navegación. */
+  checkout: '/pagos/checkout',
+  /** Retorno del TPV: pago aceptado (Redsys UrlOK). El estado real lo fija el
+   *  webhook; la página lo consulta al backend, no confía en la URL. */
+  pagoOk: '/pagos/ok',
+  /** Retorno del TPV: pago cancelado/rechazado (Redsys UrlKO). */
+  pagoKo: '/pagos/ko',
 } as const;
+
+/**
+ * Construye el path de retorno del TPV (UrlOK/UrlKO) propagando la `reservaId` en
+ * la query, para que `PagoConfirmadoPage` localice el pago al consultar el estado
+ * real al backend (no confía en parámetros de resultado de la URL de Redsys).
+ */
+export function pagoRetornoPath(base: string, reservaId: string): string {
+  const params = new URLSearchParams({ reservaId });
+  return `${base}?${params.toString()}`;
+}
 
 /**
  * Construye el path de "Confirmar unión" a una partida, propagando la `fecha` en la

--- a/frontend/src/services/pagosApi.ts
+++ b/frontend/src/services/pagosApi.ts
@@ -1,0 +1,87 @@
+// pagos-redsys-online (Grupo 6) — pagosApi.
+// Service del journey de pago online del jugador. Usa el httpClient compartido
+// (`api`) para heredar el interceptor de refresh de sesión, y reutiliza el mapeo
+// de error tipado del backend (`toReservaApiError`) para no duplicar la traducción
+// del error shape real `{ error, message, timestamp, details? }`.
+//
+// Seguridad (RN-PAY-03): los datos de tarjeta NUNCA pasan por PadelPro. Este
+// service solo obtiene los parámetros firmados del TPV (para redirigir con un form)
+// y consulta el estado del pago; la fuente de verdad del estado es el webhook
+// (server-to-server), no la URL de retorno del navegador.
+import { api } from './httpClient';
+import { toReservaApiError, type PaymentStatus } from './reservasApi';
+
+function authHeader(token: string) {
+  return { Authorization: `Bearer ${token}` };
+}
+
+/**
+ * Respuesta de `POST /api/pagos/iniciar`. Los tres campos `ds*` + `redsysUrl` son
+ * para construir y auto-enviar (POST) el formulario firmado al TPV de Redsys. El
+ * `amount` es informativo (importe congelado en backend, RN-RES-03); el importe
+ * autoritativo en céntimos viaja codificado dentro de `dsMerchantParameters`.
+ */
+export interface IniciarPagoResponse {
+  pagoId: string;
+  redsysOrderId: string;
+  redsysUrl: string;
+  amount: number;
+  status: PaymentStatus;
+  dsSignatureVersion: string;
+  dsMerchantParameters: string;
+  dsSignature: string;
+}
+
+/** Pago del historial `GET /api/pagos`. `redsysOrderId`/`transactionId` son
+ *  opcionales (referencia Redsys para mostrar en la confirmación); si el backend
+ *  no los envía se hace fallback al `id` del pago. */
+export interface PagoHistorial {
+  id: string;
+  reservaId: string;
+  amount: number;
+  method?: 'REDSYS' | 'CASH';
+  status: PaymentStatus;
+  paidAt?: string | null;
+  redsysOrderId?: string | null;
+  transactionId?: string | null;
+}
+
+/**
+ * POST /api/pagos/iniciar — solo owner (RN-AUTH-04). Devuelve el form firmado del
+ * TPV. Errores del contrato: 403 (no owner), 404 (reserva inexistente), 409 (pago
+ * ya IN_PROGRESS/PAID), 422 (reserva cancelada). Se mapean a `ReservaApiError`.
+ */
+export async function iniciarPago(
+  token: string,
+  reservaId: string
+): Promise<IniciarPagoResponse> {
+  try {
+    const { data } = await api.post<IniciarPagoResponse>(
+      '/pagos/iniciar',
+      { reservaId },
+      { headers: authHeader(token) }
+    );
+    return data;
+  } catch (err) {
+    toReservaApiError(err);
+  }
+}
+
+/**
+ * GET /api/pagos — historial de pagos propios. `token` es opcional: al volver del
+ * TPV (UrlOK/UrlKO) el access token en memoria puede haberse perdido (RN-AUTH-09,
+ * recarga de página completa); en ese caso se omite el header y se deja que el
+ * interceptor del httpClient restaure la sesión vía la cookie de refresh. Normaliza
+ * un cuerpo paginado `{ data: [...] }` por robustez.
+ */
+export async function getPagos(token: string | null): Promise<PagoHistorial[]> {
+  try {
+    const { data } = await api.get<PagoHistorial[] | { data?: PagoHistorial[] }>('/pagos', {
+      headers: token ? authHeader(token) : undefined,
+    });
+    if (Array.isArray(data)) return data;
+    return Array.isArray(data?.data) ? data.data : [];
+  } catch (err) {
+    toReservaApiError(err);
+  }
+}

--- a/frontend/src/services/reservasApi.ts
+++ b/frontend/src/services/reservasApi.ts
@@ -251,8 +251,9 @@ function codeFromStatus(status: number): ReservaErrorCode {
  *  CANCELLATION_DEADLINE_PASSED), que comparten status. Por eso el código se toma
  *  SIEMPRE del valor textual del cuerpo cuando es un `ReservaErrorCode` conocido; solo
  *  se cae a `codeFromStatus` si el cuerpo no lo trae (401 sesión, 5xx servidor, red).
- *  Re-lanza. */
-function toReservaApiError(error: unknown): never {
+ *  Re-lanza. Exportado para reutilizarlo desde otras services del mismo dominio
+ *  (p. ej. `pagosApi`) sin duplicar el mapeo del error shape real del backend. */
+export function toReservaApiError(error: unknown): never {
   const axErr = error as AxiosError<BackendErrorBody>;
   const status = axErr.response?.status ?? 0;
   const body = axErr.response?.data;

--- a/frontend/src/test/CheckoutRedsysPage.test.tsx
+++ b/frontend/src/test/CheckoutRedsysPage.test.tsx
@@ -1,0 +1,81 @@
+// pagos-redsys-online (Grupo 6, D6) — CheckoutRedsysPage — TDD.
+// Dado el response de iniciar pago (en el state de navegación), la página construye
+// el form firmado con los tres campos ds* y el action = redsysUrl, y hace auto-submit
+// (POST) al TPV. El submit se mockea (jsdom no implementa form.submit y no queremos
+// navegar de verdad en test). Sin state → mensaje de error + volver a mis reservas.
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { CheckoutRedsysPage } from '../pages/CheckoutRedsysPage';
+
+const pago = {
+  pagoId: 'p-1',
+  redsysOrderId: '0001abc',
+  redsysUrl: 'https://sis-t.redsys.es:25443/sis/realizarPago',
+  amount: 16,
+  status: 'IN_PROGRESS' as const,
+  dsSignatureVersion: 'HMAC_SHA256_V1',
+  dsMerchantParameters: 'eyJEc19NZXJjaGFudF9BbW91bnQiOiIxNjAwIn0=',
+  dsSignature: 'firma-base64-abc',
+};
+
+function renderWithState(state: unknown) {
+  return render(
+    <MemoryRouter initialEntries={[{ pathname: '/pagos/checkout', state }]}>
+      <Routes>
+        <Route path="/pagos/checkout" element={<CheckoutRedsysPage />} />
+        <Route path="/reservas/mias" element={<div>Mis reservas</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('CheckoutRedsysPage', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('construye el form firmado (3 campos ds*) con action = redsysUrl y hace auto-submit', () => {
+    const submitSpy = vi
+      .spyOn(HTMLFormElement.prototype, 'submit')
+      .mockImplementation(() => {});
+
+    renderWithState({ pago });
+
+    const form = screen.getByTestId('redsys-form') as HTMLFormElement;
+    // POST al TPV con la URL firmada.
+    expect(form.getAttribute('method')?.toUpperCase()).toBe('POST');
+    expect(form.getAttribute('action')).toBe(pago.redsysUrl);
+
+    // Los tres campos firmados con el protocolo Redsys.
+    const version = form.querySelector('input[name="Ds_SignatureVersion"]') as HTMLInputElement;
+    const params = form.querySelector('input[name="Ds_MerchantParameters"]') as HTMLInputElement;
+    const signature = form.querySelector('input[name="Ds_Signature"]') as HTMLInputElement;
+    expect(version.value).toBe(pago.dsSignatureVersion);
+    expect(params.value).toBe(pago.dsMerchantParameters);
+    expect(signature.value).toBe(pago.dsSignature);
+
+    // Auto-submit disparado al montar.
+    expect(submitSpy).toHaveBeenCalledTimes(1);
+
+    // Datos de tarjeta NUNCA en PadelPro (RN-PAY-03): no hay inputs de PAN/CVV.
+    expect(form.querySelector('input[name*="tarjeta" i]')).toBeNull();
+    expect(form.querySelector('input[name*="cvv" i]')).toBeNull();
+  });
+
+  it('muestra el importe a pagar', () => {
+    vi.spyOn(HTMLFormElement.prototype, 'submit').mockImplementation(() => {});
+    renderWithState({ pago });
+    expect(screen.getByText(/16,00\s*€/)).toBeInTheDocument();
+  });
+
+  it('sin datos de pago en el state muestra error y enlace a mis reservas, sin submit', () => {
+    const submitSpy = vi
+      .spyOn(HTMLFormElement.prototype, 'submit')
+      .mockImplementation(() => {});
+
+    renderWithState(null);
+
+    expect(screen.getByText(/pago no disponible/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /mis reservas/i })).toBeInTheDocument();
+    expect(submitSpy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/test/MisReservasPage.acciones.test.tsx
+++ b/frontend/src/test/MisReservasPage.acciones.test.tsx
@@ -108,14 +108,17 @@ describe('MisReservasPage — acciones (Grupo 5)', () => {
     expect(pagoCalled).toBe(false);
   });
 
-  it('"pagar ahora" está deshabilitado (disponible próximamente)', async () => {
+  // pagos-redsys-online (Grupo 6): "pagar ahora" ya NO está deshabilitado; se activa
+  // para el owner con pago PENDING. El flujo completo (iniciar + navegar al checkout)
+  // se cubre en MisReservasPage.pagar.test.tsx.
+  it('"pagar ahora" está activo para el owner con pago PENDING', async () => {
     server.use(http.get('/api/reservas', () => HttpResponse.json([reserva()])));
     renderPage();
 
     await screen.findByText('20:00');
     const btn = screen.getByRole('button', { name: /pagar ahora/i });
-    expect(btn).toBeDisabled();
-    expect(btn).toHaveTextContent(/próximamente/i);
+    expect(btn).toBeEnabled();
+    expect(btn).not.toHaveTextContent(/próximamente/i);
   });
 
   it('oculta acciones cuando la reserva no es cancelable (CANCELLED)', async () => {

--- a/frontend/src/test/MisReservasPage.pagar.test.tsx
+++ b/frontend/src/test/MisReservasPage.pagar.test.tsx
@@ -1,0 +1,146 @@
+// pagos-redsys-online (Grupo 6, 6.3) — MisReservasPage "pagar ahora" — TDD.
+// Activa el botón "pagar ahora" (antes deshabilitado): solo visible para el owner
+// con pago PENDING. Al pulsar, llama a POST /api/pagos/iniciar y navega al checkout
+// pasando el response en el state de navegación.
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, afterEach } from 'vitest';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { http, HttpResponse } from 'msw';
+import { AuthContext } from '../context/AuthContext';
+import { MisReservasPage } from '../pages/MisReservasPage';
+import { server } from './mocks/server';
+
+afterEach(() => server.resetHandlers());
+
+function authValue(userId: number | null = 42) {
+  return {
+    accessToken: 'user.jwt.token',
+    role: 'USER',
+    mustChangePassword: false,
+    userId,
+    isAuthenticated: true,
+    setAccessToken: () => {},
+    setSession: () => {},
+    clearMustChangePassword: () => {},
+    loadUserId: async () => {},
+  };
+}
+
+// Stub del checkout: expone el redsysUrl recibido por el state para verificar que la
+// navegación propaga el response de iniciar pago.
+function CheckoutStub() {
+  const location = useLocation();
+  const state = location.state as { pago?: { redsysUrl?: string } } | null;
+  return <div>Checkout · {state?.pago?.redsysUrl ?? 'sin-datos'}</div>;
+}
+
+function renderPage(userId: number | null = 42) {
+  return render(
+    <AuthContext.Provider value={authValue(userId)}>
+      <MemoryRouter initialEntries={['/reservas/mias']}>
+        <Routes>
+          <Route path="/reservas/mias" element={<MisReservasPage />} />
+          <Route path="/pagos/checkout" element={<CheckoutStub />} />
+          <Route path="/home" element={<div>Home</div>} />
+          <Route path="/reservas/detalle/:id" element={<div>Detalle</div>} />
+        </Routes>
+      </MemoryRouter>
+    </AuthContext.Provider>
+  );
+}
+
+function reserva(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'r-1',
+    reservationDate: '2026-07-10',
+    startTime: '20:00',
+    durationMinutes: 60,
+    status: 'CONFIRMED',
+    channel: 'WEB',
+    ownerId: 42,
+    priceTotal: 16,
+    participants: [],
+    pago: { id: 'p-1', reservaId: 'r-1', amount: 16, status: 'PENDING', createdAt: 't' },
+    createdAt: 't',
+    ...overrides,
+  };
+}
+
+const INICIAR_OK = {
+  pagoId: 'p-1',
+  redsysOrderId: '0001abc',
+  redsysUrl: 'https://sis-t.redsys.es/sis/realizarPago',
+  amount: 16,
+  status: 'IN_PROGRESS',
+  dsSignatureVersion: 'HMAC_SHA256_V1',
+  dsMerchantParameters: 'base64params',
+  dsSignature: 'firma',
+};
+
+describe('MisReservasPage — "pagar ahora" (Grupo 6)', () => {
+  it('owner con pago PENDING ve "Pagar ahora" activo', async () => {
+    server.use(http.get('/api/reservas', () => HttpResponse.json([reserva()])));
+    renderPage();
+
+    await screen.findByText('20:00');
+    const btn = screen.getByRole('button', { name: /pagar ahora/i });
+    expect(btn).toBeEnabled();
+    expect(btn).not.toHaveTextContent(/próximamente/i);
+  });
+
+  it('al pulsar "Pagar ahora" llama a iniciar pago y navega al checkout con el response', async () => {
+    let capturedBody: Record<string, unknown> = {};
+    server.use(
+      http.get('/api/reservas', () => HttpResponse.json([reserva()])),
+      http.post('/api/pagos/iniciar', async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(INICIAR_OK, { status: 200 });
+      })
+    );
+    renderPage();
+
+    await screen.findByText('20:00');
+    await userEvent.click(screen.getByRole('button', { name: /pagar ahora/i }));
+
+    expect(await screen.findByText(/checkout ·/i)).toHaveTextContent(INICIAR_OK.redsysUrl);
+    expect(capturedBody).toEqual({ reservaId: 'r-1' });
+  });
+
+  it('no muestra "Pagar ahora" a quien no es owner', async () => {
+    server.use(http.get('/api/reservas', () => HttpResponse.json([reserva()])));
+    renderPage(99);
+
+    await screen.findByText('20:00');
+    expect(screen.queryByRole('button', { name: /pagar ahora/i })).toBeNull();
+  });
+
+  it('no muestra "Pagar ahora" si el pago no está PENDING (IN_PROGRESS)', async () => {
+    server.use(
+      http.get('/api/reservas', () =>
+        HttpResponse.json([
+          reserva({ pago: { id: 'p-1', reservaId: 'r-1', amount: 16, status: 'IN_PROGRESS', createdAt: 't' } }),
+        ])
+      )
+    );
+    renderPage();
+
+    await screen.findByText('20:00');
+    expect(screen.queryByRole('button', { name: /pagar ahora/i })).toBeNull();
+  });
+
+  it('muestra error si iniciar pago falla con 409 (pago ya en curso)', async () => {
+    server.use(
+      http.get('/api/reservas', () => HttpResponse.json([reserva()])),
+      http.post('/api/pagos/iniciar', () =>
+        HttpResponse.json({ error: 'CONFLICT', message: 'Ya hay un pago activo.', timestamp: 't' }, { status: 409 })
+      )
+    );
+    renderPage();
+
+    await screen.findByText('20:00');
+    await userEvent.click(screen.getByRole('button', { name: /pagar ahora/i }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/ya está en curso/i);
+  });
+});

--- a/frontend/src/test/PagoConfirmadoPage.test.tsx
+++ b/frontend/src/test/PagoConfirmadoPage.test.tsx
@@ -1,0 +1,108 @@
+// pagos-redsys-online (Grupo 6, D6) — PagoConfirmadoPage — TDD.
+// La página de retorno del TPV NO confía en la URL: consulta GET /api/pagos y
+// muestra el estado real del pago de la reserva (por reservaId de la query):
+//   - PAID → éxito con código de reserva + referencia Redsys + importe.
+//   - FAILED → pago no completado.
+//   - IN_PROGRESS/PENDING (o pago no encontrado) → "procesando" con Actualizar
+//     (el webhook puede tardar); al pulsar, re-consulta y refleja el nuevo estado.
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, afterEach } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { http, HttpResponse } from 'msw';
+import { AuthContext } from '../context/AuthContext';
+import { PagoConfirmadoPage } from '../pages/PagoConfirmadoPage';
+import { server } from './mocks/server';
+
+afterEach(() => server.resetHandlers());
+
+function authValue() {
+  return {
+    accessToken: 'user.jwt.token',
+    role: 'USER',
+    mustChangePassword: false,
+    userId: 42,
+    isAuthenticated: true,
+    setAccessToken: () => {},
+    setSession: () => {},
+    clearMustChangePassword: () => {},
+    loadUserId: async () => {},
+  };
+}
+
+function renderPage(query = '?reservaId=r-1') {
+  return render(
+    <AuthContext.Provider value={authValue()}>
+      <MemoryRouter initialEntries={[`/pagos/ok${query}`]}>
+        <Routes>
+          <Route path="/pagos/ok" element={<PagoConfirmadoPage />} />
+          <Route path="/reservas/mias" element={<div>Mis reservas</div>} />
+          <Route path="/reservas/detalle/:id" element={<div>Detalle reserva</div>} />
+        </Routes>
+      </MemoryRouter>
+    </AuthContext.Provider>
+  );
+}
+
+describe('PagoConfirmadoPage — estado real por backend (no confía en la URL)', () => {
+  it('PAID: muestra confirmación con código de reserva, referencia Redsys e importe', async () => {
+    server.use(
+      http.get('/api/pagos', () =>
+        HttpResponse.json([
+          {
+            id: 'p-1',
+            reservaId: 'r-1',
+            amount: 16,
+            method: 'REDSYS',
+            status: 'PAID',
+            paidAt: '2026-07-05T10:00:00Z',
+            transactionId: 'AUTH-998877',
+          },
+        ])
+      )
+    );
+    renderPage();
+
+    expect(await screen.findByText(/reservada/i)).toBeInTheDocument();
+    expect(screen.getByText('r-1')).toBeInTheDocument();
+    expect(screen.getByText('AUTH-998877')).toBeInTheDocument();
+    expect(screen.getByText(/16,00\s*€/)).toBeInTheDocument();
+    expect(screen.getByText('✓ Confirmado')).toBeInTheDocument();
+  });
+
+  it('FAILED: informa de pago no completado', async () => {
+    server.use(
+      http.get('/api/pagos', () =>
+        HttpResponse.json([{ id: 'p-1', reservaId: 'r-1', amount: 16, status: 'FAILED' }])
+      )
+    );
+    renderPage();
+
+    expect(await screen.findByText(/no se ha completado/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /mis reservas/i })).toBeInTheDocument();
+  });
+
+  it('IN_PROGRESS: muestra "procesando" y al Actualizar re-consulta y refleja PAID', async () => {
+    let estado = 'IN_PROGRESS';
+    server.use(
+      http.get('/api/pagos', () =>
+        HttpResponse.json([{ id: 'p-1', reservaId: 'r-1', amount: 16, status: estado }])
+      )
+    );
+    renderPage();
+
+    expect(await screen.findByText(/procesando/i)).toBeInTheDocument();
+
+    // El webhook confirma; al refrescar, la página lo refleja.
+    estado = 'PAID';
+    await userEvent.click(screen.getByRole('button', { name: /actualizar/i }));
+
+    await waitFor(() => expect(screen.getByText(/reservada/i)).toBeInTheDocument());
+  });
+
+  it('pago aún no encontrado en el historial → "procesando" (webhook pendiente)', async () => {
+    server.use(http.get('/api/pagos', () => HttpResponse.json([])));
+    renderPage();
+    expect(await screen.findByText(/procesando/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/pagosApi.test.ts
+++ b/frontend/src/test/pagosApi.test.ts
@@ -1,0 +1,147 @@
+// pagos-redsys-online (Grupo 6) — pagosApi — TDD contra MSW.
+//  - iniciarPago: POST /api/pagos/iniciar con Bearer + { reservaId }, devuelve el
+//    form firmado (redsysUrl + los tres campos ds*); mapea 403/404/409/422.
+//  - getPagos: GET /api/pagos (array plano) con y sin token (fail-safe de retorno TPV).
+import { describe, it, expect, afterEach } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from './mocks/server';
+import { iniciarPago, getPagos } from '../services/pagosApi';
+import { ReservaApiError, isReservaApiError } from '../services/reservasApi';
+
+const TOKEN = 'user.jwt.token';
+
+afterEach(() => server.resetHandlers());
+
+const INICIAR_OK = {
+  pagoId: 'p-1',
+  redsysOrderId: '0001abc',
+  redsysUrl: 'https://sis-t.redsys.es:25443/sis/realizarPago',
+  amount: 16,
+  status: 'IN_PROGRESS',
+  dsSignatureVersion: 'HMAC_SHA256_V1',
+  dsMerchantParameters: 'eyJEc19NZXJjaGFudF9BbW91bnQiOiIxNjAwIn0=',
+  dsSignature: 'firma-base64-abc',
+};
+
+describe('pagosApi — iniciarPago', () => {
+  it('POST /api/pagos/iniciar con Bearer y { reservaId }, devuelve el form firmado', async () => {
+    let capturedAuth = '';
+    let capturedBody: Record<string, unknown> = {};
+    server.use(
+      http.post('/api/pagos/iniciar', async ({ request }) => {
+        capturedAuth = request.headers.get('Authorization') ?? '';
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(INICIAR_OK, { status: 200 });
+      })
+    );
+
+    const resp = await iniciarPago(TOKEN, 'r-1');
+
+    expect(capturedAuth).toBe(`Bearer ${TOKEN}`);
+    expect(capturedBody).toEqual({ reservaId: 'r-1' });
+    // El cliente nunca envía importe (RN-RES-03): lo congela el backend.
+    expect(capturedBody).not.toHaveProperty('amount');
+    expect(resp.redsysUrl).toContain('redsys');
+    expect(resp.dsSignatureVersion).toBe('HMAC_SHA256_V1');
+    expect(resp.dsMerchantParameters).toBe(INICIAR_OK.dsMerchantParameters);
+    expect(resp.dsSignature).toBe('firma-base64-abc');
+    expect(resp.status).toBe('IN_PROGRESS');
+  });
+
+  it('mapea 403 (no owner)', async () => {
+    server.use(
+      http.post('/api/pagos/iniciar', () =>
+        HttpResponse.json(
+          { error: 'FORBIDDEN', message: 'No eres el propietario.', timestamp: 't' },
+          { status: 403 }
+        )
+      )
+    );
+    const err = await iniciarPago(TOKEN, 'r-1').catch((e) => e);
+    expect(isReservaApiError(err)).toBe(true);
+    expect(err).toBeInstanceOf(ReservaApiError);
+    expect(err.code).toBe('FORBIDDEN');
+    expect(err.status).toBe(403);
+  });
+
+  it('mapea 404 (reserva inexistente)', async () => {
+    server.use(
+      http.post('/api/pagos/iniciar', () =>
+        HttpResponse.json({ error: 'NOT_FOUND', message: 'No existe.', timestamp: 't' }, { status: 404 })
+      )
+    );
+    const err = await iniciarPago(TOKEN, 'nope').catch((e) => e);
+    expect(err.code).toBe('NOT_FOUND');
+    expect(err.status).toBe(404);
+  });
+
+  it('mapea 409 (pago ya en curso o pagado)', async () => {
+    server.use(
+      http.post('/api/pagos/iniciar', () =>
+        HttpResponse.json(
+          { error: 'CONFLICT', message: 'Ya hay un pago activo.', timestamp: 't' },
+          { status: 409 }
+        )
+      )
+    );
+    const err = await iniciarPago(TOKEN, 'r-1').catch((e) => e);
+    expect(err.code).toBe('CONFLICT');
+    expect(err.status).toBe(409);
+  });
+
+  it('mapea 422 (reserva cancelada)', async () => {
+    server.use(
+      http.post('/api/pagos/iniciar', () =>
+        HttpResponse.json(
+          { error: 'INVALID_STATE_TRANSITION', message: 'Reserva cancelada.', timestamp: 't' },
+          { status: 422 }
+        )
+      )
+    );
+    const err = await iniciarPago(TOKEN, 'r-1').catch((e) => e);
+    expect(err.code).toBe('INVALID_STATE_TRANSITION');
+    expect(err.status).toBe(422);
+  });
+});
+
+describe('pagosApi — getPagos', () => {
+  it('GET /api/pagos con Bearer devuelve el array plano', async () => {
+    let capturedAuth = '';
+    server.use(
+      http.get('/api/pagos', ({ request }) => {
+        capturedAuth = request.headers.get('Authorization') ?? '';
+        return HttpResponse.json([
+          { id: 'p-1', reservaId: 'r-1', amount: 16, method: 'REDSYS', status: 'PAID', paidAt: 't' },
+        ]);
+      })
+    );
+
+    const result = await getPagos(TOKEN);
+    expect(capturedAuth).toBe(`Bearer ${TOKEN}`);
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe('PAID');
+  });
+
+  it('normaliza un cuerpo paginado { data: [...] } (fail-safe)', async () => {
+    server.use(
+      http.get('/api/pagos', () =>
+        HttpResponse.json({ data: [{ id: 'p-2', reservaId: 'r-2', amount: 20, status: 'FAILED' }] })
+      )
+    );
+    const result = await getPagos(TOKEN);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('p-2');
+  });
+
+  it('sin token no envía header Authorization (retorno del TPV)', async () => {
+    let hadAuth = true;
+    server.use(
+      http.get('/api/pagos', ({ request }) => {
+        hadAuth = request.headers.has('Authorization');
+        return HttpResponse.json([]);
+      })
+    );
+    await getPagos(null);
+    expect(hadAuth).toBe(false);
+  });
+});

--- a/openspec/changes/pagos-redsys-online/.openspec.yaml
+++ b/openspec/changes/pagos-redsys-online/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-05

--- a/openspec/changes/pagos-redsys-online/design.md
+++ b/openspec/changes/pagos-redsys-online/design.md
@@ -1,0 +1,57 @@
+## Context
+
+`payments` está creada (V9) con todo lo necesario para Redsys: `redsys_order_id` (UNIQUE, idempotencia RN-PAY-02), `payment_url`, `transaction_id` (Ds_AuthorisationCode), `gateway`, `method` (REDSYS/CASH), `status` (PENDING/IN_PROGRESS/PAID/FAILED/CANCELLED/REFUNDED), `paid_at`, `registered_by_id`. Cada reserva nace con un `Payment` en PENDING (importe congelado). `system_config` guarda `payment_gateway` (CASH/REDSYS), `redsys_merchant_id`, `redsys_merchant_key` cifrados AES-256; **falta `redsys_terminal`**. No hay endpoints de pago ni firma. El servicio de cifrado y el descifrado de secretos de `system_config` ya existen (usados por `configuracion-club`).
+
+Protocolo Redsys (redirección): el backend envía al TPV un form con `Ds_SignatureVersion=HMAC_SHA256_V1`, `Ds_MerchantParameters` (Base64 del JSON de parámetros, incluido `Ds_Merchant_Order`, `Ds_Merchant_Amount` en céntimos, `Ds_Merchant_MerchantCode`, `Ds_Merchant_Terminal`, `Ds_Merchant_MerchantURL` = webhook, `Ds_Merchant_UrlOK/UrlKO`) y `Ds_Signature` = HMAC-SHA256 de `Ds_MerchantParameters` usando una clave por-pedido derivada (3DES del `Ds_Merchant_Order` con la clave secreta del comercio). El webhook recibe los mismos tres campos y se valida recomputando la firma.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Owner paga online el total de su reserva vía Redsys, con importe congelado en backend (RN-RES-03).
+- Webhook robusto: firma válida en tiempo constante, idempotente, rechazo silencioso de firma inválida, nunca toca datos de tarjeta.
+- Registro de pago en efectivo por ADMIN e historial de pagos.
+- Testable sin credenciales reales del club (entorno sandbox Redsys).
+
+**Non-Goals:**
+- Pago compartido por participante (owner paga el total).
+- Reembolso real en TPV, tokenización de tarjeta, panel de conciliación.
+
+## Decisions
+
+### D1 — Nuevo submódulo/paquete `pagos` dentro del backend
+La lógica de pago (servicios, controllers, firma, DTOs) vive en su propio paquete (`com.padelpro.pagos` o `reservas.pagos`), reutilizando la entidad `Payment` y sus puertos. *Alternativa descartada:* meterlo en `reservas` — pago tiene su propio ciclo, seguridad (webhook sin JWT) y dependencias (cifrado, Redsys); separarlo mantiene la cohesión.
+
+### D2 — Firma Redsys encapsulada en una utilidad probada por unit test
+Una clase `RedsysSignature` implementa: derivar la clave por-pedido (3DES/CBC del `Ds_Merchant_Order` con la clave secreta Base64 del comercio) y calcular/verificar el HMAC-SHA256 de `Ds_MerchantParameters`. La comparación de firmas es en **tiempo constante** (`MessageDigest.isEqual`), RN-PAY-01 y caso límite de timing. Se testea con vectores del entorno de pruebas Redsys (clave sandbox pública). *Alternativa descartada:* librería de terceros — el algoritmo es corto y auditable; evitar dependencia con CVEs.
+
+### D3 — Webhook: validar firma antes de tocar nada, idempotente, siempre 200
+`ProcesarWebhookService`: (1) parsea `Ds_MerchantParameters` (Base64→JSON), (2) recomputa y compara la firma en tiempo constante; si no coincide → audita `PAYMENT_WEBHOOK_INVALID_SIGNATURE` (CRÍTICO) y responde **200** sin tocar el pago (RN-PAY-01); (3) localiza el pago por `redsys_order_id`; si ya está `PAID` → no reprocesa (RN-PAY-02) y responde 200; (4) según `Ds_Response` (`0000..0099` = OK) → `PAID` + `transaction_id` + `paid_at` + audita `PAYMENT_CONFIRMED`; si rechazo → `FAILED` + audita `PAYMENT_REJECTED`. Siempre 200 a Redsys para no provocar reintentos innecesarios. *Alternativa descartada:* responder 4xx en firma inválida — revelaría el rechazo a un atacante y provocaría reintentos.
+
+### D4 — `redsys_terminal` como nueva columna cifrable en `system_config`
+Migración Flyway pequeña que añade `redsys_terminal` (TEXT). Se lee/descifra con el mismo mecanismo que `merchant_id`/`merchant_key`. Default operativo "1" si no está configurado. *Alternativa considerada:* derivarlo del merchant_id — no es correcto; el terminal es un dato propio del comercio.
+
+### D5 — Iniciar pago: transición atómica PENDING→IN_PROGRESS y guardas de estado
+`IniciarPagoService`: valida owner (403), reserva existe (404) y no cancelada (422), pago en `PENDING` (si `IN_PROGRESS`/`PAID` → 409), genera `redsys_order_id` (formato Redsys: 4 dígitos numéricos + alfanumérico, único), calcula el form firmado, marca `IN_PROGRESS` y persiste `payment_url`. Importe = `PriceCalculator` de backend, en céntimos para Redsys (RN-RES-03). Auditoría `PAYMENT_INITIATED`.
+
+### D6 — Frontend: auto-submit del form al TPV, retorno por UrlOK/UrlKO + verificación por webhook
+La `CheckoutRedsysPage` construye un form oculto con los 3 campos y hace auto-submit al `redsysUrl` (redirección del navegador al TPV; los datos de tarjeta nunca tocan PadelPro). El **estado real del pago lo fija el webhook** (server-to-server), no el retorno del navegador; `PagoConfirmadoPage` (UrlOK/UrlKO) consulta el estado del pago del backend para mostrarlo (no confía en parámetros de la URL de retorno). *Alternativa descartada:* confiar en el retorno del navegador para marcar PAID — manipulable; el webhook es la fuente de verdad.
+
+## Risks / Trade-offs
+
+- [Sin credenciales reales del club no se puede probar end-to-end en prod] → Mitigación: usar el **entorno de pruebas Redsys** (comercio sandbox público) para dev/test; producción configura credenciales reales cifradas en `system_config`. Los unit tests de firma usan vectores conocidos.
+- [El webhook llega sin JWT: superficie de ataque] → Mitigación: única protección válida = firma HMAC en tiempo constante; rechazo silencioso; sin efectos secundarios antes de validar; rate limiting del endpoint.
+- [Datos de tarjeta llegan por error a un campo] → Mitigación: el backend solo lee los campos Redsys esperados; nunca persiste ni loguea el cuerpo crudo (RN-PAY-03); revisar que ningún logger vuelca `Ds_MerchantParameters` completo.
+- [Retorno del navegador y webhook compiten (usuario vuelve antes que el webhook)] → Mitigación: `PagoConfirmadoPage` muestra "procesando" y refresca el estado; el webhook es idempotente y autoritativo.
+- [Firma mal derivada (3DES) rompe todo silenciosamente] → Mitigación: unit tests de `RedsysSignature` con vectores del sandbox; test de round-trip (firmar→verificar).
+
+## Migration Plan
+
+- Una migración Flyway (siguiente Vn) añade `redsys_terminal` a `system_config` (nullable, cifrable). Sin otros cambios de esquema (`payments` ya está completa).
+- Despliegue: backend + frontend aditivos. `payment_gateway` sigue en CASH por defecto; activar REDSYS por config cuando haya credenciales. Rollback = revertir; los pagos existentes (PENDING/CASH) no se ven afectados.
+
+## Open Questions
+
+Resueltas en revisión (2026-07-05):
+- **Credenciales** → entorno de pruebas (sandbox) de Redsys para dev/test; reales en prod vía `system_config` cifrado.
+- **`redsys_terminal`** → migración Flyway con columna nueva (cifrable, default "1").
+- **Activación** → `payment_gateway` queda en CASH por defecto; REDSYS se activa por config cuando haya credenciales reales.

--- a/openspec/changes/pagos-redsys-online/proposal.md
+++ b/openspec/changes/pagos-redsys-online/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+El pago online está definido (`pagos-redsys` spec + mockups 09/10) pero **sin implementar**: no existe ningún endpoint de pago (`/api/pagos/*`), ni firma HMAC, ni webhook. Hoy el cobro es solo presencial (CASH, confirmado por ADMIN de forma manual — y ese registro tampoco tiene endpoint). El botón "pagar ahora" que dejamos deshabilitado en `reservas-ui-jugador-fixes` sigue muerto. Es el candidato Wave 4A y cierra el bucle de pago diferido dos veces (reservas y partidas).
+
+La base de datos ya está lista (`payments` con `redsys_order_id` UNIQUE, `payment_url`, `transaction_id`, `gateway`, `method`, `status` con todas las transiciones, `paid_at`, `registered_by_id`; `system_config` con `payment_gateway`, `redsys_merchant_id`, `redsys_merchant_key` cifrados). El gap es la lógica de aplicación + un pequeño ajuste de config (`redsys_terminal`).
+
+## What Changes
+
+- **[Backend] `POST /api/pagos/iniciar`** (solo owner, RN-AUTH-04): genera los parámetros del TPV Redsys firmados con **HMAC SHA-256** (importe congelado en backend RN-RES-03), pasa el pago a `IN_PROGRESS`, audita `PAYMENT_INITIATED`, y devuelve `redsysUrl` + parámetros firmados para redirigir al TPV. 403 si no es owner, 404 si la reserva no existe, 409 si ya hay pago activo/pagado, 422 si la reserva está cancelada.
+- **[Backend] `POST /api/pagos/webhook`** (server-to-server, sin JWT): valida la firma HMAC en **tiempo constante** (RN-PAY-01); si es válida → `PAID`/`FAILED` según `Ds_Response`, registra `transaction_id`, audita; **idempotente** ante reintentos (RN-PAY-02); firma inválida → **rechazo silencioso** (200 a Redsys) + `PAYMENT_WEBHOOK_INVALID_SIGNATURE` en audit. Nunca almacena ni loguea datos de tarjeta (RN-PAY-03).
+- **[Backend] `POST /api/admin/pagos/{reservaId}/efectivo`** (ADMIN): registra pago en efectivo → `PAID`, `method=CASH`, `registered_by_id`, audita `PAYMENT_CASH_REGISTERED`.
+- **[Backend] `GET /api/pagos`** (propios) y **`GET /api/admin/pagos`** (todos): historial de pagos.
+- **[Config] `redsys_terminal`** en `system_config` (migración Flyway pequeña; hoy hay `merchant_id`/`merchant_key` pero no terminal). Descifrado con el servicio AES-256 existente.
+- **[Frontend] Checkout Redsys** (mockup 09): tras confirmar/elegir "pagar ahora", auto-envía el formulario firmado al TPV de Redsys (los datos de tarjeta NUNCA pasan por PadelPro, RN-PAY-03). **Pago confirmado** (mockup 10): pantalla de retorno con estado, código de reserva y referencia Redsys.
+- **[Frontend] Activar "pagar ahora"** en Mis Reservas (hoy deshabilitado desde `reservas-ui-jugador-fixes`).
+
+## Capabilities
+
+### New Capabilities
+<!-- Ninguna nueva: `pagos-redsys` ya existe como spec; este change la implementa. -->
+
+### Modified Capabilities
+- `pagos-redsys`: se implementan sus 5 requirements (iniciar pago firmado, webhook válido, rechazo de firma inválida, idempotencia, pago en efectivo ADMIN).
+- `reservas`: se activa la acción "pagar ahora" en la UI y la reserva puede reflejar el estado de pago actualizado tras la confirmación (sin cambiar la lógica de dominio de creación/cancelación).
+
+## Impact
+
+- **Fase del producto**: fase-1 (`pagos-redsys` es fase-1, Wave 4A).
+- **Backend** (`com.padelpro.reservas`/pagos): nuevos servicios `IniciarPagoService`, `ProcesarWebhookService`, `RegistrarPagoEfectivoService`, `PagoQueryService`; `PagoController` + `AdminPagoController` + webhook; utilidad de firma Redsys (HMAC SHA-256 sobre `Ds_MerchantParameters` con clave 3DES-derivada por pedido, según el protocolo Redsys); puertos de comando/consulta de `Payment`; eventos de auditoría. Alinear `docs/openapi.yaml` con lo implementado.
+- **Frontend** (`frontend/src/`): `CheckoutRedsysPage` (auto-submit del form firmado), `PagoConfirmadoPage` (retorno); activar "pagar ahora" en `MisReservasPage`; funciones de pago en un service.
+- **Config/Datos**: migración Flyway `redsys_terminal` en `system_config`. El resto del esquema de `payments` ya existe (sin migración). Credenciales: **entorno de pruebas Redsys (comercio sandbox)** para dev/test; producción vía `system_config` cifrado.
+- **Seguridad**: firma HMAC en tiempo constante; datos de tarjeta fuera de PadelPro; webhook sin JWT protegido solo por firma; secretos descifrados en memoria (AES-256 existente). Auditoría de todos los eventos de pago.
+
+## Fuera de alcance
+
+- **Pago compartido por participante** ("tu parte" de partidas) — el spec de `pagos-redsys` es *owner paga el total* (RN-AUTH-04). El split 1:N (varios `Payment` por reserva / FK a participante) es una extensión posterior; aquí el owner paga el importe completo.
+- **Reembolsos automáticos vía Redsys** más allá del marcado de estado `REFUNDED` existente al cancelar. La devolución real en el TPV es un flujo posterior.
+- **Tokenización / tarjeta guardada** (el mockup muestra "tarjeta guardada" como preview) — no se almacena ni tokeniza tarjeta en v1.
+- **Panel admin de conciliación de pagos** (mockup 23, "reservas del club") — capability `administracion-club`.

--- a/openspec/changes/pagos-redsys-online/specs/pagos-redsys/spec.md
+++ b/openspec/changes/pagos-redsys-online/specs/pagos-redsys/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: Iniciar pago online con formulario Redsys firmado
+El sistema SHALL exponer `POST /api/pagos/iniciar` que, solo para el owner de la reserva (RN-AUTH-04), genera los parámetros del TPV Redsys firmados con HMAC SHA-256 (importe congelado en backend, RN-RES-03), pasa el pago a `IN_PROGRESS`, audita `PAYMENT_INITIATED` y devuelve `redsysUrl` + parámetros para redirigir al TPV.
+
+#### Scenario: Owner inicia el pago de su reserva
+- **WHEN** el owner de una reserva con pago `PENDING` envía `POST /api/pagos/iniciar` con su `reservaId`
+- **THEN** el sistema responde 200 con `{pagoId, redsysOrderId, redsysUrl, amount, status:"IN_PROGRESS"}`, el `amount` es el calculado en backend, el pago pasa a `IN_PROGRESS` y se audita `PAYMENT_INITIATED`
+
+#### Scenario: No-owner no puede iniciar el pago
+- **WHEN** un participante no-owner intenta iniciar el pago de la reserva
+- **THEN** el sistema responde 403 y el pago no cambia de estado
+
+#### Scenario: Reserva inexistente o no pagable
+- **WHEN** se inicia el pago de una reserva inexistente / cancelada / con pago ya `IN_PROGRESS` o `PAID`
+- **THEN** el sistema responde 404 / 422 / 409 respectivamente, sin generar una transacción nueva
+
+#### Scenario: El importe del cliente se ignora
+- **WHEN** el cliente incluye un importe en el cuerpo
+- **THEN** el `Ds_Merchant_Amount` enviado a Redsys corresponde siempre al importe calculado en backend (en céntimos)
+
+### Requirement: Procesar webhook Redsys con firma válida
+El sistema SHALL exponer `POST /api/pagos/webhook` (sin JWT) que valida la firma HMAC SHA-256 en tiempo constante y, si es válida, actualiza el pago a `PAID` (o `FAILED` según `Ds_Response`), registra `transaction_id` y audita el evento. Responde siempre 200 a Redsys.
+
+#### Scenario: Webhook válido con pago aprobado
+- **WHEN** Redsys notifica con firma válida y `Ds_Response` de aprobación para un pago en `IN_PROGRESS`
+- **THEN** el sistema responde 200, el pago pasa a `PAID` con `paid_at` y `transaction_id`, y audita `PAYMENT_CONFIRMED`
+
+#### Scenario: Webhook válido con pago rechazado
+- **WHEN** Redsys notifica con firma válida y `Ds_Response` de rechazo
+- **THEN** el sistema responde 200, el pago pasa a `FAILED` y audita `PAYMENT_REJECTED`
+
+### Requirement: Rechazo silencioso de webhook con firma inválida
+El sistema SHALL responder 200 a Redsys, NO alterar el estado del pago y auditar `PAYMENT_WEBHOOK_INVALID_SIGNATURE` cuando la firma HMAC no coincide, sin procesar ningún campo del cuerpo como lógica de negocio.
+
+#### Scenario: Firma inválida
+- **WHEN** llega un webhook cuya `Ds_Signature` no corresponde a la clave configurada
+- **THEN** el sistema responde 200, el pago no cambia y se audita `PAYMENT_WEBHOOK_INVALID_SIGNATURE`
+
+### Requirement: Idempotencia ante webhooks duplicados
+El sistema SHALL ignorar un webhook cuyo pago ya está en `PAID` sin reprocesarlo, y garantizar unicidad por `redsys_order_id` (RN-PAY-02).
+
+#### Scenario: Reintento de Redsys sobre un pago ya confirmado
+- **WHEN** Redsys reenvía el mismo webhook (firma válida) para un pago ya `PAID`
+- **THEN** el sistema responde 200 y el pago permanece `PAID` sin nueva confirmación duplicada
+
+### Requirement: Registro de pago en efectivo por ADMIN
+El sistema SHALL exponer `POST /api/admin/pagos/{reservaId}/efectivo` (solo ADMIN) que marca el pago como `PAID`, `method=CASH`, `registered_by_id` = ADMIN, y audita `PAYMENT_CASH_REGISTERED`.
+
+#### Scenario: ADMIN registra efectivo
+- **WHEN** el ADMIN registra el pago en efectivo de una reserva con pago `PENDING`
+- **THEN** el pago pasa a `PAID`/`CASH` con `registered_by_id` del ADMIN y se audita `PAYMENT_CASH_REGISTERED`
+
+#### Scenario: USER no puede registrar efectivo
+- **WHEN** un USER llama al endpoint de efectivo
+- **THEN** el sistema responde 403
+
+#### Scenario: Reserva ya cobrada
+- **WHEN** el ADMIN registra efectivo de una reserva cuyo pago ya está `PAID`
+- **THEN** el sistema responde 422 indicando que ya está cobrada
+
+### Requirement: Los datos de tarjeta nunca se almacenan ni registran
+El sistema NO SHALL almacenar ni registrar en logs datos de tarjeta (PAN, CVV, caducidad, titular). Solo persiste `redsys_order_id` y `transaction_id`. La comparación de firma se realiza en tiempo constante.
+
+#### Scenario: Ningún dato de tarjeta persiste ni se loguea
+- **WHEN** se procesa cualquier operación de pago
+- **THEN** no se almacena ni aparece en logs ningún dato de tarjeta; solo `redsys_order_id`/`transaction_id`

--- a/openspec/changes/pagos-redsys-online/tasks.md
+++ b/openspec/changes/pagos-redsys-online/tasks.md
@@ -36,7 +36,13 @@
 ## 7. QA
 
 - [ ] 7.1 **[Refactor]** Limpieza manteniendo verde
-- [ ] 7.2 `security-auditor`: firma en tiempo constante, webhook sin efectos antes de validar, no exposición de secretos/tarjeta en logs (RN-PAY-03), idempotencia, rate limit del webhook
+- [x] 7.2 `security-auditor`: firma en tiempo constante, webhook sin efectos antes de validar, no exposición de secretos/tarjeta en logs (RN-PAY-03), idempotencia, rate limit del webhook
+  - **Fixes de seguridad aplicados (2026-07-05, TDD Red→Green):**
+    - **MEDIO-1** Rate limit del webhook: `POST /api/pagos/webhook` ahora limitado a 60/min por IP en `RateLimitFilter` (público, sin JWT). Test `RateLimitFilterWebhookTest` (dentro/fuera del límite, por-IP).
+    - **MEDIO-2** Carrera en idempotencia: `findByRedsysOrderIdForUpdate` (`@Lock PESSIMISTIC_WRITE`, sin migración ni `@Version`) en puerto/adapter/repo de Payment; el webhook lo usa dentro de `@Transactional`. La 2ª notificación espera, re-lee PAID y no reprocesa. Tests: finder con lock + un solo `markPaid`/`PAYMENT_CONFIRMED` en duplicado.
+    - **MEDIO-3** Log-injection/XSS: `Ds_Order` sanitizado (`^[0-9A-Za-z]{1,32}$` → si no cumple, `<invalid-format>`) en TODOS los puntos de auditoría. Tests con `<script>` y salto de línea.
+    - **BAJO-2** `Ds_SignatureVersion` != `HMAC_SHA256_V1` → rechazado como firma inválida antes de verificar. Test incluido.
+  - Verificado: 11 tests unitarios de `ProcesarWebhookServiceTest` + 3 de `RateLimitFilterWebhookTest` en verde; boot del contexto Spring (JPA `@Query`/`@Lock`) validado contra Postgres real (IT en verde).
 - [ ] 7.3 `verification-specialist`: build + tests (backend maven, frontend vitest) + lint; probes de firma inválida/duplicado/no-owner
 - [ ] 7.4 `reality-checker`: journey de pago end-to-end contra el sandbox Redsys (iniciar → TPV test → webhook → PAID) — live E2E puede diferirse si requiere despliegue/túnel para el webhook
 - [ ] 7.5 Actualizar `docs/openapi.yaml` y verificar coherencia de todos los endpoints `/pagos/*`

--- a/openspec/changes/pagos-redsys-online/tasks.md
+++ b/openspec/changes/pagos-redsys-online/tasks.md
@@ -29,9 +29,9 @@
 
 ## 6. Frontend — checkout + confirmación (D6)
 
-- [ ] 6.1 **[Red]** Tests (MSW): iniciar pago devuelve redsysUrl+params → `CheckoutRedsysPage` construye el form y (mock) auto-submit; `PagoConfirmadoPage` consulta el estado del pago del backend (no confía en la URL de retorno) y muestra PAID/FAILED/procesando
-- [ ] 6.2 **[Green]** `CheckoutRedsysPage` (mockup 09, auto-submit del form firmado al TPV; datos de tarjeta fuera) + `PagoConfirmadoPage` (mockup 10, UrlOK/UrlKO → estado real por backend) + service de pagos + rutas
-- [ ] 6.3 **[Green]** Activar "pagar ahora" en `MisReservasPage` (hoy deshabilitado): llama a iniciar pago y redirige al checkout
+- [x] 6.1 **[Red]** Tests (MSW): iniciar pago devuelve redsysUrl+params → `CheckoutRedsysPage` construye el form y (mock) auto-submit; `PagoConfirmadoPage` consulta el estado del pago del backend (no confía en la URL de retorno) y muestra PAID/FAILED/procesando
+- [x] 6.2 **[Green]** `CheckoutRedsysPage` (mockup 09, auto-submit del form firmado al TPV; datos de tarjeta fuera) + `PagoConfirmadoPage` (mockup 10, UrlOK/UrlKO → estado real por backend) + service de pagos + rutas
+- [x] 6.3 **[Green]** Activar "pagar ahora" en `MisReservasPage` (hoy deshabilitado): llama a iniciar pago y redirige al checkout
 
 ## 7. QA
 

--- a/openspec/changes/pagos-redsys-online/tasks.md
+++ b/openspec/changes/pagos-redsys-online/tasks.md
@@ -4,28 +4,28 @@
 
 ## 1. Config — `redsys_terminal` + descifrado (D4)
 
-- [ ] 1.1 **[Red]** Test: `SystemConfig` expone `redsysTerminal` descifrado; default "1" si ausente
-- [ ] 1.2 **[Green]** Migración Flyway `Vn__add_redsys_terminal_to_system_config.sql` (TEXT, nullable, cifrable) + campo en la entidad/DTO + descifrado con el servicio AES-256 existente
+- [x] 1.1 **[Red]** Test: `SystemConfig` expone `redsysTerminal` descifrado; default "1" si ausente
+- [x] 1.2 **[Green]** Migración Flyway `Vn__add_redsys_terminal_to_system_config.sql` (TEXT, nullable, cifrable) + campo en la entidad/DTO + descifrado con el servicio AES-256 existente
 
 ## 2. Backend — firma Redsys (D2)
 
-- [ ] 2.1 **[Red]** Tests de `RedsysSignature` con vectores del sandbox: derivar clave por-pedido (3DES del `Ds_Merchant_Order`), calcular HMAC-SHA256 de `Ds_MerchantParameters`, round-trip firmar→verificar, comparación en tiempo constante (`MessageDigest.isEqual`)
-- [ ] 2.2 **[Green]** Utilidad `RedsysSignature` (firmar/verificar); sin dependencia de terceros; nunca loguea la clave
+- [x] 2.1 **[Red]** Tests de `RedsysSignature` con vectores del sandbox: derivar clave por-pedido (3DES del `Ds_Merchant_Order`), calcular HMAC-SHA256 de `Ds_MerchantParameters`, round-trip firmar→verificar, comparación en tiempo constante (`MessageDigest.isEqual`)
+- [x] 2.2 **[Green]** Utilidad `RedsysSignature` (firmar/verificar); sin dependencia de terceros; nunca loguea la clave
 
 ## 3. Backend — iniciar pago (D5)
 
-- [ ] 3.1 **[Red]** Tests `IniciarPagoService`: owner OK → IN_PROGRESS + form firmado + `PAYMENT_INITIATED`; no-owner → 403; reserva inexistente → 404; cancelada → 422; pago ya IN_PROGRESS/PAID → 409; importe del cliente ignorado (amount = backend en céntimos)
-- [ ] 3.2 **[Green]** `IniciarPagoService` + `PagoController` `POST /api/pagos/iniciar` + DTOs (request `reservaId`, response `pagoId/redsysOrderId/redsysUrl/amount/status`); genera `redsys_order_id` único; persiste `payment_url`; auditoría; documentar en openapi
+- [x] 3.1 **[Red]** Tests `IniciarPagoService`: owner OK → IN_PROGRESS + form firmado + `PAYMENT_INITIATED`; no-owner → 403; reserva inexistente → 404; cancelada → 422; pago ya IN_PROGRESS/PAID → 409; importe del cliente ignorado (amount = backend en céntimos)
+- [x] 3.2 **[Green]** `IniciarPagoService` + `PagoController` `POST /api/pagos/iniciar` + DTOs (request `reservaId`, response `pagoId/redsysOrderId/redsysUrl/amount/status`); genera `redsys_order_id` único; persiste `payment_url`; auditoría; documentar en openapi
 
 ## 4. Backend — webhook (D3)
 
-- [ ] 4.1 **[Red]** Tests `ProcesarWebhookService`: firma válida + aprobado → PAID + transaction_id + `PAYMENT_CONFIRMED`; firma válida + rechazo → FAILED + `PAYMENT_REJECTED`; firma inválida → 200 sin cambio + `PAYMENT_WEBHOOK_INVALID_SIGNATURE`; duplicado sobre PAID → 200 sin reproceso; order_id inexistente → 200 + alerta
-- [ ] 4.2 **[Green]** `ProcesarWebhookService` + `POST /api/pagos/webhook` (sin JWT, allowlist en SecurityConfig, rate limit); valida firma ANTES de tocar nada; idempotente; siempre 200; nunca persiste/loguea datos de tarjeta; documentar en openapi
+- [x] 4.1 **[Red]** Tests `ProcesarWebhookService`: firma válida + aprobado → PAID + transaction_id + `PAYMENT_CONFIRMED`; firma válida + rechazo → FAILED + `PAYMENT_REJECTED`; firma inválida → 200 sin cambio + `PAYMENT_WEBHOOK_INVALID_SIGNATURE`; duplicado sobre PAID → 200 sin reproceso; order_id inexistente → 200 + alerta
+- [x] 4.2 **[Green]** `ProcesarWebhookService` + `POST /api/pagos/webhook` (sin JWT, allowlist en SecurityConfig, rate limit); valida firma ANTES de tocar nada; idempotente; siempre 200; nunca persiste/loguea datos de tarjeta; documentar en openapi
 
 ## 5. Backend — efectivo ADMIN + historial
 
-- [ ] 5.1 **[Red]** Tests: ADMIN registra efectivo → PAID/CASH/registered_by + `PAYMENT_CASH_REGISTERED`; USER → 403; reserva ya PAID → 422. `GET /api/pagos` (propios) y `GET /api/admin/pagos` (todos)
-- [ ] 5.2 **[Green]** `RegistrarPagoEfectivoService` + `AdminPagoController` (`POST /api/admin/pagos/{reservaId}/efectivo`, `GET /api/admin/pagos`); `PagoQueryService` + `GET /api/pagos`; documentar en openapi
+- [x] 5.1 **[Red]** Tests: ADMIN registra efectivo → PAID/CASH/registered_by + `PAYMENT_CASH_REGISTERED`; USER → 403; reserva ya PAID → 422. `GET /api/pagos` (propios) y `GET /api/admin/pagos` (todos)
+- [x] 5.2 **[Green]** `RegistrarPagoEfectivoService` + `AdminPagoController` (`POST /api/admin/pagos/{reservaId}/efectivo`, `GET /api/admin/pagos`); `PagoQueryService` + `GET /api/pagos`; documentar en openapi
 
 ## 6. Frontend — checkout + confirmación (D6)
 

--- a/openspec/changes/pagos-redsys-online/tasks.md
+++ b/openspec/changes/pagos-redsys-online/tasks.md
@@ -35,7 +35,7 @@
 
 ## 7. QA
 
-- [ ] 7.1 **[Refactor]** Limpieza manteniendo verde
+- [x] 7.1 **[Refactor]** Limpieza manteniendo verde — sin deuda; paquete `pagos` propio, firma encapsulada
 - [x] 7.2 `security-auditor`: firma en tiempo constante, webhook sin efectos antes de validar, no exposición de secretos/tarjeta en logs (RN-PAY-03), idempotencia, rate limit del webhook
   - **Fixes de seguridad aplicados (2026-07-05, TDD Red→Green):**
     - **MEDIO-1** Rate limit del webhook: `POST /api/pagos/webhook` ahora limitado a 60/min por IP en `RateLimitFilter` (público, sin JWT). Test `RateLimitFilterWebhookTest` (dentro/fuera del límite, por-IP).
@@ -43,6 +43,6 @@
     - **MEDIO-3** Log-injection/XSS: `Ds_Order` sanitizado (`^[0-9A-Za-z]{1,32}$` → si no cumple, `<invalid-format>`) en TODOS los puntos de auditoría. Tests con `<script>` y salto de línea.
     - **BAJO-2** `Ds_SignatureVersion` != `HMAC_SHA256_V1` → rechazado como firma inválida antes de verificar. Test incluido.
   - Verificado: 11 tests unitarios de `ProcesarWebhookServiceTest` + 3 de `RateLimitFilterWebhookTest` en verde; boot del contexto Spring (JPA `@Query`/`@Lock`) validado contra Postgres real (IT en verde).
-- [ ] 7.3 `verification-specialist`: build + tests (backend maven, frontend vitest) + lint; probes de firma inválida/duplicado/no-owner
-- [ ] 7.4 `reality-checker`: journey de pago end-to-end contra el sandbox Redsys (iniciar → TPV test → webhook → PAID) — live E2E puede diferirse si requiere despliegue/túnel para el webhook
-- [ ] 7.5 Actualizar `docs/openapi.yaml` y verificar coherencia de todos los endpoints `/pagos/*`
+- [x] 7.3 `verification-specialist`: PASS — 29 unit backend + ArchUnit + migración V13 (contra PG real) + frontend 27/27; tsc/eslint limpios; contrato `amount` en euros coherente front↔back. Probes de firma inválida/duplicado/no-owner OK
+- [ ] 7.4 `reality-checker`: journey de pago end-to-end contra el sandbox Redsys (iniciar → TPV test → webhook → PAID) — **PENDIENTE de live E2E: requiere despliegue + túnel público para el webhook; cubierto a nivel de firma/contrato por unit tests con vectores sandbox + tests MSW**
+- [x] 7.5 `docs/openapi.yaml` actualizado con todos los endpoints `/pagos/*` (iniciar, webhook, efectivo, historial) alineados a la implementación real

--- a/openspec/changes/pagos-redsys-online/tasks.md
+++ b/openspec/changes/pagos-redsys-online/tasks.md
@@ -1,0 +1,42 @@
+# Pago online Redsys (fase-1, Wave 4A)
+
+> Orden TDD estricto (Red → Green → Refactor) en cada grupo. Owner paga el total (pago compartido por participante DIFERIDO). Tests contra el entorno de pruebas Redsys (comercio sandbox); datos de tarjeta NUNCA en PadelPro (RN-PAY-03).
+
+## 1. Config — `redsys_terminal` + descifrado (D4)
+
+- [ ] 1.1 **[Red]** Test: `SystemConfig` expone `redsysTerminal` descifrado; default "1" si ausente
+- [ ] 1.2 **[Green]** Migración Flyway `Vn__add_redsys_terminal_to_system_config.sql` (TEXT, nullable, cifrable) + campo en la entidad/DTO + descifrado con el servicio AES-256 existente
+
+## 2. Backend — firma Redsys (D2)
+
+- [ ] 2.1 **[Red]** Tests de `RedsysSignature` con vectores del sandbox: derivar clave por-pedido (3DES del `Ds_Merchant_Order`), calcular HMAC-SHA256 de `Ds_MerchantParameters`, round-trip firmar→verificar, comparación en tiempo constante (`MessageDigest.isEqual`)
+- [ ] 2.2 **[Green]** Utilidad `RedsysSignature` (firmar/verificar); sin dependencia de terceros; nunca loguea la clave
+
+## 3. Backend — iniciar pago (D5)
+
+- [ ] 3.1 **[Red]** Tests `IniciarPagoService`: owner OK → IN_PROGRESS + form firmado + `PAYMENT_INITIATED`; no-owner → 403; reserva inexistente → 404; cancelada → 422; pago ya IN_PROGRESS/PAID → 409; importe del cliente ignorado (amount = backend en céntimos)
+- [ ] 3.2 **[Green]** `IniciarPagoService` + `PagoController` `POST /api/pagos/iniciar` + DTOs (request `reservaId`, response `pagoId/redsysOrderId/redsysUrl/amount/status`); genera `redsys_order_id` único; persiste `payment_url`; auditoría; documentar en openapi
+
+## 4. Backend — webhook (D3)
+
+- [ ] 4.1 **[Red]** Tests `ProcesarWebhookService`: firma válida + aprobado → PAID + transaction_id + `PAYMENT_CONFIRMED`; firma válida + rechazo → FAILED + `PAYMENT_REJECTED`; firma inválida → 200 sin cambio + `PAYMENT_WEBHOOK_INVALID_SIGNATURE`; duplicado sobre PAID → 200 sin reproceso; order_id inexistente → 200 + alerta
+- [ ] 4.2 **[Green]** `ProcesarWebhookService` + `POST /api/pagos/webhook` (sin JWT, allowlist en SecurityConfig, rate limit); valida firma ANTES de tocar nada; idempotente; siempre 200; nunca persiste/loguea datos de tarjeta; documentar en openapi
+
+## 5. Backend — efectivo ADMIN + historial
+
+- [ ] 5.1 **[Red]** Tests: ADMIN registra efectivo → PAID/CASH/registered_by + `PAYMENT_CASH_REGISTERED`; USER → 403; reserva ya PAID → 422. `GET /api/pagos` (propios) y `GET /api/admin/pagos` (todos)
+- [ ] 5.2 **[Green]** `RegistrarPagoEfectivoService` + `AdminPagoController` (`POST /api/admin/pagos/{reservaId}/efectivo`, `GET /api/admin/pagos`); `PagoQueryService` + `GET /api/pagos`; documentar en openapi
+
+## 6. Frontend — checkout + confirmación (D6)
+
+- [ ] 6.1 **[Red]** Tests (MSW): iniciar pago devuelve redsysUrl+params → `CheckoutRedsysPage` construye el form y (mock) auto-submit; `PagoConfirmadoPage` consulta el estado del pago del backend (no confía en la URL de retorno) y muestra PAID/FAILED/procesando
+- [ ] 6.2 **[Green]** `CheckoutRedsysPage` (mockup 09, auto-submit del form firmado al TPV; datos de tarjeta fuera) + `PagoConfirmadoPage` (mockup 10, UrlOK/UrlKO → estado real por backend) + service de pagos + rutas
+- [ ] 6.3 **[Green]** Activar "pagar ahora" en `MisReservasPage` (hoy deshabilitado): llama a iniciar pago y redirige al checkout
+
+## 7. QA
+
+- [ ] 7.1 **[Refactor]** Limpieza manteniendo verde
+- [ ] 7.2 `security-auditor`: firma en tiempo constante, webhook sin efectos antes de validar, no exposición de secretos/tarjeta en logs (RN-PAY-03), idempotencia, rate limit del webhook
+- [ ] 7.3 `verification-specialist`: build + tests (backend maven, frontend vitest) + lint; probes de firma inválida/duplicado/no-owner
+- [ ] 7.4 `reality-checker`: journey de pago end-to-end contra el sandbox Redsys (iniciar → TPV test → webhook → PAID) — live E2E puede diferirse si requiere despliegue/túnel para el webhook
+- [ ] 7.5 Actualizar `docs/openapi.yaml` y verificar coherencia de todos los endpoints `/pagos/*`


### PR DESCRIPTION
## Resumen

Implementa la capability `pagos-redsys` (Wave 4A): pago online por Redsys (owner paga el total) + registro de efectivo por ADMIN + historial. Desbloquea el "pagar ahora" que estaba deshabilitado en reservas. La tabla `payments` ya estaba lista; se añade solo `redsys_terminal` (V13).

- **Backend** (paquete `com.padelpro.pagos`): `POST /api/pagos/iniciar` (form firmado HMAC SHA-256, solo owner, importe backend en céntimos), `POST /api/pagos/webhook` (firma en tiempo constante, idempotente con lock pesimista, rechazo silencioso, rate-limited, siempre 200), `POST /api/admin/pagos/{reservaId}/efectivo`, `GET /api/pagos` + `/api/admin/pagos`. Utilidad `RedsysSignature` (3DES + HMAC, sin dependencias) probada con vectores del sandbox.
- **Frontend**: CheckoutRedsysPage (auto-submit al TPV; la tarjeta NUNCA pasa por PadelPro), PagoConfirmadoPage (estado real por webhook, no por la URL de retorno), "pagar ahora" activado en Mis Reservas.

## Issues vinculados

- Closes #194

## Seguridad (security-auditor: 0 críticos/altos; 3 MEDIOS corregidos)

- Firma HMAC en **tiempo constante** validada ANTES de tocar el pago; datos de tarjeta/secretos nunca en logs (RN-PAY-03).
- **MEDIO-1** webhook con **rate limiting** (60/min/IP). **MEDIO-2** idempotencia con **lock pesimista** (evita doble `PAYMENT_CONFIRMED` en carrera). **MEDIO-3** `Ds_Order` **sanitizado** antes de auditar (anti log-injection/XSS). BAJO-2: `Ds_SignatureVersion` validado.
- Owner-only (RN-AUTH-04), importe del cliente ignorado (RN-RES-03), sin retroceso de estado (RN-PAY-04).

## Config / activación

Sandbox Redsys para dev/test; credenciales reales en `system_config` cifrado (prod). `payment_gateway` queda en **CASH por defecto**; REDSYS se activa por config cuando haya credenciales reales.

## Testing

- [x] Backend: 29 unit (incl. firma con vectores sandbox, webhook idempotente/firma inválida/no-owner) + ArchUnit + migración V13 contra Postgres real.
- [x] Frontend: 27 pagos (checkout, confirmado, pagar ahora), suite total verde; tsc/eslint limpios.
- [x] verification-specialist: PASS.
- [ ] **Live E2E contra sandbox Redsys (reality-checker): diferido** — requiere despliegue + túnel público para el webhook; cubierto por unit tests con vectores + MSW.

## Fuera de alcance

Pago compartido por participante (owner paga el total), reembolso real en TPV, tokenización — extensiones posteriores.

🤖 Generado con Claude Code (orchestrator agent)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added online card payment flow, including payment initiation, webhook handling, and payment history views.
  * Added an admin cash-payment registration flow and payment list for administrators.
  * Added checkout and payment-confirmation pages in the frontend, plus “Pay now” actions from reservations.
  * Added support for storing an additional payment terminal setting.

* **Bug Fixes**
  * Improved webhook reliability with idempotent processing and safer handling of repeated notifications.
  * Added clearer payment error handling and status-based confirmation screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->